### PR TITLE
MC-10262: Create subnet for virtual network docs

### DIFF
--- a/source/includes/azure/_networks.md
+++ b/source/includes/azure/_networks.md
@@ -75,6 +75,6 @@ Attributes | &nbsp;
 ---------- | -----
 `name`<br/>*string* | The name of the virtual network
 `region`<br/>*string* | The region in which the virtual network is located
-`addressSpace`<br/>*string* | The first address range (CIDR format) that will be covered by this virtual network
+`addressSpace`<br/>*string* | The first address range (IPV4 CIDR format) that will be covered by this virtual network
 `subnetName`<br/>*string* | The first subnet name within this virtual network
-`subnetAddressPrefix`<br/>*string* | The first subnet address range (CIDR format) within this virtual network
+`subnetAddressPrefix`<br/>*string* | The first subnet address range (IPV4 CIDR format) within this virtual network

--- a/source/includes/azure/_subnets.md
+++ b/source/includes/azure/_subnets.md
@@ -121,6 +121,41 @@ Attributes | &nbsp;
 `nics.id`<br/>*string* | The id for the nic. 
 `nics.subnetName`<br/>*string* | The name for the subnet to which to the nic belongs. 
 
+<!-------------------- CREATE A SUBNET -------------------->
+
+#### Create a subnet
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/v1/services/azure/example/subnets"
+
+# Request example:
+```
+
+```json
+{
+  "name": "default",
+  "addressPrefix": "10.0.1.0/24",
+  "parentNetworkId": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnets</code>
+
+Create a new subnet.
+
+Required | &nbsp;
+------- | -----------
+`name` <br/>*string* | The name of the subnet. The name cannot exceed 80 characters.
+`addressPrefix` <br/>*string* | The portion of the parent network's address space (IPV4 CIDR format) allocated to the subnet. The range cannot overlap with other subnets. The smallest range you can specify is /29.
+`parentNetworkId` <br/>*string* | The subnet's parent network id.
+
+Optional | &nbsp;
+------- | -----------
+`networkSecurityGroupName` <br/>*string* | The name of an existing network security group to be associated with the subnet. The security group must exist in the same subscription and location as the virtual network.
+
 <!-------------------- DELETE A SUBNET -------------------->
 
 #### Delete a subnet


### PR DESCRIPTION
### Fixes [MC-10262](https://cloud-ops.atlassian.net/browse/MC-10262)

#### Code walkthrough : @evanluc 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
User should be able to create a subnet for a virtual network.

#### Solution
- Adapted existing methods in `NetworkUtils` for validation
- See the test `Should suggest an address space for subnets` in `NetworkUtilsSpec` for examples of what subnet prefixes will be suggested
- Subnet prefix suggesteion will also be reused on network creation

#### Test cases
- `CreateSubnetSpec`
- `CreateSubnetViewSpec`
- `NetworkUtilsSpec`

#### UI changes
![create-subnet-info](https://user-images.githubusercontent.com/8960233/76130165-d4bd3b00-5fd7-11ea-82de-a07566a2508d.jpg)

#### Related PRs
- PR https://github.com/cloudops/cloudmc-azure-plugin/pull/107