### PR TITLE
MC-9239: document service connections apiInfo and parameters

### DIFF
--- a/source/includes/administration/_environments.md
+++ b/source/includes/administration/_environments.md
@@ -70,7 +70,7 @@ Attributes | &nbsp;
 ```shell
 # Retrieve visible environment
 
-curl "https://cloudmc_endpoint/v1/environment/[environment-id]" \
+curl "https://cloudmc_endpoint/v1/environment/487a2745-bb8a-44bc-adb1-e3b048f6def2" \
    -H "MC-Api-Key: your_api_key"
 
 # Response body example
@@ -188,7 +188,7 @@ The responses' `data` field contains the updated [environment](#administration-e
 
 ```shell
 # Update an environment
-curl -X POST "https://cloudmc_endpoint/v1/environments/[environment-id]" \
+curl -X POST "https://cloudmc_endpoint/v1/environments/11b6dc20-484c-4142-b440-22ba003caecc" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
@@ -229,7 +229,7 @@ You will need the `Environments update` permission to execute this operation.
 ```shell
 # Delete an environment
 
-curl "https://cloudmc_endpoint/v1/environments/[environment-id]" \
+curl "https://cloudmc_endpoint/v1/environments/11b6dc20-484c-4142-b440-22ba003caecc" \
    -X DELETE -H "MC-Api-Key: your_api_key"
 
 ```

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -80,7 +80,7 @@ Retrieve an organization's details
 
 ```shell
 # Retrieve an organization
-curl "https://cloudmc_endpoint/v1/organizations/[id]" \
+curl "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c0cb5" \
    -H "MC-Api-Key: your_api_key"
 
 # Response body example
@@ -190,7 +190,7 @@ Update an organization. It's parent organization cannot be changed. It can be as
 
 ```shell
 # Update an organization
-curl -X PUT "https://cloudmc_endpoint/v1/organizations/[id]" \
+curl -X PUT "https://cloudmc_endpoint/v1/organizations/3f913132-d479-4332-8fee-9a8c0c01328a" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
@@ -228,7 +228,7 @@ Delete an organization. The caller may not delete his own organization. Also, an
 
 ```shell
 # Delete an organization
-curl -X DELETE "https://cloudmc_endpoint/v1/organizations/[id]" \
+curl -X DELETE "https://cloudmc_endpoint/v1/organizations/3f913132-d479-4332-8fee-9a8c0c01328a" \
    -H "MC-Api-Key: your_api_key"
 ```
 

