### PR TITLE
MC-9194 finish GCP instances doc + add regions, images, networks, SSH keys

### DIFF
--- a/source/includes/gcp/_disks.md
+++ b/source/includes/gcp/_disks.md
@@ -57,7 +57,7 @@ Attributes | &nbsp;
 `selfLink`<br/>*string* | Server-defined URL for this resource
 `type`<br/>*string* | URL of the disk type resource describing which disk type to use to create the disk. Choices are ':url/pd-standard' or ':url/pd-ssd'.
 `lastAttachTimestamp`<br/>*string* | Timestamp representing the last time the disk was attached.
-`users`<br/>*Array[String] | Links to the instances the disk is attached to.
+`users`<br/>*Array[string]* | Links to the instances the disk is attached to.
 `labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
 `physicalBlockSizeBytes`<br/>*string* | Physical block size of the persistent disk, in bytes. Currently supported sizes are 4096 and 16384.
 `kind`<br/>*string* | Type of the resource.
@@ -121,7 +121,7 @@ Attributes | &nbsp;
 `selfLink`<br/>*string* | Server-defined URL for this resource
 `type`<br/>*string* | URL of the disk type resource describing which disk type to use to create the disk. Choices are ':url/pd-standard' or ':url/pd-ssd'.
 `lastAttachTimestamp`<br/>*string* | Timestamp representing the last time the disk was attached.
-`users`<br/>*Array[String] | Links to the instances the disk is attached to.
+`users`<br/>*Array[string]* | Links to the instances the disk is attached to.
 `labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
 `physicalBlockSizeBytes`<br/>*string* | Physical block size of the persistent disk, in bytes. Currently supported sizes are 4096 and 16384.
 `kind`<br/>*string* | Type of the resource.

--- a/source/includes/gcp/_images.md
+++ b/source/includes/gcp/_images.md
@@ -1,6 +1,6 @@
 ### Images
 
-Images are virtual machine images that have a virtual disk that contains a bootable operating system.
+Images are virtual machine images that have a virtual disk which contains a bootable operating system.
 
 <!-------------------- LIST IMAGES -------------------->
 
@@ -94,8 +94,8 @@ Attributes | &nbsp;
 `family`<br/>*string* | The name of the image family to which this image belongs
 `kind`<br/>*string* | Type of the resource
 `labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
-`licenseCodes`<br/>*Array* | Integer license codes indicating which licenses are attached to this image.
-`licenses`<br/>*Array* | Any applicable license URI
+`licenseCodes`<br/>*Array[integer]* | License codes indicating which licenses are attached to this image.
+`licenses`<br/>*Array[URI]* | Any applicable license URI
 `rawDisk`<br/>*Object* | The parameters of the raw disk image
 `selfLink`<br/>*string* | Server-defined URL for this resource
 `sourceType`<br/>*string* | The type of the image used to create this disk. The default and only value is RAW
@@ -161,8 +161,8 @@ Attributes | &nbsp;
 `family`<br/>*string* | The name of the image family to which this image belongs
 `kind`<br/>*string* | Type of the resource
 `labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
-`licenseCodes`<br/>*Array* | Integer license codes indicating which licenses are attached to this image.
-`licenses`<br/>*Array* | Any applicable license URI
+`licenseCodes`<br/>*Array[integer]* | License codes indicating which licenses are attached to this image.
+`licenses`<br/>*Array[URI]* | Any applicable license URI
 `rawDisk`<br/>*Object* | The parameters of the raw disk image
 `selfLink`<br/>*string* | Server-defined URL for this resource
 `sourceType`<br/>*string* | The type of the image used to create this disk. The default and only value is RAW

