### PR TITLE
Added API docs for "create snapshot" operation on Volume and Snapshot entities

### DIFF
--- a/source/includes/cloudstack/_snapshots.md
+++ b/source/includes/cloudstack/_snapshots.md
@@ -126,7 +126,7 @@ Create a snapshot of an existing storage [volume](#cloudstack-storage). Note tha
 
 Required | &nbsp;
 ---------- | -----
-volumeId<br/>*UUID* | The id of the [volume](#cloudstack-storage) on which the snapshot is to be taken.
+`volumeId`<br/>*UUID* | The id of the [volume](#cloudstack-storage) on which the snapshot is to be taken.
 
 Optional | &nbsp;
 ------ | -----------

--- a/source/includes/cloudstack/_snapshots.md
+++ b/source/includes/cloudstack/_snapshots.md
@@ -88,3 +88,47 @@ Attributes | &nbsp;
 `volumeId`<br/>*UUID* | The id of the [volume](#cloudstack-volumes) that was snapshotted
 `volume`<br/>*string* | The name of the [volume](#cloudstack-volumes) that was snapshotted
 `volumeType`<br/>*string* | The type of the [volume](#cloudstack-volumes) that was snapshotted
+
+
+<!-------------------- CREATE A SNAPSHOT OF A VOLUME -------------------->
+
+
+#### Create a snapshot
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/v1/services/compute-on/testing/snapshots?operation=create"
+
+# Request should look like this
+```
+```json
+{
+  "volumeId": "4fe54594-a788-442c-b7a8-0237f7a4f70d",
+  "name": "LionelMessi",
+  "rapid": true
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/snapshots?operation=create</code>
+
+Create a snapshot of an existing storage [volume](#cloudstack-storage). Note that the volume must be attached to an instance. A detached volume cannot be **snapshot*****'ed***. You can get a list of volumes using [this](#cloudstack-list-volumes) API.
+
+*Two* **optional** *parameters can be passed with this call*:
+
+  1. A ***unique name*** for the snapshot. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. 
+    
+    *Eg:* *[instance.name]\_[volume.name]\_[timestamp]* >>> ***i-root-6E7_RapidVol_20190117153537***
+
+  2. The ***location*** as to where the snapshot is supposed to be made. This is denoted by the flag - ***rapid***.
+
+Required | &nbsp;
+---------- | -----
+volumeId<br/>*UUID* | The id of the [volume](#cloudstack-storage) on which the snapshot is to be taken.
+
+Optional | &nbsp;
+------ | -----------
+`name`<br/>*string* | The name to be given to the newly created **snapshot**.
+`rapid`<br/>*boolean* | Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. 

--- a/source/includes/cloudstack/_snapshots.md
+++ b/source/includes/cloudstack/_snapshots.md
@@ -114,7 +114,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/snapshots?operation=create</code>
 
-Create a snapshot of an existing [volume](#cloudstack-storage). Note that the volume must be attached to an instance. A detached volume cannot be **snapshot*****'ed***. You can get a list of volumes using [this](#cloudstack-list-volumes) API.
+Create a snapshot of an existing [volume](#cloudstack-storage). Note that the volume must be in its *READY* state to be able to take a snapshot of it. You can get a list of volumes using [this](#cloudstack-list-volumes) API.
 
 Required | &nbsp;
 ---------- | -----

--- a/source/includes/cloudstack/_snapshots.md
+++ b/source/includes/cloudstack/_snapshots.md
@@ -107,22 +107,14 @@ curl -X POST \
 ```json
 {
   "volumeId": "4fe54594-a788-442c-b7a8-0237f7a4f70d",
-  "name": "LionelMessi",
+  "name": "BeforeUpgradeToV2",
   "rapid": true
 }
 ```
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/snapshots?operation=create</code>
 
-Create a snapshot of an existing storage [volume](#cloudstack-storage). Note that the volume must be attached to an instance. A detached volume cannot be **snapshot*****'ed***. You can get a list of volumes using [this](#cloudstack-list-volumes) API.
-
-*Two* **optional** *parameters can be passed with this call*:
-
-  1. A ***unique name*** for the snapshot. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. 
-    
-    *Eg:* *[instance.name]\_[volume.name]\_[timestamp]* >>> ***i-root-6E7_RapidVol_20190117153537***
-
-  2. The ***location*** as to where the snapshot is supposed to be made. This is denoted by the flag - ***rapid***.
+Create a snapshot of an existing [volume](#cloudstack-storage). Note that the volume must be attached to an instance. A detached volume cannot be **snapshot*****'ed***. You can get a list of volumes using [this](#cloudstack-list-volumes) API.
 
 Required | &nbsp;
 ---------- | -----
@@ -130,5 +122,5 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------ | -----------
-`name`<br/>*string* | The name to be given to the newly created **snapshot**.
-`rapid`<br/>*boolean* | Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. 
+`name`<br/>*string* | A ***unique name*** to be given to the newly created **snapshot**. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. <br/><br/>*Eg:* *[instance.name]\_[volume.name]\_[timestamp]* >>> ***i-root-6E7_RapidVol_20190117153537***
+`rapid`<br/>*boolean* | Indicates the ***location*** as to where the snapshot is supposed to be created. <br/><br/>Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. 

--- a/source/includes/cloudstack/_snapshots.md
+++ b/source/includes/cloudstack/_snapshots.md
@@ -122,5 +122,5 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------ | -----------
-`name`<br/>*string* | A ***unique name*** to be given to the newly created **snapshot**. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. <br/><br/>*Eg:* *[instance.name]\_[volume.name]\_[timestamp]* >>> ***i-root-6E7_RapidVol_20190117153537***
+`name`<br/>*string* | A ***unique name*** to be given to the newly created **snapshot**. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. <br/><br/>*Eg:*<br/>&nbsp;&nbsp;&nbsp;&nbsp;*[instance.name]\_[volume.name]\_[timestamp]*<br/>&nbsp;&nbsp;&nbsp;&nbsp;***i-root-6E7_RapidVol_20190117153537***
 `rapid`<br/>*boolean* | Indicates the ***location*** as to where the snapshot is supposed to be created. <br/><br/>Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. 

--- a/source/includes/cloudstack/_volumes.md
+++ b/source/includes/cloudstack/_volumes.md
@@ -204,3 +204,47 @@ curl -X POST \
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/volumes/:id?operation=detachFromInstance</code>
 
 Detach a data volume from an [instance](#cloudstack-instances).
+
+
+<!-------------------- CREATE A SNAPSHOT OF A VOLUME -------------------->
+
+
+#### Create a volume snapshot
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/v1/services/compute-on/testing/volumes/4fe54594-a788-442c-b7a8-0237f7a4f70d?operation=createSnapshotFromVolume"
+
+# Request should look like this
+```
+```json
+{
+   "snapshot": {
+      "name": "CaptainMarvel",
+      "rapid": true
+   }
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/volumes/:id?operation=createSnapshotFromVolume</code>
+
+Create a snapshot of an existing storage [volume](#cloudstack-storage). Note that the volume must be attached to an instance. A detached volume cannot be **snapshot*****'ed***. 
+
+*Two* **optional** *parameters can be passed with this call:*
+
+  1. A ***unique name*** for the snapshot. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. 
+    
+    *Eg:* *[instance.name]\_[volume.name]\_[timestamp]*  >>>  ***i-root-6E7_RapidVol_20190117153537***
+
+  2. The ***location*** as to where the snapshot is supposed to be made. This is denoted by the flag - ***rapid***. If this is set to ```true``` the snapshot will be created in the primary storage, where the volume resides. Rapid snapshots enable much faster volume and template creation than from regular snapshots, but at a higher expense. Not all volumes support the **rapid** snapshot option.
+
+Note that these *optional* parameters must be provided as a nested ***json*** under the object ***snapshot***. This is because the operation is carried out on the *volume* entity's *snapshot* attribute. This is different if the operation is invoked on the *snapshot* entity as shown [here](#cloudstack-create-a-snapshot).
+
+Optional | &nbsp;
+------ | -----------
+`name`<br/>*string* | The name to be given to the newly created **snapshot**.
+`rapid`<br/>*boolean* | Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. 
+

--- a/source/includes/cloudstack/_volumes.md
+++ b/source/includes/cloudstack/_volumes.md
@@ -235,6 +235,6 @@ Create a snapshot of an existing [volume](#cloudstack-storage). Note that the vo
 
 Optional | &nbsp;
 ------ | -----------
-`name`<br/>*string* | A ***unique name*** to be given to the newly created **snapshot**. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. <br/><br/>*Eg:* *[instance.name]\_[volume.name]\_[timestamp]* >>> ***i-root-6E7_RapidVol_20190117153537***
+`name`<br/>*string* | A ***unique name*** to be given to the newly created **snapshot**. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. <br/><br/>*Eg:*<br/>&nbsp;&nbsp;&nbsp;&nbsp;*[instance.name]\_[volume.name]\_[timestamp]*<br/>&nbsp;&nbsp;&nbsp;&nbsp;***i-root-6E7_RapidVol_20190117153537***
 `rapid`<br/>*boolean* | Indicates the ***location*** as to where the snapshot is supposed to be made. <br/><br/>Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. <br/><br/>*Note: Rapid snapshots enable much faster volume and template creation than from regular snapshots, but at a higher expense. Not all volumes support the* **rapid** *snapshot option.*
 

--- a/source/includes/cloudstack/_volumes.md
+++ b/source/includes/cloudstack/_volumes.md
@@ -223,7 +223,7 @@ curl -X POST \
 ```json
 {
    "snapshot": {
-      "name": "CaptainMarvel",
+      "name": "PreMigrationState",
       "rapid": true
    }
 }
@@ -231,20 +231,10 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/volumes/:id?operation=createSnapshotFromVolume</code>
 
-Create a snapshot of an existing storage [volume](#cloudstack-storage). Note that the volume must be attached to an instance. A detached volume cannot be **snapshot*****'ed***. 
-
-*Two* **optional** *parameters can be passed with this call:*
-
-  1. A ***unique name*** for the snapshot. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. 
-    
-    *Eg:* *[instance.name]\_[volume.name]\_[timestamp]*  >>>  ***i-root-6E7_RapidVol_20190117153537***
-
-  2. The ***location*** as to where the snapshot is supposed to be made. This is denoted by the flag - ***rapid***. If this is set to ```true``` the snapshot will be created in the primary storage, where the volume resides. Rapid snapshots enable much faster volume and template creation than from regular snapshots, but at a higher expense. Not all volumes support the **rapid** snapshot option.
-
-Note that these *optional* parameters must be provided as a nested ***json*** under the object ***snapshot***. This is because the operation is carried out on the *volume* entity's *snapshot* attribute. This is different if the operation is invoked on the *snapshot* entity as shown [here](#cloudstack-create-a-snapshot).
+Create a snapshot of an existing [volume](#cloudstack-storage). Note that the volume must be attached to an instance. A detached volume cannot be **snapshot*****'ed***. 
 
 Optional | &nbsp;
 ------ | -----------
-`name`<br/>*string* | The name to be given to the newly created **snapshot**.
-`rapid`<br/>*boolean* | Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. 
+`name`<br/>*string* | A ***unique name*** to be given to the newly created **snapshot**. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. <br/><br/>*Eg:* *[instance.name]\_[volume.name]\_[timestamp]* >>> ***i-root-6E7_RapidVol_20190117153537***
+`rapid`<br/>*boolean* | Indicates the ***location*** as to where the snapshot is supposed to be made. <br/><br/>Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. <br/><br/>*Note: Rapid snapshots enable much faster volume and template creation than from regular snapshots, but at a higher expense. Not all volumes support the* **rapid** *snapshot option.*
 

--- a/source/includes/cloudstack/_volumes.md
+++ b/source/includes/cloudstack/_volumes.md
@@ -231,7 +231,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/volumes/:id?operation=createSnapshotFromVolume</code>
 
-Create a snapshot of an existing [volume](#cloudstack-storage). Note that the volume must be attached to an instance. A detached volume cannot be **snapshot*****'ed***. 
+Create a snapshot of an existing [volume](#cloudstack-storage). Note that the volume must be in its *READY* state to be able to take a snapshot of it. 
 
 Optional | &nbsp;
 ------ | -----------


### PR DESCRIPTION
### Tracked by issue: [MC-8218](https://cloud-ops.atlassian.net/browse/MC-8218)

#### Code walkthrough : @simongodard 

#### Issue
There feature request was to add **create snapshot** operation on the snapshots entity. However the docs were not updated to have info on the **create snapshot** operation on both entity types `volume` and `shapshot`.

#### Solution
Added the expected operation in the user-story and updated all missing docs.

#### UI Changes
![mc-8218-api](https://user-images.githubusercontent.com/7249208/51366592-6ad09200-1ab4-11e9-91a3-d1f0147c8ba3.png)