--- a/source/includes/administration/_roles.md
+++ b/source/includes/administration/_roles.md
@@ -18,7 +18,6 @@ curl "https://cloudmc_endpoint/rest/roles?v=v2&environment_id=4865a023-1dd5-45a3
 ```
 ```json
 {
-{
    "data":[
       {
          "creationDate":"2019-03-11T22:16:15.000Z",

--- a/source/includes/administration/_service_connections.md
+++ b/source/includes/administration/_service_connections.md
@@ -64,12 +64,12 @@ Attributes | &nbsp;
 
 ### Retrieve API credentials
 
-`GET /{serviceConnectionId}/apiInfo`
+`GET /services/connections/:id/apiInfo`
 
 ```shell
 # Retrieve your API credentials
 curl -X GET \
-  "https://system.cloudmc-dev.cloudops-devteam.com/rest/services/connections/5b0172cf-00bd-43de-b2e8-9aaf217c8c35/apiInfo?environmentId=ce3b76e6-c4e1-4e11-850d-e31a3055dc8e" \
+  "https://system.cloudmc-dev.cloudops-devteam.com/rest/services/connections/[id]/apiInfo?environmentId=[id]" \
   -H "MC-Api-Key: your_api_key" \
 # Response body example
 ```
@@ -98,7 +98,7 @@ curl -X GET \
 }
 ```
 
-Retrieve your API keys for some environment within a service. A user can only access their own API keys, and only for environments where they are a member.
+Retrieve your API keys for some environment within a service. A user can only access their own API keys and only for environments where they are a member.
 
 Query Parameters (*required*) | &nbsp;
 ---------- | -----
@@ -108,18 +108,18 @@ Query Parameters (*required*) | &nbsp;
 Attributes | &nbsp;
 ---- | -----------
 `canRegenerateCredentials`<br/>*boolean* | True if the user can regenerate their API keys for the service.
-`fields`<br/>*Array[object]* | An array of key-value pairs describing the users' API keys for the service.<br/>*includes*: `key`, `value` and `sensitive`
+`fields`<br/>*Array[object]* | An array of objects that describe the different parameters (*e.g. endpoint, api_key, secret_key, project_id*) comprised in the users' API credentials.<br/>*includes*: `key`, `value` and `sensitive`
 
 <!-------------------- GET PARAMETERS -------------------->
 
 ### Retrieve connection parameters
 
-`GET /{serviceConnectionId}/parameters`
+`GET /services/connections/:id/parameters`
 
 ```shell
 # Retrieve the connection parameters
 curl -X GET \
-  "https://system.cloudmc-dev.cloudops-devteam.com/rest/services/connections/5b0172cf-00bd-43de-b2e8-9aaf217c8c35/parameters" \
+  "https://system.cloudmc-dev.cloudops-devteam.com/rest/services/connections/[id]/parameters" \
   -H "MC-Api-key: your_api_key" \
 # Response body example
 ```
@@ -143,8 +143,8 @@ curl -X GET \
 }
 ```
 
-Retrieve a service connection's parameters, used to create and manage connections to services. To retrieve the parameters, you need to be an operator or be granted permissions to manage service connections.
+Retrieve a service connection's parameters, used to create and manage connections to services. You can retreive these parameteres only if you are assigned a role that has the `Manage Service connections` permission granted to it.
 
 Attributes | &nbsp;
 ---- | -----------
-`data`<br/>*Array[object]* | An array of objects describing the service connection's parameters.<br/>*includes*: `parameter`, `id`, `value` and `serviceConnection.id`
+`data`<br/>*Array[object]* | An array of objects that describe the service connection parameters.<br/>*includes*: `parameter`, `id`, `value` and `serviceConnection.id`

--- a/source/includes/administration/_service_connections.md
+++ b/source/includes/administration/_service_connections.md
@@ -69,7 +69,7 @@ Attributes | &nbsp;
 ```shell
 # Retrieve your API credentials
 curl -X GET \
-  "https://cloudmc_endpoint/v1/services/connections/[id]/apiInfo?environmentId=[id]" \
+  "https://cloudmc_endpoint/v1/services/connections/378442e0-d9a4-4e55-83e3-220ba1f909a8/apiInfo?environmentId=c880f6b2-f52e-40d5-b289-7211c0319ebc" \
   -H "MC-Api-Key: your_api_key" \
 # Response body example
 ```
@@ -119,7 +119,7 @@ Attributes | &nbsp;
 ```shell
 # Retrieve the connection parameters
 curl -X GET \
-  "https://cloudmc_endpoint/v1/services/connections/[id]/parameters" \
+  "https://cloudmc_endpoint/v1/services/connections/378442e0-d9a4-4e55-83e3-220ba1f909a8/parameters" \
   -H "MC-Api-key: your_api_key" \
 # Response body example
 ```

--- a/source/includes/administration/_service_connections.md
+++ b/source/includes/administration/_service_connections.md
@@ -59,3 +59,92 @@ Attributes | &nbsp;
 `name`<br/>*string* | The name of the service connection
 `type`<br/>*string* | The type of the service connection.
 `status`<br/>*Object* | Status of the service connection. Tells you if the service is up.<br/>*includes*: `lastUpdated`, `reachable`
+
+<!-------------------- GET APIINFO -------------------->
+
+### Retrieve API credentials
+
+`GET /{serviceConnectionId}/apiInfo`
+
+```shell
+# Retrieve your API credentials
+curl -X GET \
+  "https://system.cloudmc-dev.cloudops-devteam.com/rest/services/connections/5b0172cf-00bd-43de-b2e8-9aaf217c8c35/apiInfo?environmentId=ce3b76e6-c4e1-4e11-850d-e31a3055dc8e" \
+  -H "MC-Api-Key: your_api_key" \
+# Response body example
+```
+```json
+{
+    "data": {
+        "canRegenerateCredentials": true,
+        "fields": [{
+            "key": "endpoint",
+            "value": "https://your_endpoint.com/auth",
+            "sensitive": false
+        }, {
+            "key": "api_key",
+            "value": "my_api_key",
+            "sensitive": true
+        }, {
+            "key": "secret_key",
+            "value": "my_secret_key",
+            "sensitive": true
+        }, {
+            "key": "project_id",
+            "value": "079bdead-61b5-4b38-86ed-dbbf963808ec",
+            "sensitive": false
+        }]
+    }
+}
+```
+
+Retrieve your API keys for some environment within a service. A user can only access their own API keys, and only for environments where they are a member.
+
+Query Parameters (*required*) | &nbsp;
+---------- | -----
+`environmentId`<br/>*UUID* | The id of the environment.
+
+
+Attributes | &nbsp;
+---- | -----------
+`canRegenerateCredentials`<br/>*boolean* | True if the user can regenerate their API keys for the service.
+`fields`<br/>*Array[object]* | An array of key-value pairs describing the users' API keys for the service.<br/>*includes*: `key`, `value` and `sensitive`
+
+<!-------------------- GET PARAMETERS -------------------->
+
+### Retrieve connection parameters
+
+`GET /{serviceConnectionId}/parameters`
+
+```shell
+# Retrieve the connection parameters
+curl -X GET \
+  "https://system.cloudmc-dev.cloudops-devteam.com/rest/services/connections/5b0172cf-00bd-43de-b2e8-9aaf217c8c35/parameters" \
+  -H "MC-Api-key: your_api_key" \
+# Response body example
+```
+```json
+{
+    "data": [{
+        "parameter": "jsonCredentials",
+        "id": "ee7f5ba3-3efc-4efd-819b-1dd947b3473a",
+        "value": "JSON representation of credentials here",
+        "serviceConnection": {
+            "id": "d461e683-30c9-4b4e-bab6-def1a3575227"
+        }
+    }, {
+        "parameter": "billingAccountId",
+        "id": "cd404ae3-884d-4b38-a9b7-cd1bba5c0a46",
+        "value": "02C9H96Q-2H1JS2-K9SJD8",
+        "serviceConnection": {
+            "id": "d461e683-30c9-4b4e-bab6-def1a3575227"
+        } 
+    }]
+}
+```
+
+Retrieve a service connection's parameters, used to create and manage connections to services. To retrieve the parameters, you need to be an operator or be granted permissions to manage service connections.
+
+Attributes | &nbsp;
+---- | -----------
+`data`<br/>*Array[object]* | An array of objects describing the service connection's parameters.<br/>*includes*: `parameter`, `id`, `value` and `serviceConnection.id`

--- a/source/includes/administration/_service_connections.md
+++ b/source/includes/administration/_service_connections.md
@@ -69,7 +69,7 @@ Attributes | &nbsp;
 ```shell
 # Retrieve your API credentials
 curl -X GET \
-  "https://system.cloudmc-dev.cloudops-devteam.com/rest/services/connections/[id]/apiInfo?environmentId=[id]" \
+  "https://cloudmc_endpoint/v1/services/connections/[id]/apiInfo?environmentId=[id]" \
   -H "MC-Api-Key: your_api_key" \
 # Response body example
 ```
@@ -119,7 +119,7 @@ Attributes | &nbsp;
 ```shell
 # Retrieve the connection parameters
 curl -X GET \
-  "https://system.cloudmc-dev.cloudops-devteam.com/rest/services/connections/[id]/parameters" \
+  "https://cloudmc_endpoint/v1/services/connections/[id]/parameters" \
   -H "MC-Api-key: your_api_key" \
 # Response body example
 ```

--- a/source/includes/administration/_users.md
+++ b/source/includes/administration/_users.md
@@ -71,7 +71,7 @@ Attributes | &nbsp;
 ```shell
 # Retrieve visible user
 
-curl "https://cloudmc_endpoint/v1/users/[user-id]" \
+curl "https://cloudmc_endpoint/v1/users/fdf60a19-980d-4380-acab-914485111305" \
    -H "MC-Api-Key: your_api_key"
 
 # Response body example
@@ -188,9 +188,9 @@ The responses' `data` field contains the created [user](#administration-users) w
 `PUT /users/:id`
 
 ```shell
-# Create a user
+# Update a user
 
-curl -X PUT "https://cloudmc_endpoint/v1/users/[user-id]" \
+curl -X PUT "https://cloudmc_endpoint/v1/users/dd01c908-371c-4ec5-9fd7-80b1bfac8975" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request-body]"
@@ -236,7 +236,7 @@ The responses' `data` field contains the updated [user](#administration-users).
 ```shell
 # Delete a user
 
-curl "https://cloudmc_endpoint/v1/users/[user-id]" \
+curl "https://cloudmc_endpoint/v1/users/dd01c908-371c-4ec5-9fd7-80b1bfac8975" \
    -X DELETE -H "MC-Api-Key: your_api_key"
 
 ```
@@ -255,7 +255,7 @@ Delete a specific user. You will need the `Delete an existing user` permission t
 ```shell
 # Unlock a user that was locked from the system
 
-curl "https://cloudmc_endpoint/v1/users/[user-id]/unlock" \
+curl "https://cloudmc_endpoint/v1/users/dd01c908-371c-4ec5-9fd7-80b1bfac8975/unlock" \
    -X POST -H "MC-Api-Key: your_api_key"
 
 ```

--- a/source/includes/cloudstack/_load_balancer_rules.md
+++ b/source/includes/cloudstack/_load_balancer_rules.md
@@ -72,7 +72,7 @@ Query Parameters | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/compute-on/test_area/loadbalancerrules/:id"
+   "https://cloudmc_endpoint/v1/services/compute-on/test_area/loadbalancerrules/f8ed7f44-449c-4510-848c-dc18e6665db1"
 ```
 ```json
 {

--- a/source/includes/cloudstack/_network_acls.md
+++ b/source/includes/cloudstack/_network_acls.md
@@ -57,7 +57,7 @@ Query Parameters | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/compute-on/test_area/networkacls/:id"
+   "https://cloudmc_endpoint/v1/services/compute-on/test_area/networkacls/736d0c2e-d6b5-43fc-bcf0-732fce9a509e"
 ```
 ```json
 {

--- a/source/includes/cloudstack/_nics.md
+++ b/source/includes/cloudstack/_nics.md
@@ -171,7 +171,7 @@ Required | &nbsp;
 
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/compute-on/test_area/nics"
+   "https://cloudmc_endpoint/v1/services/compute-on/test_area/nics/fff1f45a-8350-4c87-be43-947b96d01ebd"
 ```
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/nics/:id</code>


### PR DESCRIPTION
### Fixes [MC-9239](https://cloud-ops.atlassian.net/browse/MC-9239)

Documented relevant parts of the **Service connections** api, replaced all values with fake info
- `/{serviceConnectionId}/apiInfo`
- `/{serviceConnectionId}/parameters`

![docday](https://user-images.githubusercontent.com/8960233/59066793-da85c480-887d-11e9-9e97-fb73d4c281a3.jpg)


### Update
- updated all the docs to use real ids in the cURL statements (`[id]` and `:id` placeholders were being used in some places)
- made sure to match the cURL id to the id from the response body when necessary