--- a/source/includes/gcp/_images.md
+++ b/source/includes/gcp/_images.md
@@ -118,7 +118,7 @@ Response body:
 ```
 ```json
 {
-   "data":     {
+   "data": {
       "archiveSizeBytes": "16469314560",
       "creationTimestamp": "2019-05-15T19:01:21.060-07:00",
       "description": "CentOS, CentOS, 7, x86_64 built on 20190515",

--- a/source/includes/gcp/_images.md
+++ b/source/includes/gcp/_images.md
@@ -1,0 +1,174 @@
+### Images
+
+Images are virtual machine images that have a virtual disk that contains a bootable operating system.
+
+<!-------------------- LIST IMAGES -------------------->
+
+#### List images
+
+```shell
+curl -H "MC-Api-Key: your_api_key" \
+    "https://api.your.cloudmc/v1/services/gcp/test-area/images"
+
+Response body:
+```
+```json
+{
+  "data": [
+    {
+      "archiveSizeBytes": "10843137280",
+      "creationTimestamp": "2019-05-14T16:49:57.269-07:00",
+      "description": "Debian, Debian GNU/Linux, 9 (stretch), amd64 built on 20190514",
+      "diskSizeGb": "10",
+      "family": "debian-9",
+      "guestOsFeatures": [
+        {
+          "type": "VIRTIO_SCSI_MULTIQUEUE"
+        }
+      ],
+      "kind": "compute#image",
+      "labelFingerprint": "42WmSpB8rSM=",
+      "licenseCodes": [
+        "1000205"
+      ],
+      "licenses": [
+        "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+      ],
+      "rawDisk": {
+        "containerType": "TAR",
+        "source": ""
+      },
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
+      "sourceType": "RAW",
+      "status": "READY",
+      "vendorFamily": "debian-cloud",
+      "shortName": "Debian",
+      "iconUrl": "/rest/services/assets/gcp/os_logo/debian.png",
+      "id": "2447790134347098827",
+      "name": "debian-9-stretch-v20190514"
+    },
+    {
+      "archiveSizeBytes": "16469314560",
+      "creationTimestamp": "2019-05-15T19:01:21.060-07:00",
+      "description": "CentOS, CentOS, 7, x86_64 built on 20190515",
+      "diskSizeGb": "10",
+      "family": "centos-7",
+      "kind": "compute#image",
+      "labelFingerprint": "42WmSpB8rSM=",
+      "licenseCodes": [
+        "1000207"
+      ],
+      "licenses": [
+        "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/licenses/centos-7"
+      ],
+      "rawDisk": {
+        "containerType": "TAR",
+        "source": ""
+      },
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20190515",
+      "sourceType": "RAW",
+      "status": "READY",
+      "vendorFamily": "centos-cloud",
+      "shortName": "CentOS",
+      "iconUrl": "/rest/services/assets/gcp/os_logo/centos.png",
+      "id": "4658005417542122143",
+      "name": "centos-7-v20190515"
+    }
+  ],
+  "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/images</code>
+
+Retrieve a list of available images.
+
+Attributes | &nbsp;
+------- | -----------
+`archiveSizeBytes`<br/>*string* | Size of the image tar.gz archive stored in Google Cloud Storage (in bytes)
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`description`<br/>*string* | An optional description of this resource
+`diskSizeGb`<br/>*string* | Size of the image when restored onto a persistent disk (in GB)
+`family`<br/>*string* | The name of the image family to which this image belongs
+`kind`<br/>*string* | Type of the resource
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
+`licenseCodes`<br/>*Array* | Integer license codes indicating which licenses are attached to this image.
+`licenses`<br/>*Array* | Any applicable license URI
+`rawDisk`<br/>*Object* | The parameters of the raw disk image
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`sourceType`<br/>*string* | The type of the image used to create this disk. The default and only value is RAW
+`status`<br/>*string* | The status of the image. An image can be used to create other resources, such as instances, only after the image has been successfully created and the status is set to READY. Possible values are FAILED, PENDING, or READY.
+`vendorFamily`<br/>*string* | Image family's vendor name
+`shortName`<br/>*string* | A short version of the OS image's name
+`iconUrl`<br/>*string* | Icon representing the OS image
+`id`<br/>*UUID* | The image's id
+`name`<br/>*string* | The image's name
+
+<!-------------------- RETRIEVE AN IMAGE -------------------->
+
+#### Retrieve an image
+
+```shell
+curl -H "MC-Api-Key: your_api_key" \
+    "https://api.your.cloudmc/v1/services/gcp/test-area/images/4658005417542122143"
+
+Response body:
+```
+```json
+{
+   "data":     {
+      "archiveSizeBytes": "16469314560",
+      "creationTimestamp": "2019-05-15T19:01:21.060-07:00",
+      "description": "CentOS, CentOS, 7, x86_64 built on 20190515",
+      "diskSizeGb": "10",
+      "family": "centos-7",
+      "kind": "compute#image",
+      "labelFingerprint": "42WmSpB8rSM=",
+      "licenseCodes": [
+        "1000207"
+      ],
+      "licenses": [
+        "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/licenses/centos-7"
+      ],
+      "rawDisk": {
+        "containerType": "TAR",
+        "source": ""
+      },
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20190515",
+      "sourceType": "RAW",
+      "status": "READY",
+      "vendorFamily": "centos-cloud",
+      "shortName": "CentOS",
+      "iconUrl": "/rest/services/assets/gcp/os_logo/centos.png",
+      "id": "4658005417542122143",
+      "name": "centos-7-v20190515"
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/images/:id</code>
+
+Retrieve information about an image
+
+Attributes | &nbsp;
+------- | -----------
+`archiveSizeBytes`<br/>*string* | Size of the image tar.gz archive stored in Google Cloud Storage (in bytes)
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`description`<br/>*string* | An optional description of this resource
+`diskSizeGb`<br/>*string* | Size of the image when restored onto a persistent disk (in GB)
+`family`<br/>*string* | The name of the image family to which this image belongs
+`kind`<br/>*string* | Type of the resource
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
+`licenseCodes`<br/>*Array* | Integer license codes indicating which licenses are attached to this image.
+`licenses`<br/>*Array* | Any applicable license URI
+`rawDisk`<br/>*Object* | The parameters of the raw disk image
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`sourceType`<br/>*string* | The type of the image used to create this disk. The default and only value is RAW
+`status`<br/>*string* | The status of the image. An image can be used to create other resources, such as instances, only after the image has been successfully created and the status is set to READY. Possible values are FAILED, PENDING, or READY.
+`vendorFamily`<br/>*string* | Image family's vendor name
+`shortName`<br/>*string* | A short version of the OS image's name
+`iconUrl`<br/>*string* | Icon representing the OS image
+`id`<br/>*UUID* | The image's id
+`name`<br/>*string* | The image's name

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -334,7 +334,7 @@ Destroy an existing instance.
 #### Change machine type
 A machine type determine the number of vCPUs and the size of the memory allocated to new [instances](#gcp-instances).
 
-```
+```shell
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
@@ -349,15 +349,7 @@ curl -X POST \
    "memoryInGB": "4.5"
 }
 ```
-```
-# Response body example
-```
-```json
-{
-  "taskId": "c92b6fa5-d32a-4484-a433-31ca90c2ed8b",
-  "taskStatus": "PENDING"
-}
-```
+
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=resize</code>
 
 Updates the number of vCPUs and memory of an existing instance.
@@ -380,3 +372,34 @@ Optional | &nbsp;
 ------ | -----------
 `cpuCount`<br/>*string* | Updated number of vCPUs of instance
 `memoryInGB`<br/>*string* | Updated memory of instance
+
+<!-------------------- START AN INSTANCE -------------------->
+
+#### Start an instance
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/6564997542943928188?operation=start"
+
+```
+
+ <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=start</code>
+
+Start an existing instance. The instance must be in the *TERMINATED* status for this operation to work.
+
+<!-------------------- STOP AN INSTANCE -------------------->
+
+#### Stop an instance
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/6564997542943928188?operation=stop"
+```
+
+ <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=stop</code>
+
+ Stop an existing instance. The instance must be in either the *RUNNING* or *STOPPING* status for this operation to work. The default behavior is that the instance (denote by **id**) will be stopped gracefully.

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -86,6 +86,7 @@ curl -X GET \
       "subnetworkName": "default",
       "iconUrl": "/rest/services/assets/gcp/os_logo/debian.png",
       "osImageName": "debian-9-stretch",
+      "osImageUrl": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
       "osImageSizeInGb": 0,
       "bootDiskSizeInGb": 0,
       "cpuCount": 2,
@@ -129,6 +130,7 @@ Attributes | &nbsp;
 `subnetworkName`<br/>*string* | The sub-network within the network the instance is connected to
 `iconUrl`<br/>*string* | Icon representing the OS installed on the instance's boot disk
 `osImageName`<br/>*string* | The name of the OS image installed on the instance's boot disk
+`osImageUrl`<br/>*string* | The full URL to the OS image
 `osImageSizeInGb`<br/>*string* | The size of the OS image
 `bootDiskSizeInGb`<br/>*string* | The size of the instance's boot disk
 `cpuCount`<br/>*string* | The number of vCPUs for the machine type
@@ -137,6 +139,195 @@ Attributes | &nbsp;
 `name`<br/>*string* | The display name of the instance
 `shortZone`<br/>*string* | A short version of the zone name
 `shortRegion`<br/>*string* | A short version of the region name
+
+<!-------------------- RETRIEVE AN INSTANCE -------------------->
+
+#### Retrieve an instance
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/5611478403377505138"
+
+# The above command returns JSON structured like this:
+```
+```json
+{
+  "data": {
+    "status": "RUNNING",
+    "zone": "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-a",
+    "machineType": "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-a/machineTypes/f1-micro",
+    "cpuPlatform": "Intel Skylake",
+    "creationTimestamp": "2019-04-19T12:12:30.756-07:00",
+    "deletionProtection": false,
+    "disks": [
+      {
+        "autoDelete": true,
+        "boot": true,
+        "deviceName": "i-test-kkn",
+        "guestOsFeatures": [
+          {
+            "type": "VIRTIO_SCSI_MULTIQUEUE"
+          }
+        ],
+        "index": 0,
+        "interface": "SCSI",
+        "kind": "compute#attachedDisk",
+        "licenses": [
+          "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch"
+        ],
+        "mode": "READ_WRITE",
+        "source": "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-a/disks/i-test-kkn",
+        "type": "PERSISTENT"
+      }
+    ],
+    "kind": "compute#instance",
+    "labelFingerprint": "42WmSpB8rSM=",
+    "metadata": {
+      "fingerprint": "WFshDDge4fM=",
+      "kind": "compute#metadata"
+    },
+    "networkInterfaces": [
+      {
+        "accessConfigs": [
+          {
+            "kind": "compute#accessConfig",
+            "name": "external-nat",
+            "natIP": "35.203.99.102",
+            "networkTier": "PREMIUM",
+            "type": "ONE_TO_ONE_NAT"
+          }
+        ],
+        "fingerprint": "NG6-4Cdf0KA=",
+        "kind": "compute#networkInterface",
+        "name": "nic0",
+        "network": "https://www.googleapis.com/compute/v1/projects/test-area-oox/global/networks/default",
+        "networkIP": "10.162.0.7",
+        "subnetwork": "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/northamerica-northeast1/subnetworks/default"
+      }
+    ],
+    "scheduling": {
+      "automaticRestart": true,
+      "onHostMaintenance": "MIGRATE",
+      "preemptible": false
+    },
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-a/instances/i-test-kkn",
+    "startRestricted": false,
+    "tags": {
+      "fingerprint": "42WmSpB8rSM="
+    },
+    "shortMachineType": "custom-2-2048",
+    "project": "test-area-oox",
+    "internalIp": "10.162.0.7",
+    "externalIp": "35.203.99.102",
+    "networkName": "default",
+    "subnetworkName": "default",
+    "iconUrl": "/rest/services/assets/gcp/os_logo/debian.png",
+    "osImageName": "debian-9-stretch",
+    "osImageUrl": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
+    "osImageSizeInGb": 0,
+    "bootDiskSizeInGb": 0,
+    "cpuCount": 2,
+    "memoryInGB": 2.000000,
+    "id": "5611478403377505138",
+    "name": "i-test-kkn",
+    "shortZone": "northamerica-northeast1-a",
+    "shortRegion": "northamerica-northeast1"
+  }
+}
+```
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id</code>
+
+Retrieve an instance in a given [environment](#administration-environments)
+
+Attributes | &nbsp;
+------- | -----------
+`status`<br/>*string* | The status of the instance. One of the following values: PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, and TERMINATED.
+`zone`<br/>*string* | URL of the zone where the instance resides. 
+`machineType`<br/>*string* | URL of the machine type resource used by this instance
+`cpuPlatform`<br/>*string* | The CPU platform used by this instance
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`deletionProtection`<br/>*string* | Whether the resource should be protected against deletion
+`disks`<br/>*Array[Disk]* | Array of disks associated with this instance
+`kind`<br/>*string* | Type of the resource
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
+`metadata`<br/>*object* | The metadata key/value pairs assigned to this instance
+`networkInterfaces`<br/>*Array[object]* | An array of network configurations for this instance
+`scheduling`<br/>*object* | Sets the scheduling options for this instance
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`startRestricted`<br/>*boolean* | Whether a VM has been restricted for start because Compute Engine has detected suspicious activity.
+`tags`<br/>*object* | Tags to apply to this instance. Tags are used to identify valid sources or targets for network firewalls and are specified by the client during instance creation
+`shortMachineType`<br/>*string* | A short version of the machineType name
+`project`<br/>*string* | The project where the instance resides
+`internalIp`<br/>*string* | The instance's internal IP
+`networkName`<br/>*string* | The network to which the instance is connected to
+`subnetworkName`<br/>*string* | The sub-network within the network the instance is connected to
+`iconUrl`<br/>*string* | Icon representing the OS installed on the instance's boot disk
+`osImageName`<br/>*string* | The name of the OS image installed on the instance's boot disk
+`osImageUrl`<br/>*string* | The full URL to the OS image
+`osImageSizeInGb`<br/>*string* | The size of the OS image
+`bootDiskSizeInGb`<br/>*string* | The size of the instance's boot disk
+`cpuCount`<br/>*string* | The number of vCPUs for the machine type
+`memoryInGB`<br/>*string* | The memory size for the machine name
+`id`<br/>*UUID* | The id of the instance
+`name`<br/>*string* | The display name of the instance
+`shortZone`<br/>*string* | A short version of the zone name
+`shortRegion`<br/>*string* | A short version of the region name
+
+<!-------------------- CREATE AN INSTANCE -------------------->
+
+#### Create an instance
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/instances"
+
+# Request should look like this
+```
+```json
+{
+  "name": "my-instance",
+  "shortRegion": "northamerica-northeast1",
+  "shortZone": "northamerica-northeast1-a",
+  "bootDiskType": "pd-standard",
+  "bootDiskSizeInGb": "10",
+  "cpuCount": "2",
+  "memoryInGB": "4.5",
+  "osImageUrl": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances</code>
+
+Creates a new instance
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*string* | The display name of the instance
+`shortRegion`<br/>*string* | A short version of the region name
+`shortZone`<br/>*string* | A short version of the zone name
+`bootDiskType`<br/>*string* | The boot disk type. Choices are 'pd-standard' or 'pd-ssd'
+`bootDiskSizeInGb` <br/>*string* | The size of the boot disk in GB. Acceptable values are 1 to 2000, inclusive
+`cpuCount`<br/>*string* | Updated number of vCPUs of instance
+`memoryInGB`<br/>*string* | Updated memory of instance
+`osImageUrl`<br/>*string* | The full URL to the OS image
+
+<!-------------------- DELETE AN INSTANCE -------------------->
+
+#### Delete an instance
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/5611478403377505138"
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id</code>
+
+Destroy an existing instance.
 
 <!-------------------- CHANGE MACHINE TYPE -------------------->
 
@@ -169,7 +360,7 @@ curl -X POST \
 ```
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=resize</code>
 
-Update the number of vCPUs and memory of an existing instance.
+Updates the number of vCPUs and memory of an existing instance.
 
 <aside class="notice">
 The maximum number of vCPUs allowed for a machine type is determined by the zone where the instance will be hosted.
@@ -178,7 +369,7 @@ This number is enforced by the 'CPUS' Quota.
 </aside>
 <aside class="notice">
 The memory per vCPU of a machine type must be between 0.9 GB and 6.5 GB per vCPU, inclusive.
-The total memory for a machine type must be a multiple of 256 MB. For example, 6.9 GB is not acceptable, but 6.75 GB and 7 GB are acceptable.
+The total memory for a machine type must be a multiple of 512 MB. For example, 6.9 GB is not acceptable, but 6.5 GB and 7 GB are acceptable.
 </aside>
 
 <aside class="warning">
@@ -188,4 +379,4 @@ The total memory for a machine type must be a multiple of 256 MB. For example, 6
 Optional | &nbsp;
 ------ | -----------
 `cpuCount`<br/>*string* | Updated number of vCPUs of instance
-`memoryInGB`<br/>*string* | Updated memory of instance.
+`memoryInGB`<br/>*string* | Updated memory of instance

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -285,7 +285,7 @@ curl -X POST \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances"
 
-# Request should look like this
+# Request example:
 ```
 ```json
 {
@@ -302,7 +302,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances</code>
 
-Creates a new instance
+Create a new instance
 
 Required | &nbsp;
 ------- | -----------
@@ -352,7 +352,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=resize</code>
 
-Updates the number of vCPUs and memory of an existing instance.
+Update the number of vCPUs and memory of an existing instance.
 
 <aside class="notice">
 The maximum number of vCPUs allowed for a machine type is determined by the zone where the instance will be hosted.

--- a/source/includes/gcp/_networks.md
+++ b/source/includes/gcp/_networks.md
@@ -1,0 +1,111 @@
+### Networks
+
+A network is an isolated network where you can place groups of resources, such as [instances](#gcp-instances).
+
+<!-------------------- LIST NETWORKS -------------------->
+
+#### List networks
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/networks"
+
+# Example:
+```
+```json
+{
+  "data": [
+    {
+      "autoCreateSubnetworks": true,
+      "creationTimestamp": "2019-03-12T07:09:22.374-07:00",
+      "description": "Default network for the project",
+      "id": "6402509859159933821",
+      "name": "default",
+      "kind": "compute#network",
+      "routingConfig": {
+        "routingMode": "REGIONAL"
+      },
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area-oox/global/networks/default",
+      "subnetworks": [
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-east1/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-central1/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-west2/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-west1/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/northamerica-northeast1/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-east4/subnetworks/default"
+      ]
+    }
+  ],
+  "metadata": {
+    "recordCount": 1
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks</code>
+
+Retrieve a list of all networks in an [environment](#administration-environments)
+
+Attributes | &nbsp;
+---------- | -----
+`autoCreateSubnetworks`<br/>*boolean* | When set to true, the VPC network is created in "auto" mode. When set to false, the VPC network is created in "custom" mode.
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`description`<br/>*string* | An optional description of this resource
+`id`<br/>*string* | The network's id
+`name`<br/>*string* | The network's name
+`kind`<br/>*string* | Type of the resource
+`routingConfig`<br/>*object* | The network-level routing configuration for this network. Used by Cloud Router to determine what type of network-wide routing behavior to enforce. RoutingMode is either REGIONAL or GLOBAL.
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`subnetworks`<br/>*Array[URL]* | Server-defined fully-qualified URLs for all subnetworks in this VPC network
+
+<!-------------------- RETRIEVE A NETWORK -------------------->
+
+#### Retrieve a network
+
+```shell
+curl -H "MC-Api-Key: your_api_key" \
+    "https://api.your.cloudmc/v1/services/gcp/test-area/networks/6402509859159933821"
+
+Response body:
+```
+```json
+{
+   "data": {
+      "autoCreateSubnetworks": true,
+      "creationTimestamp": "2019-03-12T07:09:22.374-07:00",
+      "description": "Default network for the project",
+      "id": "6402509859159933821",
+      "name": "default",
+      "kind": "compute#network",
+      "routingConfig": {
+        "routingMode": "REGIONAL"
+      },
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area-oox/global/networks/default",
+      "subnetworks": [
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-east1/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-central1/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-west2/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-west1/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/northamerica-northeast1/subnetworks/default",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-east4/subnetworks/default"
+      ]
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks/:id</code>
+
+Retrieve information about a network
+
+Attributes | &nbsp;
+---------- | -----
+`autoCreateSubnetworks`<br/>*boolean* | When set to true, the VPC network is created in "auto" mode. When set to false, the VPC network is created in "custom" mode.
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`description`<br/>*string* | An optional description of this resource
+`id`<br/>*string* | The network's id
+`name`<br/>*string* | The network's name
+`kind`<br/>*string* | Type of the resource
+`routingConfig`<br/>*object* | The network-level routing configuration for this network. Used by Cloud Router to determine what type of network-wide routing behavior to enforce. RoutingMode is either REGIONAL or GLOBAL.
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`subnetworks`<br/>*Array[URL]* | Server-defined fully-qualified URLs for all subnetworks in this VPC network

--- a/source/includes/gcp/_regions.md
+++ b/source/includes/gcp/_regions.md
@@ -59,10 +59,10 @@ Attributes | &nbsp;
 `id`<br/>*UUID* | The region's id
 `kind`<br/>*string* | Type of the resource
 `name`<br/>*string* | The region's name
-`quotas`<br/>*Array* | Quotas assigned to this region
+`quotas`<br/>*Array[object]* | Quotas assigned to this region
 `selfLink`<br/>*string* | Server-defined URL for this resource
 `status`<br/>*string* | tatus of the region, either UP or DOWN
-`zones`<br/>*Array* | A list of zones available in this region, in the form of resource URLs
+`zones`<br/>*Array[URL]* | A list of zones available in this region, in the form of resource URLs
 
 <!-------------------- RETRIEVE A REGION -------------------->
 
@@ -116,7 +116,7 @@ Attributes | &nbsp;
 `id`<br/>*UUID* | The region's id
 `kind`<br/>*string* | Type of the resource
 `name`<br/>*string* | The region's name
-`quotas`<br/>*Array* | Quotas assigned to this region
+`quotas`<br/>*Array[object]* | Quotas assigned to this region
 `selfLink`<br/>*string* | Server-defined URL for this resource
 `status`<br/>*string* | tatus of the region, either UP or DOWN
-`zones`<br/>*Array* | A list of zones available in this region, in the form of resource URLs
+`zones`<br/>*Array[URL]* | A list of zones available in this region, in the form of resource URLs

--- a/source/includes/gcp/_regions.md
+++ b/source/includes/gcp/_regions.md
@@ -1,0 +1,122 @@
+### Regions
+
+A region is a geographical area where a resource is located. Regions contains multiple Zones.
+
+<!-------------------- LIST REGIONS -------------------->
+
+#### List regions
+
+```shell
+curl -H "MC-Api-Key: your_api_key" \
+    "https://api.your.cloudmc/v1/services/gcp/test-area/regions"
+
+Response body:
+```
+```json
+{
+  "data": [
+    {
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "description": "northamerica-northeast1",
+      "id": "1330",
+      "kind": "compute#region",
+      "name": "northamerica-northeast1",
+      "quotas": [
+        {
+          "limit": 24.0,
+          "metric": "CPUS",
+          "usage": 0.0
+        },
+        {
+          "limit": 4096.0,
+          "metric": "DISKS_TOTAL_GB",
+          "usage": 40.0
+        }
+      ],
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/northamerica-northeast1",
+      "status": "UP",
+      "zones": [
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-a",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-b",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-c"
+      ]
+    },
+  ],
+  "metadata": {
+    "recordCount": 1
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/regions</code>
+
+Retrieve a list of available regions, filtered by the [service connection](#administration-service-connections)'s policies.
+
+Attributes | &nbsp;
+------- | -----------
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`description`<br/>*string* | An optional description of this resource
+`id`<br/>*UUID* | The region's id
+`kind`<br/>*string* | Type of the resource
+`name`<br/>*string* | The region's name
+`quotas`<br/>*Array* | Quotas assigned to this region
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`status`<br/>*string* | tatus of the region, either UP or DOWN
+`zones`<br/>*Array* | A list of zones available in this region, in the form of resource URLs
+
+<!-------------------- RETRIEVE A REGION -------------------->
+
+#### Retrieve a region
+
+```shell
+curl -H "MC-Api-Key: your_api_key" \
+    "https://api.your.cloudmc/v1/services/gcp/test-area/regions/1330"
+
+Response body:
+```
+```json
+{
+   "data": {
+      "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+      "description": "northamerica-northeast1",
+      "id": "1330",
+      "kind": "compute#region",
+      "name": "northamerica-northeast1",
+      "quotas": [
+        {
+          "limit": 24.0,
+          "metric": "CPUS",
+          "usage": 0.0
+        },
+        {
+          "limit": 4096.0,
+          "metric": "DISKS_TOTAL_GB",
+          "usage": 40.0
+        }
+      ],
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/northamerica-northeast1",
+      "status": "UP",
+      "zones": [
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-a",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-b",
+        "https://www.googleapis.com/compute/v1/projects/test-area-oox/zones/northamerica-northeast1-c"
+      ]
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/regions/:id</code>
+
+Retrieve information about a region
+
+Attributes | &nbsp;
+------- | -----------
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`description`<br/>*string* | An optional description of this resource
+`id`<br/>*UUID* | The region's id
+`kind`<br/>*string* | Type of the resource
+`name`<br/>*string* | The region's name
+`quotas`<br/>*Array* | Quotas assigned to this region
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`status`<br/>*string* | tatus of the region, either UP or DOWN
+`zones`<br/>*Array* | A list of zones available in this region, in the form of resource URLs

--- a/source/includes/gcp/_ssh_keys.md
+++ b/source/includes/gcp/_ssh_keys.md
@@ -1,0 +1,112 @@
+### SSH keys
+
+SSH keys are managed at the [environment](#administration-environments) level.
+
+<!-------------------- LIST SSH KEYS -------------------->
+
+#### List SSH keys
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/sshkeys"
+
+# Example:
+```
+```json
+{
+  "data": [
+    {
+      "id": "user1",
+      "name": "user1",
+      "publicKey": "ssh-rsa mypublickey user1@host.com"
+    }
+  ],
+  "metadata": {
+    "recordCount": 1
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys</code>
+
+Retrieve a list of all SSH keys in an [environment](#administration-environments)
+
+Attributes | &nbsp;
+---------- | -----
+`id`<br/>*string* | The SSH key's id
+`name`<br/>*string* | The name of the SSH key
+`publicKey`<br/>*string* | A string representing the protocol, public key and username. [GCP SSH keys documentation](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#sshkeyformat)
+
+<!-------------------- RETRIEVE AN SSH KEY -------------------->
+
+#### Retrieve an SSH key
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/sshkeys/user1"
+
+# Example:
+```
+```json
+{
+  "data": {
+    "id": "user1",
+    "name": "user1",
+    "publicKey": "ssh-rsa mypublickey user1@host.com"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys/:id</code>
+
+Retrieve information about an SSH key of an [environment](#administration-environments)
+
+Attributes | &nbsp;
+---------- | -----
+`id`<br/>*string* | The SSH key's id
+`name`<br/>*string* | The name of the SSH key
+`publicKey`<br/>*string* | A string representing the protocol, public key and username. [GCP SSH keys documentation](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#sshkeyformat)
+
+<!-------------------- ADD AN SSH KEY -------------------->
+
+#### Add an SSH key
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/sshkeys"
+
+# Request example:
+```
+```json
+{
+  "name": "user1",
+  "publicKey": "ssh-rsa mypublickey user1@host.com"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys</code>
+
+Add an SSH key to the [environment](#administration-environments)
+
+Attributes | &nbsp;
+---------- | -----
+`name`<br/>*string* | The name of the SSH key
+`publicKey`<br/>*string* | A string representing the protocol, public key and username. [GCP SSH keys documentation](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#sshkeyformat)
+
+<!-------------------- DELETE AN SSH KEY -------------------->
+
+#### Delete an SSH key
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/sshkeys/user1"
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys/:id</code>
+
+Destroy an existing SSH key from the [environment](#administration-environments)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -59,6 +59,8 @@ includes:
   - gcp
   - gcp/instances
   - gcp/disks
+  - gcp/images
+  - gcp/regions
 
 search: true
 ---

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -61,6 +61,8 @@ includes:
   - gcp/disks
   - gcp/images
   - gcp/regions
+  - gcp/ssh_keys
+  - gcp/networks
 
 search: true
 ---


### PR DESCRIPTION
### Fixes [MC-9194](https://cloud-ops.atlassian.net/browse/MC-9194),  [MC-9248](https://cloud-ops.atlassian.net/browse/MC-9248),  [MC-9249](https://cloud-ops.atlassian.net/browse/MC-9249)

Adding to instances:
- retrieve an instance
- create an instance
- delete an instance
- start an instance
- stop an instance

Adding images:
- list images
- retrieve an image

Adding regions:
- list regions
- retrieve a region

Adding networks:
- list networks
- retrieve a network

Adding SSH keys:
- list SSH keys
- retrieve an SSH key
- add SSH key
- delete SSH key