### PR TITLE
MC-10436: document k8 rollback and uninstall helm releases

### DIFF
--- a/source/includes/gcp/_k8_releases.md
+++ b/source/includes/gcp/_k8_releases.md
@@ -320,15 +320,16 @@ Attributes | &nbsp;
 `namespace`<br/>*string* | The namespace to which the release is installed
 
 <!-- ROLLBACK RELEASE -->
-### Rollback release to previous revision
+#### Rollback release to previous revision
 
 ```shell
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=rollback"
-```
+   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=rollback&cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
 
 # The above command returns JSON structured like this:
+```
+
 ```json
 {
     "data": {
@@ -341,9 +342,21 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=rollback</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=rollback&cluster_id=:cluster_id</code>
 
 Rollback a release in a given [environment](#administration-environments) to the previous revision.
+
+Mandatory | &nbsp;
+------- | -----------
+`cluster_id` <br/>*string* | The id of the cluster in which to rollback the release.
+
+Attributes | &nbsp;
+------- | -----------
+`name` <br/>*string* | The name of the release.
+`version` <br/>*string* | The new release revision.
+`namespace` <br/>*string* | The namespace from which the release will be rolled back.
+`taskId` <br/>*string* | The task id related to the pod rollback.
+`taskStatus` <br/>*string* | The status of the operation.
 
 <!-------------------- UPGRADE RELEASE -------------------->
 #### Upgrade release
@@ -355,33 +368,32 @@ curl -X POST \
    -d "request_body"
 
 
-# Request body example:
+# Request body examples:
 ```
 ```json
-#Change to the latest version of a chart
+# Change to the latest version of a chart
 {
   "upgradeChart":  "stable/aerospike" 
 }
 ```
 
 ```json
-#Change to a specific version of a chart
+# Change to a specific version of a chart
 {
   "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
 }
 ```
 
 ```json
-#Change the values for the latest version
+# Change the values for the latest version
 {
   "upgradeChart" : "stable/aerospike",
   "values": "---\n\"replicaCount\": 3\n"
 }
 ```
 
-
 ```json
-#The above command returns JSON structured like this:
+# The above command returns JSON structured like this
 {
   "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
   "taskStatus": "SUCCESS"
@@ -394,21 +406,25 @@ Upgrade a release in a given [environment](#administration-environments)
 
 Mandatory | &nbsp;
 ------- | -----------
-`cluster_id` <br/>*string* | The id of the cluster in which to list the releases. 
+`cluster_id` <br/>*string* | The id of the cluster in which to upgrade the release. 
 `upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  
-
 
 Optional | &nbsp;
 ------- | -----------
 `values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.
 
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the pod upgrade.
+`taskStatus` <br/>*string* | The status of the operation.
+
 <!-- UNINSTALL RELEASE -->
-### Uninstall a release
+#### Uninstall a release
 
 ```shell
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=uninstall"
+   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=uninstall&cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
    -d "request_body"
 
 # Request body example
@@ -419,12 +435,8 @@ curl -X POST \
 }
 ```
 
-Optional | &nbsp;
-------- | -----------
-`keepHistory` <br/>*bool* | If true, will keep release history after uninstalling. Defaults to false.
-
-# The above command returns JSON structured like this:
 ```json
+# The above command returns JSON structured like this
 {
     "data": {
         "version": 0,
@@ -435,6 +447,21 @@ Optional | &nbsp;
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=rollback</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=uninstall&cluster_id=:cluster_id</code>
 
 Uninstall a release in a given [environment](#administration-environments).
+
+Mandatory | &nbsp;
+------- | -----------
+`cluster_id` <br/>*string* | The id of the cluster in which to uninstall the release.
+
+Optional | &nbsp;
+------- | -----------
+`keepHistory` <br/>*bool* | If true, will keep release history after uninstalling. Defaults to false.
+
+Attributes | &nbsp;
+------- | -----------
+`version` <br/>*string* | The uninstalled release's revision. Revision 0 indicated it was uninstalled.
+`keepHistory` <br/>*string* | The *keepHistory* value used when uninstalling the chart.
+`taskId` <br/>*string* | The task id related to the pod uninstall.
+`taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/gcp/_k8_releases.md
+++ b/source/includes/gcp/_k8_releases.md
@@ -332,13 +332,18 @@ curl -X POST \
 
 ```json
 {
-    "data": {
-        "name": "aerospike-1579797954",
-        "version": 8,
-        "namespace": "pspensieri",
-    },
-    "taskId": "13943961-4a2c-4439-b7c9-05113d3b593a",
-    "taskStatus": "SUCCESS"
+  "data": {
+      "name": "aerospike-1579797954",
+      "version": 8,
+      "info": {
+          "deleted": "",
+          "description": "Rollback to 6",
+          "status": "deployed",
+          ...
+      ...
+  },
+  "taskId": "13943961-4a2c-4439-b7c9-05113d3b593a",
+  "taskStatus": "SUCCESS"
 }
 ```
 
@@ -352,9 +357,7 @@ Mandatory | &nbsp;
 
 Attributes | &nbsp;
 ------- | -----------
-`name` <br/>*string* | The name of the release.
-`version` <br/>*string* | The new release revision.
-`namespace` <br/>*string* | The namespace from which the release will be rolled back.
+`data` <br/>*Object* | The release object. See [get release](#get-release) for a description of the release attributes.
 `taskId` <br/>*string* | The task id related to the pod rollback.
 `taskStatus` <br/>*string* | The status of the operation.
 
@@ -438,12 +441,12 @@ curl -X POST \
 ```json
 # The above command returns JSON structured like this
 {
-    "data": {
-        "version": 0,
-        "keepHistory": false
-    },
-    "taskId": "938f11b2-b37d-459e-8cf2-dea05c4d8f63",
-    "taskStatus": "SUCCESS"
+  "data": {
+      "version": 0,
+      "keepHistory": false
+  },
+  "taskId": "938f11b2-b37d-459e-8cf2-dea05c4d8f63",
+  "taskStatus": "SUCCESS"
 }
 ```
 

--- a/source/includes/gcp/_k8_releases.md
+++ b/source/includes/gcp/_k8_releases.md
@@ -319,7 +319,31 @@ Attributes | &nbsp;
 `version`<br/>*string* | The revision of the release
 `namespace`<br/>*string* | The namespace to which the release is installed
 
+<!-- ROLLBACK RELEASE -->
+### Rollback release to previous revision
 
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=rollback"
+```
+
+# The above command returns JSON structured like this:
+```json
+{
+    "data": {
+        "name": "aerospike-1579797954",
+        "version": 8,
+        "namespace": "pspensieri",
+    },
+    "taskId": "13943961-4a2c-4439-b7c9-05113d3b593a",
+    "taskStatus": "SUCCESS"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=rollback</code>
+
+Rollback a release in a given [environment](#administration-environments) to the previous revision.
 
 <!-------------------- UPGRADE RELEASE -------------------->
 #### Upgrade release
@@ -331,7 +355,7 @@ curl -X POST \
    -d "request_body"
 
 
-# Request example:
+# Request body example:
 ```
 Change to the latest version of a chart
 ```json
@@ -374,3 +398,40 @@ Mandatory | &nbsp;
 Optional | &nbsp;
 ------- | -----------
 `values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.
+
+<!-- UNINSTALL RELEASE -->
+### Uninstall a release
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=uninstall"
+   -d "request_body"
+
+# Request body example
+```
+```json
+{
+   "keepHistory": true
+}
+```
+
+Optional | &nbsp;
+------- | -----------
+`keepHistory` <br/>*bool* | If true, will keep release history after uninstalling. Defaults to false.
+
+# The above command returns JSON structured like this:
+```json
+{
+    "data": {
+        "version": 0,
+        "keepHistory": false
+    },
+    "taskId": "938f11b2-b37d-459e-8cf2-dea05c4d8f63",
+    "taskStatus": "SUCCESS"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=rollback</code>
+
+Uninstall a release in a given [environment](#administration-environments).

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -316,9 +316,10 @@ Attributes | &nbsp;
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=rollback"
-```
 
 # The above command returns JSON structured like this:
+```
+
 ```json
 {
     "data": {
@@ -335,6 +336,14 @@ curl -X POST \
 
 Rollback a release in a given [environment](#administration-environments) to the previous revision.
 
+Attributes | &nbsp;
+------- | -----------
+`name` <br/>*string* | The name of the release.
+`version` <br/>*string* | The new release revision.
+`namespace` <br/>*string* | The namespace from which the release will be rolled back.
+`taskId` <br/>*string* | The task id related to the pod rollback.  
+`taskStatus` <br/>*string* | The status of the operation.
+
 <!-------------------- UPGRADE RELEASE -------------------->
 ### Upgrade release
 
@@ -345,25 +354,25 @@ curl -X POST \
    -d "request_body"
 
 
-# Request body example:
+# Request body examples:
 ```
 
 ```json
-#Change to the latest version of a chart
+# Change to the latest version of a chart
 {
   "upgradeChart":  "stable/aerospike" 
 }
 ```
 
 ```json
-#Change to a specific version of a chart
+# Change to a specific version of a chart
 {
   "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
 }
 ```
 
 ```json
-#Change the values for the latest version
+# Change the values for the latest version
 {
   "upgradeChart" : "stable/aerospike",
   "values": "---\n\"replicaCount\": 3\n"
@@ -372,7 +381,7 @@ curl -X POST \
 
 
 ```json
-#The above command returns JSON structured like this:
+# The above command returns JSON structured like this
 {
   "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
   "taskStatus": "SUCCESS"
@@ -392,6 +401,11 @@ Optional | &nbsp;
 ------- | -----------
 `values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.
 
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the pod upgrade.
+`taskStatus` <br/>*string* | The status of the operation.
+
 <!-- UNINSTALL RELEASE -->
 ### Uninstall a release
 
@@ -409,12 +423,8 @@ curl -X POST \
 }
 ```
 
-Optional | &nbsp;
-------- | -----------
-`keepHistory` <br/>*bool* | If true, will keep release history after uninstalling. Defaults to false.
-
-# The above command returns JSON structured like this:
 ```json
+# The above command returns JSON structured like this
 {
     "data": {
         "version": 0,
@@ -425,6 +435,17 @@ Optional | &nbsp;
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=rollback</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=uninstall</code>
 
 Uninstall a release in a given [environment](#administration-environments).
+
+Optional | &nbsp;
+------- | -----------
+`keepHistory` <br/>*bool* | If true, will keep release history after uninstalling. Defaults to false.
+
+Attributes | &nbsp;
+------- | -----------
+`version` <br/>*string* | The uninstalled release's revision. Revision 0 indicated it was uninstalled.
+`keepHistory` <br/>*string* | The *keepHistory* value used when uninstalling the chart.
+`taskId` <br/>*string* | The task id related to the pod uninstall.
+`taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -308,7 +308,31 @@ Attributes | &nbsp;
 `version`<br/>*string* | The revision of the release
 `namespace`<br/>*string* | The namespace to which the release is installed
 
+<!-- ROLLBACK RELEASE -->
+### Rollback release to previous revision
 
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=rollback"
+```
+
+# The above command returns JSON structured like this:
+```json
+{
+    "data": {
+        "name": "aerospike-1579797954",
+        "version": 8,
+        "namespace": "pspensieri",
+    },
+    "taskId": "13943961-4a2c-4439-b7c9-05113d3b593a",
+    "taskStatus": "SUCCESS"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=rollback</code>
+
+Rollback a release in a given [environment](#administration-environments) to the previous revision.
 
 <!-------------------- UPGRADE RELEASE -------------------->
 ### Upgrade release
@@ -320,7 +344,7 @@ curl -X POST \
    -d "request_body"
 
 
-# Request example:
+# Request body example:
 ```
 Change to the latest version of a chart
 ```json
@@ -362,3 +386,40 @@ Mandatory | &nbsp;
 Optional | &nbsp;
 ------- | -----------
 `values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.
+
+<!-- UNINSTALL RELEASE -->
+### Uninstall a release
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=uninstall"
+   -d "request_body"
+
+# Request body example
+```
+```json
+{
+   "keepHistory": true
+}
+```
+
+Optional | &nbsp;
+------- | -----------
+`keepHistory` <br/>*bool* | If true, will keep release history after uninstalling. Defaults to false.
+
+# The above command returns JSON structured like this:
+```json
+{
+    "data": {
+        "version": 0,
+        "keepHistory": false
+    },
+    "taskId": "938f11b2-b37d-459e-8cf2-dea05c4d8f63",
+    "taskStatus": "SUCCESS"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=rollback</code>
+
+Uninstall a release in a given [environment](#administration-environments).

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -322,13 +322,18 @@ curl -X POST \
 
 ```json
 {
-    "data": {
-        "name": "aerospike-1579797954",
-        "version": 8,
-        "namespace": "pspensieri",
-    },
-    "taskId": "13943961-4a2c-4439-b7c9-05113d3b593a",
-    "taskStatus": "SUCCESS"
+  "data": {
+      "name": "aerospike-1579797954",
+      "version": 8,
+      "info": {
+          "deleted": "",
+          "description": "Rollback to 6",
+          "status": "deployed",
+          ...
+      ...
+  },
+  "taskId": "13943961-4a2c-4439-b7c9-05113d3b593a",
+  "taskStatus": "SUCCESS"
 }
 ```
 
@@ -338,9 +343,7 @@ Rollback a release in a given [environment](#administration-environments) to the
 
 Attributes | &nbsp;
 ------- | -----------
-`name` <br/>*string* | The name of the release.
-`version` <br/>*string* | The new release revision.
-`namespace` <br/>*string* | The namespace from which the release will be rolled back.
+`data` <br/>*Object* | The release object. See [get release](#get-release) for a description of the release attributes.
 `taskId` <br/>*string* | The task id related to the pod rollback.  
 `taskStatus` <br/>*string* | The status of the operation.
 
@@ -426,12 +429,12 @@ curl -X POST \
 ```json
 # The above command returns JSON structured like this
 {
-    "data": {
-        "version": 0,
-        "keepHistory": false
-    },
-    "taskId": "938f11b2-b37d-459e-8cf2-dea05c4d8f63",
-    "taskStatus": "SUCCESS"
+  "data": {
+      "version": 0,
+      "keepHistory": false
+  },
+  "taskId": "938f11b2-b37d-459e-8cf2-dea05c4d8f63",
+  "taskStatus": "SUCCESS"
 }
 ```
 


### PR DESCRIPTION
Document Kubernetes **rollback to previous revision** and **uninstall** releases.
- added to both GCP and K8 docs

#### Related PRs
- rollback release to previous revision https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/37
- uninstall release https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/28