### PR TITLE
MC-11024: Added the association of public ip to an instance at creation.

### DIFF
--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -33,7 +33,8 @@ curl -X GET \
       "privateIp": "10.0.0.4",
       "macAddress": "00-0D-3A-84-0B-EF",
       "powerState": "PowerState/running",
-      "displayPowerState": "running"
+      "displayPowerState": "running",
+      "networkInterfaceId": "/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkInterfaces/nic3244866cf2f"
     }
   ],
   "metadata": {
@@ -66,7 +67,7 @@ Attributes | &nbsp;
 `publicIp`<br/>*string* | The public ip address assigned to the instance
 `powerState`<br/>*string* | The status of the instance. One of the following values:    PowerState/running, PowerState/deallocating, PowerState/deallocated, PowerState/starting, PowerState/stopped, PowerState/stopping and PowerState/unknown
 `displayPowerState`<br/>*string* | The status of the instance. One of the following values: running, deallocating, deallocated, starting, stopped, stopping and unknown
-
+`networkInterfaceId`<br/>*string* | The fully qualified id of the primary network interface associate to the instance
 
 <!-------------------- RETRIEVE AN INSTANCE -------------------->
 
@@ -98,7 +99,8 @@ curl -X GET \
     "privateIp": "10.0.0.4",
     "macAddress": "00-0D-3A-0B-F2-96",
     "powerState": "PowerState/running",
-    "displayPowerState": "running"
+    "displayPowerState": "running",
+    "networkInterfaceId": "/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkInterfaces/nic3244866cf2f"
   }
 }
 ```
@@ -127,6 +129,7 @@ Attributes | &nbsp;
 `publicIp`<br/>*string* | The public ip address assigned to the instance
 `powerState`<br/>*string* | The status of the instance. One of the following values:    PowerState/running, PowerState/deallocating, PowerState/deallocated, PowerState/starting, PowerState/stopped, PowerState/stopping and PowerState/unknown
 `displayPowerState`<br/>*string* | The status of the instance. One of the following values: running, deallocating, deallocated, starting, stopped, stopping and unknown
+`networkInterfaceId`<br/>*string* | The fully qualified id of the primary network interface associate to the instance
 
 <!-------------------- CREATE AN INSTANCE -------------------->
 
@@ -192,6 +195,8 @@ Optional | &nbsp;
 ------- | -----------
 `password`<br/>*string* | The password of the administrator account. It must be between between 12 and 72 characters and must be a combination of 3 of the following patterns : Special characters, Uppercase, Lowercase and Numbers. The password is mandatory if the sshkey is not provided.
 `sshkey`<br/>*string* | The ssh key public portion that will be assigned to the user on the machine. This cannot be used for a Windows based OS.
+`publicIpAddressId`<br/>*string* | The fully qualified id of the public IP address to associate to the instance.
+"
 
 <!-------------------- DELETE AN INSTANCE -------------------->
 

--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -196,7 +196,6 @@ Optional | &nbsp;
 `password`<br/>*string* | The password of the administrator account. It must be between between 12 and 72 characters and must be a combination of 3 of the following patterns : Special characters, Uppercase, Lowercase and Numbers. The password is mandatory if the sshkey is not provided.
 `sshkey`<br/>*string* | The ssh key public portion that will be assigned to the user on the machine. This cannot be used for a Windows based OS.
 `publicIpAddressId`<br/>*string* | The fully qualified id of the public IP address to associate to the instance.
-"
 
 <!-------------------- DELETE AN INSTANCE -------------------->
 


### PR DESCRIPTION
Added the network interface id of the primary nic associated to an instance

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

### Feature [MC-11024](https://cloud-ops.atlassian.net/browse/MC-11024)

#### Code walkthrough : @GuillaumeVialle 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
Could not associate a public IP address on the instance creation.

#### Solution
Add an option to select an available public IP address in the create instance.

#### Test cases
- Manual API tests
- UI tests
- Unit Tests

#### UI changes
** Create Instance screen**
![image](https://user-images.githubusercontent.com/56133634/78709330-77235380-78e1-11ea-846f-564e80278431.png)
![image](https://user-images.githubusercontent.com/56133634/78709366-83a7ac00-78e1-11ea-9969-599be4dc4e91.png)
![image](https://user-images.githubusercontent.com/56133634/78709638-f9ac1300-78e1-11ea-9c5d-a453f8f397fb.png)

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/124
- PR # https://github.com/cloudops/cloudmc-azure-plugin/pull/179
