### PR TITLE
Feature/mc 9437 create health check

### DIFF
--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -23,10 +23,11 @@ curl -X GET \
       "name": "healthcheckname",
       "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area/global/healthChecks/healthcheckname",
       "httpHealthCheck": {
+        "host": "",
         "port": 80,
+        "portName": "http",
         "proxyHeader": "NONE",
-        "request": "",
-        "response": ""
+        "requestPath": "/"
       },
       "timeoutSec": 5,
       "type": "HTTP",
@@ -51,13 +52,15 @@ Attributes | &nbsp;
 `checkIntervalSec`<br/>*int* | How often (in seconds) to send a health check. The default value is 5 seconds
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
 `description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
-`healthyThreshold`<br/>*int* | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
+`healthyThreshold`ç | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
+`httpHealthCheck` <br/>*object* | object
+`httpSHealthCheck` <br/>*object* | object
 `id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
 `kind`<br/>*string* | Type of the resource.
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
 `timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
-`type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
+`type`<br/>*string* | Specifies the type of the healthCheck, either  HTTP or HTTPS. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
 `portNumber`<br/>*string* | The port number for health check
 
@@ -84,11 +87,12 @@ curl -X GET \
     "name": "firsthealthcheck",
     "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area/global/healthChecks/firsthealthcheck",
     "httpHealthCheck": {
-      "port": 80,
-      "proxyHeader": "NONE",
-      "request": "",
-      "response": ""
-    },
+        "host": "",
+        "port": 80,
+        "portName": "http",
+        "proxyHeader": "NONE",
+        "requestPath": "/"
+      },
     "timeoutSec": 5,
     "type": "HTTP",
     "unhealthyThreshold": 3,
@@ -107,6 +111,8 @@ Attributes | &nbsp;
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
 `description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
 `healthyThreshold`<br/>*int* | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
+`httpHealthCheck` <br/>*object* | object
+`httpSHealthCheck` <br/>*object* | object
 `id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
 `kind`<br/>*string* | Type of the resource.
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -1,6 +1,6 @@
 ### Health checks
 
-<!-------------------- List HEALTH CHECK -------------------->
+<!-------------------- LIST HEALTH CHECK -------------------->
 #### List health checks
 
 ```shell
@@ -20,7 +20,7 @@ curl -X GET \
       "healthyThreshold": 2,
       "id": "5930212998788364011",
       "kind": "compute#healthCheck",
-      "name": "healthcheckname",
+      "name": "hc-name-xxx",
       "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area/global/healthChecks/healthcheckname",
       "httpHealthCheck": {
         "host": "",
@@ -53,14 +53,14 @@ Attributes | &nbsp;
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
 `description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
 `healthyThreshold`ç | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
-`httpHealthCheck` <br/>*object* | object
-`httpSHealthCheck` <br/>*object* | object
+`httpHealthCheck` <br/>*object* | When the type is set to HTTP, this object represents the health check
+`httpSHealthCheck` <br/>*object* | When the type is set to HTTPS, this object represents the health check
 `id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
 `kind`<br/>*string* | Type of the resource.
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
 `timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
-`type`<br/>*string* | Specifies the type of the healthCheck, either  HTTP or HTTPS. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
+`type`<br/>*string* | Specifies the type of the health check, either HTTP or HTTPS. If not specified, the default is HTTP. Exactly one of the protocol-specific health check field must be specified, which must match type field.
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
 `portNumber`<br/>*string* | The port number for health check
 
@@ -84,7 +84,7 @@ curl -X GET \
     "healthyThreshold": 2,
     "id": "5930212998788364011",
     "kind": "compute#healthCheck",
