### PR TITLE
Added "force stop" flag to the "stop" operation on the instances endpoint

### DIFF
--- a/source/includes/cloudstack/_instances.md
+++ b/source/includes/cloudstack/_instances.md
@@ -348,7 +348,7 @@ curl -X POST \
 
 Optional | &nbsp;
 ------ | -----------
-`shouldForceStop`<br/>*boolean* | Setting it to **true** will force stop an instance that is either *Running* or in the process of *Stopping*
+`forceStop`<br/>*boolean* | Setting it to **true** will force stop an instance that is either *Running* or in the process of *Stopping*
 
 <!-------------------- REBOOT AN INSTANCE -------------------->
 

--- a/source/includes/cloudstack/_instances.md
+++ b/source/includes/cloudstack/_instances.md
@@ -333,11 +333,22 @@ curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29?operation=stop"
+
+# Request example:
+```
+```json
+{
+   "shouldForceStop":true
+}
 ```
 
  <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=stop</code>
 
- Stop an existing instance. The instance must be in the *Running* state for this operation to work.
+ Stop an existing instance. The instance must be in either the *Running* or *Stopping* state for this operation to work. The default behavior is that the instance (denote by **id**) will be stopped gracefully. An *additional* parameter can be passed with the call to *force stop* an instance. If the API is invoked on an instance that is already in the *Stopping* state, then a *force stop* is enforced regardless of whether this *optional* parameter was provided or not.
+
+Optional | &nbsp;
+------ | -----------
+`shouldForceStop`<br/>*boolean* | Setting it to **true** will force stop an instance that is either *Running* or in the process of *Stopping*
 
 <!-------------------- REBOOT AN INSTANCE -------------------->
 

--- a/source/includes/cloudstack/_instances.md
+++ b/source/includes/cloudstack/_instances.md
@@ -338,7 +338,7 @@ curl -X POST \
 ```
 ```json
 {
-   "shouldForceStop":true
+   "forceStop":true
 }
 ```
 


### PR DESCRIPTION
### Tracked by issue: [MC-2397](https://cloud-ops.atlassian.net/browse/MC-2397)

#### Code walkthrough : @simongodard 

#### Issue
The **stop** operation on the *instances* endpoint does not support the **force stop** flag.

#### Solution
Added the option on the plugin repo and updated docs

<img width="842" alt="apidocs" src="https://user-images.githubusercontent.com/7249208/51038243-a03f2200-1580-11e9-8744-73d3fab5dc55.png">

![docsupdate](https://user-images.githubusercontent.com/7249208/51038371-07f56d00-1581-11e9-9faf-39acafe80103.png)
