### PR TITLE
MC-11025: Added update operation api documentation

### DIFF
--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -143,3 +143,35 @@ Optional | &nbsp;
 `allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Default value is `DYNAMIC` for SKU `BASIC`, and `STATIC` for SKU `STANDARD`.
 `idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Default value is 4 minutes.
 `domainName` <br/>*string* | The subdomain part of the fqdn.
+
+
+<!-------------------- UPDATE A PUBLIC IP -------------------->
+
+#### Update a public ip address
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body"
+   "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses//subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/publicIPAddresses/some-public-ip?operation=update"
+
+# Request Example:
+```
+
+```json
+{
+	"allocationMethod" : "DYNAMIC",
+	"idleTimeout" : 30,
+	"domainName" : "samplePublicIP"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses/:id?operation=update</code>
+
+Update a public IP address in a given [environment](#administration-environments)
+
+Attribute | &nbsp;
+------- | -----------
+`allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Not providing will no change it.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Not providing will keep the value.
+`domainName` <br/>*string* | The subdomain part of the fqdn. If it is empty or not provided, the entry will be removed from the DNS.

--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -150,10 +150,10 @@ Optional | &nbsp;
 #### Update a public ip address
 
 ```shell
-curl -X POST \
+curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body"
-   "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses//subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/publicIPAddresses/some-public-ip?operation=update"
+   "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses//subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/publicIPAddresses/some-public-ip"
 
 # Request Example:
 ```
@@ -166,12 +166,12 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses/:id?operation=update</code>
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses/:id</code>
 
 Update a public IP address in a given [environment](#administration-environments)
 
 Attribute | &nbsp;
 ------- | -----------
-`allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Not providing will no change it.
-`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Not providing will keep the value.
+`allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Not providing it will keep the actual value. Cannot be change for Standard SKU public IP address.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Not providing it will keep the actual value.
 `domainName` <br/>*string* | The subdomain part of the fqdn. If it is empty or not provided, the entry will be removed from the DNS.

--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -51,7 +51,7 @@ Attributes | &nbsp;
 `sku`  <br /> *string* | The sku of the public IP. Possible values: `BASIC`, `STANDARD`.
 `domainName` <br/>*string* | The subdomain part of the fqdn. This is only present if one is defined.
 `fqn` <br/>*string* | The fqdn which points to the public IP.
-`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. It can be between 4 and 30 minutes.
 `allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`.
 `ipVersion` <br/>*string* |  IP version of the public IP address. Possible values: `IPV4`, `IPV6`.
 
@@ -99,7 +99,7 @@ Attributes | &nbsp;
 `sku`  <br /> *string* | The sku of the public IP. Possible values: `BASIC`, `STANDARD`.
 `domainName` <br/>*string* | The subdomain part of the fqdn. This is only present if one is defined.
 `fqn` <br/>*string* | The fqdn which points to the public IP.
-`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. It can be between 4 and 30 minutes.
 `allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`.
 `ipVersion` <br/>*string* |  IP version of the public IP address. Possible values: `IPV4`, `IPV6`.
 
@@ -141,7 +141,7 @@ Optional | &nbsp;
 ------- | -----------
 `sku`  <br /> *string* | The sku of the public IP. Possible values: `BASIC`, `STANDARD`. Default value is `BASIC`.
 `allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Default value is `DYNAMIC` for SKU `BASIC`, and `STATIC` for SKU `STANDARD`.
-`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Default value is 4 minutes.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. It can be between 4 and 30 minutes. Default value is 4 minutes.
 `domainName` <br/>*string* | The subdomain part of the fqdn.
 
 
@@ -173,5 +173,5 @@ Update a public IP address in a given [environment](#administration-environments
 Attribute | &nbsp;
 ------- | -----------
 `allocationMethod` <br/>*string* | Allocation method of the public IP address. Possible values: `DYNAMIC`, `STATIC`. Not providing it will keep the actual value. Cannot be change for Standard SKU public IP address.
-`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. I can be between 4 and 30 minutes. Not providing it will keep the actual value.
+`idleTimeout` <br/>*integer* | The number of minutes for the idleTimeout. It can be between 4 and 30 minutes. Not providing it will keep the actual value.
 `domainName` <br/>*string* | The subdomain part of the fqdn. If it is empty or not provided, the entry will be removed from the DNS.


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

### Feature [MC-11025](https://cloud-ops.atlassian.net/browse/MC-11025)

#### Code walkthrough : @evanluc 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
If we want to change settings on the public ip, it was not possible.

#### Solution
Added the update operation on the public IP configuration to allow modifications on the public IPs.

#### Test cases
- Manual Test
- Manual UI test
- Unit test

#### UI changes
**List view**
![image](https://user-images.githubusercontent.com/56133634/78574108-8928c780-77f7-11ea-9202-68b068a8e947.png)

**Detailed view**
![image](https://user-images.githubusercontent.com/56133634/78574071-7c0bd880-77f7-11ea-90f7-86589681991b.png)

** Edit Public IP Page**
![image](https://user-images.githubusercontent.com/56133634/78574025-68f90880-77f7-11ea-9e55-9f1239fe2152.png)


#### Related PRs
- PR # https://github.com/cloudops/cloudmc-azure-plugin/pull/174
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/121