-    "name": "firsthealthcheck",
+    "name": "hc-name-xxx",
     "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area/global/healthChecks/firsthealthcheck",
     "httpHealthCheck": {
         "host": "",
@@ -111,14 +111,14 @@ Attributes | &nbsp;
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
 `description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
 `healthyThreshold`<br/>*int* | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
-`httpHealthCheck` <br/>*object* | object
-`httpSHealthCheck` <br/>*object* | object
+`httpHealthCheck` <br/>*object* | When the type is set to HTTP, this object represents the health check
+`httpSHealthCheck` <br/>*object* | When the type is set to HTTPS, this object represents the health check
 `id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
 `kind`<br/>*string* | Type of the resource.
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
 `timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
-`type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
+`type`<br/>*string* | Specifies the type of the health check, either HTTP or HTTPS. If not specified, the default is HTTP. Exactly one of the protocol-specific health check field must be specified, which must match type field.
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
 `portNumber`<br/>*string* | The port number for health check
 
@@ -141,7 +141,7 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
-`type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is HTTP. 
+`type`<br/>*string* | Specifies the type of the health check, either HTTP or HTTPS. If not specified, the default is HTTP. 
 `portNumber`<br/>*string* | The port number for the health check. The default is 80 for HTTP, 443 for HTTPS.
 `description`<br/>*string* | Description of the health check
 

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -99,7 +99,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks/:id</code>
 
-Retrieve a healthcheck in a given [environment](#administration-environments)
+Retrieve a health check in a given [environment](#administration-environments)
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -1,5 +1,92 @@
 ### Health checks
 
+<!-------------------- List HEALTH CHECK -------------------->
+#### List health Checks
+
+```shell
+curl --request GET \
+  --url http://cloudmc_endpoint/api/v2/services/your_service/your_environment/healthchecks \
+  --header 'mc-api-key: your_api_keys'
+  # The above command returns JSON structured like this:
+```
+
+```json
+{
+  "data": [
+    {
+      "checkIntervalSec": 10,
+      "creationTimestamp": "2019-09-18T12:39:48.982-07:00",
+      "description": "",
+      "healthyThreshold": 2,
+      "id": "5930212998788364011",
+      "kind": "compute#healthCheck",
+      "name": "firsthealthcheck",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/cmc-gcp-env-jamie-hvh/global/healthChecks/firsthealthcheck",
+      "tcpHealthCheck": {
+        "port": 80,
+        "proxyHeader": "NONE",
+        "request": "",
+        "response": ""
+      },
+      "timeoutSec": 5,
+      "type": "TCP",
+      "unhealthyThreshold": 3,
+      "portNumber": "80"
+    }
+  ],
+  "metadata": {
+    "recordCount": 1
+  }
+}
+```
+
+<code>
+   GET /service/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks
+</code>
+
+Retrieve a list of all healtch checks
+
+Attributes | &nbsp;
+------- | -----------
+`checkIntervalSec`<br/>*int* | How often (in seconds) to send a health check. The default value is 5 seconds
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
+`healthyThreshold`<br/>*int* | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
+`id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.ATTACHED, DETACHING, RESIZING, DELETING, and DEPRECATED.
+`kind`<br/>*string* | Type of the resource.
+`name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`tcpHealthCheck`<br/>*string* | object
+`physicalBlockSizeBytes`<br/>*string* | Physical block size of the persistent disk, in bytes. Currently supported sizes are 4096 and 16384.
+`timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
+`type`<br/>*string* | Specifies the type of the healthCheck, either TCP, SSL, HTTP, HTTPS or HTTP2. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
+`unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
+`portNumber`<br/>*string* | The port number for health check
+
+<!-------------------- Create A HEALTH CHECK -------------------->
+#### Create a health Check
+```shell
+curl --request POST \
+  --url 'http://cloudmc_endpoint/rest/services/your_gcp_connection/your_gcp_environment/healthchecks?operation=create
+
+  --header 'MC-Api-Key: your_api_key'\
+  --data '{"name":"health_check_name","portNumber":"your_port_number","type":"your_protocol_type"}'
+```
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks</code>
+
+Create a new health check
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*string* | The display name of the health check
+`Type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is HTTP. 
+`portNumber`<br/>*string* | The port number for the health check. The default is 80.
+
+Optional | &nbsp;
+------- | -----------
+`description`<br/>*string* | Decription of the health check
+
+
 <!-------------------- DELETE A HEALTH CHECK -------------------->
 
 #### Delete a health check
@@ -13,3 +100,5 @@ curl -X DELETE \
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks/:id</code>
 
 Destroy an existing health check. A health check can only be deleted if it's not used by a [backend service](#gcp-backend-services).
+
+

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -1,12 +1,12 @@
 ### Health checks
 
 <!-------------------- List HEALTH CHECK -------------------->
-#### List health Checks
+#### List health checks
 
 ```shell
-curl --request GET \
-  --url http://cloudmc_endpoint/api/v2/services/your_service/your_environment/healthchecks \
-  --header 'mc-api-key: your_api_keys'
+curl -X GET \
+  -H 'MC-Api-key: your_api_key'
+  "https://cloudmc_endpoint/v1/services/gcp/test-area/healthchecks"
   # The above command returns JSON structured like this:
 ```
 
@@ -20,8 +20,8 @@ curl --request GET \
       "healthyThreshold": 2,
       "id": "5930212998788364011",
       "kind": "compute#healthCheck",
-      "name": "firsthealthcheck",
-      "selfLink": "https://www.googleapis.com/compute/v1/projects/cmc-gcp-env-jamie-hvh/global/healthChecks/firsthealthcheck",
+      "name": "healthcheckname",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area/global/healthChecks/healthcheckname",
       "tcpHealthCheck": {
         "port": 80,
         "proxyHeader": "NONE",
@@ -52,25 +52,23 @@ Attributes | &nbsp;
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
 `description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
 `healthyThreshold`<br/>*int* | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
-`id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.ATTACHED, DETACHING, RESIZING, DELETING, and DEPRECATED.
+`id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
 `kind`<br/>*string* | Type of the resource.
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
-`tcpHealthCheck`<br/>*string* | object
-`physicalBlockSizeBytes`<br/>*string* | Physical block size of the persistent disk, in bytes. Currently supported sizes are 4096 and 16384.
 `timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
 `type`<br/>*string* | Specifies the type of the healthCheck, either TCP, SSL, HTTP, HTTPS or HTTP2. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
 `portNumber`<br/>*string* | The port number for health check
 
-<!-------------------- Create A HEALTH CHECK -------------------->
+<!-------------------- CREATE A HEALTH CHECK -------------------->
 #### Create a health Check
 ```shell
-curl --request POST \
-  --url 'http://cloudmc_endpoint/rest/services/your_gcp_connection/your_gcp_environment/healthchecks?operation=create
-
-  --header 'MC-Api-Key: your_api_key'\
-  --data '{"name":"health_check_name","portNumber":"your_port_number","type":"your_protocol_type"}'
+curl -X POST \
+  -H 'MC-Api-Key: your_api_key' \
+  -H "Content-Type: application/json" \
+  -d "request _body" \
+  "https://cloudmc_endpoint/v1/services/gcp/test-area/healthchecks"
 ```
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks</code>
 
@@ -79,8 +77,8 @@ Create a new health check
 Required | &nbsp;
 ------- | -----------
 `name`<br/>*string* | The display name of the health check
-`Type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is HTTP. 
-`portNumber`<br/>*string* | The port number for the health check. The default is 80.
+`type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is HTTP. 
+`portNumber`<br/>*string* | The port number for the health check. The default is 80 for HTTP, 443 for HTTPS.
 
 Optional | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -61,8 +61,63 @@ Attributes | &nbsp;
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
 `portNumber`<br/>*string* | The port number for health check
 
+<!-------------------- RETRIEVE A HEALTH CHECK -------------------->
+
+#### Retrieve a health check
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/healthchecks/5930212998788364011"
+
+# The above command returns JSON structured like this:
+```
+```json
+{
+  "data": {
+    "checkIntervalSec": 10,
+    "creationTimestamp": "2019-09-18T12:39:48.982-07:00",
+    "description": "",
+    "healthyThreshold": 2,
+    "id": "5930212998788364011",
+    "kind": "compute#healthCheck",
+    "name": "firsthealthcheck",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cmc-gcp-env-jamie-hvh/global/healthChecks/firsthealthcheck",
+    "tcpHealthCheck": {
+      "port": 80,
+      "proxyHeader": "NONE",
+      "request": "",
+      "response": ""
+    },
+    "timeoutSec": 5,
+    "type": "TCP",
+    "unhealthyThreshold": 3,
+    "portNumber": "80"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks/:id</code>
+
+Retrieve a healthcheck in a given [environment](#administration-environments)
+
+Attributes | &nbsp;
+------- | -----------
+`checkIntervalSec`<br/>*int* | How often (in seconds) to send a health check. The default value is 5 seconds
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
+`healthyThreshold`<br/>*int* | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
+`id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
+`kind`<br/>*string* | Type of the resource.
+`name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
+`type`<br/>*string* | Specifies the type of the healthCheck, either TCP, SSL, HTTP, HTTPS or HTTP2. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
+`unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
+`portNumber`<br/>*string* | The port number for health check
+
 <!-------------------- CREATE A HEALTH CHECK -------------------->
-#### Create a health Check
+#### Create a health check
 ```shell
 curl -X POST \
   -H 'MC-Api-Key: your_api_key' \
@@ -82,7 +137,7 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
-`description`<br/>*string* | Decription of the health check
+`description`<br/>*string* | Description of the health check
 
 
 <!-------------------- DELETE A HEALTH CHECK -------------------->

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -22,14 +22,14 @@ curl -X GET \
       "kind": "compute#healthCheck",
       "name": "healthcheckname",
       "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area/global/healthChecks/healthcheckname",
-      "tcpHealthCheck": {
+      "httpHealthCheck": {
         "port": 80,
         "proxyHeader": "NONE",
         "request": "",
         "response": ""
       },
       "timeoutSec": 5,
-      "type": "TCP",
+      "type": "HTTP",
       "unhealthyThreshold": 3,
       "portNumber": "80"
     }
@@ -57,7 +57,7 @@ Attributes | &nbsp;
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
 `timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
-`type`<br/>*string* | Specifies the type of the healthCheck, either TCP, SSL, HTTP, HTTPS or HTTP2. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
+`type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
 `portNumber`<br/>*string* | The port number for health check
 
@@ -82,15 +82,15 @@ curl -X GET \
     "id": "5930212998788364011",
     "kind": "compute#healthCheck",
     "name": "firsthealthcheck",
-    "selfLink": "https://www.googleapis.com/compute/v1/projects/cmc-gcp-env-jamie-hvh/global/healthChecks/firsthealthcheck",
-    "tcpHealthCheck": {
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area/global/healthChecks/firsthealthcheck",
+    "httpHealthCheck": {
       "port": 80,
       "proxyHeader": "NONE",
       "request": "",
       "response": ""
     },
     "timeoutSec": 5,
-    "type": "TCP",
+    "type": "HTTP",
     "unhealthyThreshold": 3,
     "portNumber": "80"
   }
@@ -112,7 +112,7 @@ Attributes | &nbsp;
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
 `timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
-`type`<br/>*string* | Specifies the type of the healthCheck, either TCP, SSL, HTTP, HTTPS or HTTP2. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
+`type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is Http. Exactly one of the protocol-specific health check field must be specified, which must match type field.
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
 `portNumber`<br/>*string* | The port number for health check
 
@@ -132,11 +132,11 @@ Create a new health check
 Required | &nbsp;
 ------- | -----------
 `name`<br/>*string* | The display name of the health check
-`type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is HTTP. 
-`portNumber`<br/>*string* | The port number for the health check. The default is 80 for HTTP, 443 for HTTPS.
 
 Optional | &nbsp;
 ------- | -----------
+`type`<br/>*string* | Specifies the type of the healthCheck, either HTTP or HTTPS. If not specified, the default is HTTP. 
+`portNumber`<br/>*string* | The port number for the health check. The default is 80 for HTTP, 443 for HTTPS.
 `description`<br/>*string* | Description of the health check
 
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

add api doc for GCP-create-health-check