### PR TITLE
Remove real API key from doc

### DIFF
--- a/source/includes/administration/_resource_commitments.md
+++ b/source/includes/administration/_resource_commitments.md
@@ -11,7 +11,7 @@ Resource commitments allow you to set specific commitment levels on cloud resour
 ```shell
 # Retrieve visible resource commitments
 curl "https://cloudmc_endpoint/v1/resource_commitments" \
-   -H "MC-Api-Key: b8oa9XlEQbb19qshabirg=="
+   -H "MC-Api-Key: your_api_key"
 
 # Response body example
 ```
@@ -103,7 +103,7 @@ Attributes | &nbsp;
 # Retrieve visible a resource commitment
 
 curl "https://cloudmc_endpoint/v1/resource_commitments/fbgc7647-71e6-w69b-998a-c02rf58bf2e6" \
-   -H "MC-Api-Key: b8oa9XlEQbb19qshabirg=="
+   -H "MC-Api-Key: your_api_key"
 
 # Response body example
 ```
@@ -189,7 +189,7 @@ Attributes | &nbsp;
 # Create a resource commitment
 
 curl -X POST "https://cloudmc_endpoint/v1/resource_commitments" \
-   -H "MC-Api-Key: b8oa9XlEQbb19qshabirg==" \
+   -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
 
@@ -260,7 +260,7 @@ The responses' `data` field contains the created [resource-commitment](#administ
 ```shell
 # Update a resource commitment
 curl -X PUT "https://cloudmc_endpoint/v1/resource_commitments/fbgc7647-71e6-w69b-998a-c02rf58bf2e6" \
-   -H "MC-Api-Key: b8oa9XlEQbb19qshabirg==" \
+   -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
 
@@ -336,7 +336,7 @@ The responses' `data` field contains the created [resource-commitment](#administ
 # Delete a resource commitment
 
 curl "https://cloudmc_endpoint/v1/resource_commitments/fbgc7647-71e6-w69b-998a-c02rf58bf2e6" \
-   -X DELETE -H "MC-Api-Key: b8oa9XlEQbb19qshabirg=="
+   -X DELETE -H "MC-Api-Key: your_api_key"
 
 ```
 


### PR DESCRIPTION
Found a real API key in the documentation.

Removing it and using our usual placeholder.