### PR TITLE
Feature/mc 11017 create public ip

### DIFF
--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -128,7 +128,7 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses/:id</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses</code>
 
 Create a public IP address in a given [environment](#administration-environments)
 

--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -132,12 +132,14 @@ curl -X GET \
 
 Create a public IP address in a given [environment](#administration-environments)
 
-
-Attributes | &nbsp;
+Required | &nbsp;
 ------- | -----------
 `name` <br/>*string* | The name of the public IP address.
 `region` <br/>*string* | The region where the public IP address is located.
+
+Optional | &nbsp;
+------- | -----------
 `sku`  <br /> *string* | The sku of the public IP. Possible values: `BASIC`, `STANDARD`. Default value is `BASIC`.
 `allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Default value is `DYNAMIC` for SKU `BASIC`, and `STATIC` for SKU `STANDARD`.
 `idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Default value is 4 minutes.
-`domainName` <br/>*string* | The subdomain part of the fqdn. Optional.
+`domainName` <br/>*string* | The subdomain part of the fqdn.

--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -138,6 +138,6 @@ Attributes | &nbsp;
 `name` <br/>*string* | The name of the public IP address.
 `region` <br/>*string* | The region where the public IP address is located.
 `sku`  <br /> *string* | The sku of the public IP. Possible values: `BASIC`, `STANDARD`. Default value is `BASIC`.
-`allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Default value for SKU `BASIC` is `DYNAMIC` and `STATIC` for SKU `STANDARD`.
+`allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Default value is `DYNAMIC` for SKU `BASIC`, and `STATIC` for SKU `STANDARD`.
 `idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Default value is 4 minutes.
 `domainName` <br/>*string* | The subdomain part of the fqdn. Optional.

--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -26,6 +26,7 @@ curl -X GET \
       "domainName": "somepublicip",
       "fqdn": "somepublicip.eastus.cloudapp.azure.com",
       "sku": "BASIC",
+      "idleTimeout": 7,
       "allocationMethod": "DYNAMIC",
       "ipVersion": "IPV4"
     }
@@ -50,6 +51,7 @@ Attributes | &nbsp;
 `sku`  <br /> *string* | The sku of the public IP.
 `domainName` <br/>*string* | The subdomain part of the fqdn. This is only present if one is defined.
 `fqn` <br/>*string* | The fqdn which points to the public IP.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes.
 `allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`.
 `ipVersion` <br/>*string* |  IP version of the public IP address. Possible values: `IPV4`, `IPV6`.
 
@@ -76,6 +78,7 @@ curl -X GET \
     "domainName": "somepublicip",
     "fqdn": "somepublicip.eastus.cloudapp.azure.com",
     "sku": "BASIC",
+    "idleTimeout": 7,
     "allocationMethod": "DYNAMIC",
     "ipVersion": "IPV4"
   }
@@ -96,5 +99,45 @@ Attributes | &nbsp;
 `sku`  <br /> *string* | The sku of the public IP.
 `domainName` <br/>*string* | The subdomain part of the fqdn. This is only present if one is defined.
 `fqn` <br/>*string* | The fqdn which points to the public IP.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes.
 `allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`.
 `ipVersion` <br/>*string* |  IP version of the public IP address. Possible values: `IPV4`, `IPV6`.
+
+
+<!-------------------- CREATE A PUBLIC IP -------------------->
+
+#### Create a public ip address
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body"
+   "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses"
+
+# Request Example:
+```
+
+```json
+{
+	"name":"samplePublicIP",
+	"region" : "canadacentral",
+	"sku": "BASIC",
+	"allocationMethod" : "DYNAMIC",
+	"idleTimeout" : 30,
+	"domainName" : "samplePublicIP"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses/:id</code>
+
+Create a public IP address in a given [environment](#administration-environments)
+
+
+Attributes | &nbsp;
+------- | -----------
+`name` <br/>*string* | The name of the public IP address.
+`region` <br/>*string* | The region where the public IP address is located.
+`sku`  <br /> *string* | The sku of the public IP. Possible values: `BASIC`, `STANDARD`. Default value is `BASIC`.
+`allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Default value for SKU `BASIC` is `DYNAMIC` and `STATIC` for SKU `STANDARD`.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Default value is 4 minutes.
+`domainName` <br/>*string* | The subdomain part of the fqdn. Optional.

--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -109,7 +109,7 @@ Attributes | &nbsp;
 #### Create a public ip address
 
 ```shell
-curl -X GET \
+curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body"
    "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses"


### PR DESCRIPTION
### Feature [MC-11017](https://cloud-ops.atlassian.net/browse/MC-11017)

#### Code walkthrough : @GuillaumeVialle 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
It was possible to list the public IP addresses but we could not create a new one.

#### Solution
Implement the creation of public IP address

#### Test cases
- Unit tests
- Manual UI test
- Manual API test

#### UI changes
**List view** 
![image](https://user-images.githubusercontent.com/56133634/78133965-5cd30c80-73ed-11ea-8d7b-c606b0a62c45.png)

**Create view** 
![image](https://user-images.githubusercontent.com/56133634/78133912-462cb580-73ed-11ea-886b-875448ec9f7e.png)
![image](https://user-images.githubusercontent.com/56133634/78133939-504eb400-73ed-11ea-8050-41e2a09f5f29.png)

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-ui/pull/716
- PR # https://github.com/cloudops/cloudmc-azure-plugin/pull/167
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/120
