### PR TITLE
Added missing state

### DIFF
--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -45,7 +45,7 @@ Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id of the public IP address. This is a canonized id from azure which is the form of `/subscriptions/:subscriptionid/resourceGroups/:resourcegroup/providers/`Microsoft.Network/publicIPAddresses/:publicIpName.
 `name` <br/>*string* | The name of the public IP address.
-`state` <br/>*string* | The state of the public IP address. Possible state: `ATTACHED`, `DETACHED`.
+`state` <br/>*string* | The state of the public IP address. Possible state: `ATTACHED`, `DETACHED`, `UPDATING`, `DELETING`.
 `ipAddress` <br/>*string* | The IP address of the public IP. If the public IP has never been associated before, then you won't have an ip address yet.
 `region` <br/>*string* | The region where the public IP address is located.
 `sku`  <br /> *string* | The sku of the public IP. Possible values: `BASIC`, `STANDARD`.
@@ -93,7 +93,7 @@ Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id of the public IP address. This is a canonized id from azure which is the form of `/subscriptions/:subscriptionid/resourceGroups/:resourcegroup/providers/`Microsoft.Network/publicIPAddresses/:publicIpName.
 `name` <br/>*string* | The name of the public IP address.
-`state` <br/>*string* | The state of the public IP address. Possible state: `ATTACHED`, `DETACHED`.
+`state` <br/>*string* | The state of the public IP address. Possible state: `ATTACHED`, `DETACHED`, `UPDATING`, `DELETING`.
 `ipAddress` <br/>*string* | The IP address of the public IP. If the public IP has never been associated before, then you won't have an ip address yet.
 `region` <br/>*string* | The region where the public IP address is located.
 `sku`  <br /> *string* | The sku of the public IP. Possible values: `BASIC`, `STANDARD`.


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
### Improvement [MC-11025](https://cloud-ops.atlassian.net/browse/MC-11025)

#### Code walkthrough : @lamminade 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
While doing the DOD of the edit public ip address, i found out the the update and delete status where not handle in the list.

#### Solution
Added the status in the possible list.

#### Test cases
- Unit test in the fetcher
- Manual UI test

#### UI changes
No changes

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/126
- PR # https://github.com/cloudops/cloudmc-azure-plugin/pull/183
