### PR TITLE
MC-10909: Added few parameters for the instance. Documented fields no…

### DIFF
--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -32,6 +32,12 @@ curl -X GET \
       "region": "canadacentral",
       "privateIp": "10.0.0.4",
       "macAddress": "00-0D-3A-84-0B-EF",
+      "subnetName": "default",
+      "networkName": "vn_root_qyg",
+      "supportsPremiumIO": true,
+      "supportsUltraIO": false,
+      "attachableDiskSlots": 2,
+      "usedLuns": [1],
       "powerState": "PowerState/running",
       "displayPowerState": "running",
       "networkInterfaces": [
@@ -70,6 +76,12 @@ Attributes | &nbsp;
 `privateIp`<br/>*string* | The private ip address assigned to the instance
 `internalFqdn`<br/>*string* | The internal FQDN assigned to the instance
 `macAddress`<br/>*string* | The MAC address assigned to the instance
+`subnetName`<br/>*string* | The name of the subnet that the instance is part of
+`networkName`<br/>*string* | The name of the network that the instance is part of
+`supportsPremiumIO`<br/>*boolean* | If the instance supports Premium IO. This is fixed by the machine type.
+`supportsUltraIO`<br/>*boolean* | If the instance supports Ultra IO. This is fixed by the machine type.
+`attachableDiskSlots`<br/>*integer* | The number of data disk that can be attached to the instance. This is fixed by the machine type.
+`usedLuns`<br/>*array* | An array of all the LUNs already used for the data disks.
 `publicIp`<br/>*string* | The public ip address assigned to the instance
 `powerState`<br/>*string* | The status of the instance. One of the following values:    PowerState/running, PowerState/deallocating, PowerState/deallocated, PowerState/starting, PowerState/stopped, PowerState/stopping and PowerState/unknown
 `displayPowerState`<br/>*string* | The status of the instance. One of the following values: running, deallocating, deallocated, starting, stopped, stopping and unknown
@@ -105,6 +117,12 @@ curl -X GET \
     "region": "canadacentral",
     "privateIp": "10.0.0.4",
     "macAddress": "00-0D-3A-0B-F2-96",
+    "subnetName": "default",
+    "networkName": "vn_root_qyg",
+    "supportsPremiumIO": true,
+    "supportsUltraIO": false,
+    "attachableDiskSlots": 2,
+    "usedLuns": [],
     "powerState": "PowerState/running",
     "displayPowerState": "running",
     "networkInterfaces": [
@@ -139,6 +157,12 @@ Attributes | &nbsp;
 `privateIp`<br/>*string* | The private ip address assigned to the instance
 `internalFqdn`<br/>*string* | The internal FQDN assigned to the instance
 `macAddress`<br/>*string* | The MAC address assigned to the instance
+`subnetName`<br/>*string* | The name of the subnet that the instance is part of
+`networkName`<br/>*string* | The name of the network that the instance is part of
+`supportsPremiumIO`<br/>*boolean* | If the instance supports Premium IO. This is fixed by the machine type.
+`supportsUltraIO`<br/>*boolean* | If the instance supports Ultra IO. This is fixed by the machine type.
+`attachableDiskSlots`<br/>*integer* | The number of data disk that can be attached to the instance. This is fixed by the machine type.
+`usedLuns`<br/>*array* | An array of all the LUNs already used for the data disks.
 `publicIp`<br/>*string* | The public ip address assigned to the instance
 `powerState`<br/>*string* | The status of the instance. One of the following values:    PowerState/running, PowerState/deallocating, PowerState/deallocated, PowerState/starting, PowerState/stopped, PowerState/stopping and PowerState/unknown
 `displayPowerState`<br/>*string* | The status of the instance. One of the following values: running, deallocating, deallocated, starting, stopped, stopping and unknown

--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -61,31 +61,31 @@ Retrieve a list of all instances in a given [environment](#administration-enviro
 
 Attributes | &nbsp;
 ------- | -----------
-`id` <br/>*string* | The id of the instance. This is a canonized id from azure which is the form of `/subscriptions/:subscriptionid/resourceGroups/:resourcegroup/providers/`Microsoft.Compute/virtualMachines/:instanceName
-`name` <br/>*string* | The name of the instance
-`machineType`<br/>*string* | The type of machine assigned for this instance
+`id` <br/>*string* | The id of the instance. This is a canonized id from azure which is the form of `/subscriptions/:subscriptionid/resourceGroups/:resourcegroup/providers/`Microsoft.Compute/virtualMachines/:instanceName.
+`name` <br/>*string* | The name of the instance.
+`machineType`<br/>*string* | The type of machine assigned for this instance.
 `numberOfCores`<br/>*int* | The number of cores provisioned for this instance. This is determined by the machine type.
 `memoryInGB`<br/>*int* | The number of memory in GB provisioned for this instance. This is determined by the machine type.
-`imagePublisher`<br/>*string* | The publisher of the instance used to create the instance
-`imageOffer`<br/>*string* | The image offer that was used to create the instance
-`imageSku`<br/>*string* | The image SKU that was used to create the instance
-`imageVersion`<br/>*string* | The image version that was used to create the instance
-`displayImage`<br/>*string* | Displayable value of the image information
+`imagePublisher`<br/>*string* | The publisher of the instance used to create the instance.
+`imageOffer`<br/>*string* | The image offer that was used to create the instance.
+`imageSku`<br/>*string* | The image SKU that was used to create the instance.
+`imageVersion`<br/>*string* | The image version that was used to create the instance.
+`displayImage`<br/>*string* | Displayable value of the image information.
 `osType`<br/>*string* | The OS type of the instance. This can be either Windows or Linux.
-`region`<br/>*string* | The region in which the instance is located
-`privateIp`<br/>*string* | The private ip address assigned to the instance
-`internalFqdn`<br/>*string* | The internal FQDN assigned to the instance
-`macAddress`<br/>*string* | The MAC address assigned to the instance
-`subnetName`<br/>*string* | The name of the subnet that the instance is part of
-`networkName`<br/>*string* | The name of the network that the instance is part of
-`supportsPremiumIO`<br/>*boolean* | If the instance supports Premium IO. This is fixed by the machine type.
-`supportsUltraIO`<br/>*boolean* | If the instance supports Ultra IO. This is fixed by the machine type.
-`attachableDiskSlots`<br/>*integer* | The number of data disk that can be attached to the instance. This is fixed by the machine type.
-`usedLuns`<br/>*array* | An array of all the LUNs already used for the data disks.
-`publicIp`<br/>*string* | The public ip address assigned to the instance
-`powerState`<br/>*string* | The status of the instance. One of the following values:    PowerState/running, PowerState/deallocating, PowerState/deallocated, PowerState/starting, PowerState/stopped, PowerState/stopping and PowerState/unknown
-`displayPowerState`<br/>*string* | The status of the instance. One of the following values: running, deallocating, deallocated, starting, stopped, stopping and unknown
-`networkInterfaces`<br/>*list* | A list of network interfaces of the instance. Contains fields: `id`, `name`, `primary`
+`region`<br/>*string* | The region in which the instance is located.
+`privateIp`<br/>*string* | The private ip address assigned to the instance.
+`internalFqdn`<br/>*string* | The internal FQDN assigned to the instance.
+`macAddress`<br/>*string* | The MAC address assigned to the instance.
+`subnetName`<br/>*string* | The name of the subnet that the instance is part of.
+`networkName`<br/>*string* | The name of the network that the instance is part of.
+`supportsPremiumIO`<br/>*boolean* | If the instance supports Premium disks. This is fixed by the machine type.
+`supportsUltraIO`<br/>*boolean* | If the instance supports Ultra disks. This is fixed by the machine type.
+`attachableDiskSlots`<br/>*integer* | The number of managed disks that can be attached to the instance. This is fixed by the machine type.
+`usedLuns`<br/>*array* | An array of all the LUNs associated with the managed disks attached to this instance.
+`publicIp`<br/>*string* | The public ip address assigned to the instance.
+`powerState`<br/>*string* | The status of the instance. One of the following values:    PowerState/running, PowerState/deallocating, PowerState/deallocated, PowerState/starting, PowerState/stopped, PowerState/stopping and PowerState/unknown.
+`displayPowerState`<br/>*string* | The status of the instance. One of the following values: running, deallocating, deallocated, starting, stopped, stopping and unknown.
+`networkInterfaces`<br/>*list* | A list of network interfaces of the instance. Contains fields: `id`, `name`, `primary`.
 
 
 <!-------------------- RETRIEVE AN INSTANCE -------------------->
@@ -142,31 +142,31 @@ Retrieve an instance in a given [environment](#administration-environments)
 
 Attributes | &nbsp;
 ------- | -----------
-`id` <br/>*string* | The id of the instance. This is a canonized id from azure which is the form of `/subscriptions/${subscriptionid}/resourceGroups/${resourcegroup}/providers/Microsoft.Compute/virtualMachines/${instanceName}`
-`name` <br/>*string* | The name of the instance
-`machineType`<br/>*string* | The type of machine assigned for this instance
+`id` <br/>*string* | The id of the instance. This is a canonized id from azure which is the form of `/subscriptions/${subscriptionid}/resourceGroups/${resourcegroup}/providers/Microsoft.Compute/virtualMachines/${instanceName}`.
+`name` <br/>*string* | The name of the instance.
+`machineType`<br/>*string* | The type of machine assigned for this instance.
 `numberOfCores`<br/>*int* | The number of cores provisioned for this instance. This is determined by the machine type.
 `memoryInGB`<br/>*int* | The number of memory in GB provisioned for this instance. This is determined by the machine type.
-`imagePublisher`<br/>*string* | The publisher of the instance used to create the instance
-`imageOffer`<br/>*string* | The image offer that was used to create the instance
-`imageSku`<br/>*string* | The image SKU that was used to create the instance
-`imageVersion`<br/>*string* | The image version that was used to create the instance
+`imagePublisher`<br/>*string* | The publisher of the instance used to create the instance.
+`imageOffer`<br/>*string* | The image offer that was used to create the instance.
+`imageSku`<br/>*string* | The image SKU that was used to create the instance.
+`imageVersion`<br/>*string* | The image version that was used to create the instance.
 `osType`<br/>*string* | The OS type of the instance. This can be either Windows or Linux.
-`displayImage`<br/>*string* | Displayable value of the image information
-`region`<br/>*string* | The region in which the instance is located
-`privateIp`<br/>*string* | The private ip address assigned to the instance
-`internalFqdn`<br/>*string* | The internal FQDN assigned to the instance
-`macAddress`<br/>*string* | The MAC address assigned to the instance
-`subnetName`<br/>*string* | The name of the subnet that the instance is part of
-`networkName`<br/>*string* | The name of the network that the instance is part of
-`supportsPremiumIO`<br/>*boolean* | If the instance supports Premium IO. This is fixed by the machine type.
-`supportsUltraIO`<br/>*boolean* | If the instance supports Ultra IO. This is fixed by the machine type.
-`attachableDiskSlots`<br/>*integer* | The number of data disk that can be attached to the instance. This is fixed by the machine type.
-`usedLuns`<br/>*array* | An array of all the LUNs already used for the data disks.
-`publicIp`<br/>*string* | The public ip address assigned to the instance
-`powerState`<br/>*string* | The status of the instance. One of the following values:    PowerState/running, PowerState/deallocating, PowerState/deallocated, PowerState/starting, PowerState/stopped, PowerState/stopping and PowerState/unknown
-`displayPowerState`<br/>*string* | The status of the instance. One of the following values: running, deallocating, deallocated, starting, stopped, stopping and unknown
-`networkInterfaces`<br/>*list* | A list of network interfaces of the instance. Contains fields: `id`, `name`, `primary`
+`displayImage`<br/>*string* | Displayable value of the image information.
+`region`<br/>*string* | The region in which the instance is located.
+`privateIp`<br/>*string* | The private ip address assigned to the instance.
+`internalFqdn`<br/>*string* | The internal FQDN assigned to the instance.
+`macAddress`<br/>*string* | The MAC address assigned to the instance.
+`subnetName`<br/>*string* | The name of the subnet that the instance is part of.
+`networkName`<br/>*string* | The name of the network that the instance is part of.
+`supportsPremiumIO`<br/>*boolean* | If the instance supports Premium disks. This is fixed by the machine type.
+`supportsUltraIO`<br/>*boolean* | If the instance supports Ultra disks. This is fixed by the machine type.
+`attachableDiskSlots`<br/>*integer* | The number of managed disks that can be attached to the instance. This is fixed by the machine type.
+`usedLuns`<br/>*array* | An array of all the LUNs associated with the managed disks attached to this instance.
+`publicIp`<br/>*string* | The public ip address assigned to the instance.
+`powerState`<br/>*string* | The status of the instance. One of the following values:    PowerState/running, PowerState/deallocating, PowerState/deallocated, PowerState/starting, PowerState/stopped, PowerState/stopping and PowerState/unknown.
+`displayPowerState`<br/>*string* | The status of the instance. One of the following values: running, deallocating, deallocated, starting, stopped, stopping and unknown.
+`networkInterfaces`<br/>*list* | A list of network interfaces of the instance. Contains fields: `id`, `name`, `primary`.
 
 <!-------------------- CREATE AN INSTANCE -------------------->
 
@@ -218,14 +218,14 @@ Create a new instance
 
 Required | &nbsp;
 ------- | -----------
-`name` <br/>*string* | The name of the instance. The name cannot exceed 64 characters
-`machineType`<br/>*string* | The type of machine assigned for this instance
-`imagePublisher`<br/>*string* | The image publisher from which the image is selected
-`imageOffer`<br/>*string* | The image offer that was used to create the instance
-`imageSku`<br/>*string* | The image SKU that was used to create the instance
-`imageVersion`<br/>*string* | The image version that was used to create the instance
-`region`<br/>*string* | The region in which the instance is located
-`subnet`<br/>*string* | The subnet id that the instance will be part of
+`name` <br/>*string* | The name of the instance. The name cannot exceed 64 characters.
+`machineType`<br/>*string* | The type of machine assigned for this instance.
+`imagePublisher`<br/>*string* | The image publisher from which the image is selected.
+`imageOffer`<br/>*string* | The image offer that was used to create the instance.
+`imageSku`<br/>*string* | The image SKU that was used to create the instance.
+`imageVersion`<br/>*string* | The image version that was used to create the instance.
+`region`<br/>*string* | The region in which the instance is located.
+`subnet`<br/>*string* | The subnet id that the instance will be part of.
 `username`<br/>*string* | The administrator username which will be created on the instance. It cannot be a reserve user such as admin, root or administrator and must not be more than 20 characters.
 
 Optional | &nbsp;
@@ -289,7 +289,7 @@ The subscription is limiting the number VMs and different machine sizes you can 
 
 Required | &nbsp;
 ------ | -----------
-`machineType`<br/>*string* | The new machine type to assign to the instance
+`machineType`<br/>*string* | The new machine type to assign to the instance.
 
 <!-------------------- RESET PASSWORD -------------------->
 

--- a/source/includes/azure/_subnets.md
+++ b/source/includes/azure/_subnets.md
@@ -19,6 +19,7 @@ curl -X GET \
     {
       "addressPrefix": "10.1.2.0/24",
       "parentNetworkId": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet",
+      "parentNetworkName": ":example-vnet",
       "allocatedIpAddresses": 3,
       "availableAddresses": 248,
       "totalNumberIps": 251,
@@ -45,6 +46,7 @@ Attributes | &nbsp;
 ---------- | -----
 `id`<br/>*string* | The id associated to the subnet. This is a canonized id from azure which is the form of `/subscriptions/:subscriptionid/resourceGroups/:resourcegroup/providers/Microsoft.Network/virtualNetworks/:networkName/subnets/:subnetName`
 `parentNetworkId` <br/>*string* | The id for the parent network. 
+`parentNetworkName` <br/>*string* | The name for the parent network.
 `name`<br/>*string* | The name of the subnet.
 `region`<br/>*string* | The region in which the parent of the subnet is located. 
 `allocatedAddresses`<br/>*int* | The number of allocated addresses in the subnet.
@@ -60,6 +62,7 @@ Additional Attributes: Network filter included | &nbsp;
 `nics.primaryPrivateIp`<br/>*string* | The primary private ip for the nic. 
 `nics.id`<br/>*string* | The id for the nic. 
 `nics.subnetName`<br/>*string* | The name for the subnet to which to the nic belongs. 
+`nics.networkName`<br/>*string* | The name for the network to which to the nic belongs. 
 
 
 <!-------------------- GET A SUBNET -------------------->
@@ -75,29 +78,26 @@ curl -X GET \
 ```
 ```json
 {
-  "data": [
-    {
-      "addressPrefix": "10.1.2.0/24",
-      "parentNetworkId": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet",
-      "allocatedIpAddresses": 3,
-      "availableAddresses": 248,
-      "totalNumberIps": 251,
-      "id": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet",
-      "region": "eastus",
-      "name": "example-subnet",
-      "networkSecurityGroupName": "test-rg",
-      "nics": [
-        {
-          "name": "sample-nic",
-          "subnetName": "example-subnet",
-          "primaryPrivateIp": "10.1.2.4",
-          "id": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/networkInterfaces/virtualNetworks/sample-nic"
-        }
-      ],
-    }
-  ],
-  "metadata": {
-    "recordCount": 1
+  "data": {
+    "addressPrefix": "10.1.2.0/24",
+    "parentNetworkId": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet",
+    "parentNetworkName": ":example-vnet",
+    "allocatedIpAddresses": 3,
+    "availableAddresses": 248,
+    "totalNumberIps": 251,
+    "id": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet",
+    "region": "eastus",
+    "name": "example-subnet",
+    "networkSecurityGroupName": "test-rg",
+    "nics": [
+      {
+        "name": "sample-nic",
+        "subnetName": "example-subnet",
+        "subnetName": ":example-vnet",
+        "primaryPrivateIp": "10.1.2.4",
+        "id": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/networkInterfaces/virtualNetworks/sample-nic"
+      }
+    ]
   }
 }
 ```
@@ -111,6 +111,7 @@ Attributes | &nbsp;
 `addressPrefix`<br/>*string* | The IPv4 CIDR representing the address range for the subnet.
 `id`<br/>*string* | The id associated to the subnet. This is a canonized id from azure which is the form of `/subscriptions/:subscriptionid/resourceGroups/:resourcegroup/providers/Microsoft.Network/virtualNetworks/:networkName/subnets/:subnetName`
 `parentNetworkId` <br/>*string* | The id for the parent network. 
+`parentNetworkName` <br/>*string* | The name for the parent network.
 `name`<br/>*string* | The name of the subnet.
 `region`<br/>*string* | The region in which the parent of the subnet is located. 
 `allocatedAddresses`<br/>*int* | The number of allocated addresses in the subnet.
@@ -123,6 +124,7 @@ Attributes | &nbsp;
 `nics.primaryPrivateIp`<br/>*string* | The primary private ip for the nic. 
 `nics.id`<br/>*string* | The id for the nic. 
 `nics.subnetName`<br/>*string* | The name for the subnet to which to the nic belongs. 
+`nics.networkName`<br/>*string* | The name for the network to which to the nic belongs. 
 
 <!-------------------- CREATE A SUBNET -------------------->
 


### PR DESCRIPTION
…t documented.

Added a small attribute to the network interface and subnet to have the network name as well

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
### Feature [MC-10909](https://cloud-ops.atlassian.net/browse/MC-10909)

#### Code walkthrough : @lamminade 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
The list and detailed view for the instance is not standard with the other list and detailed from the current plugin and others.

#### Solution
Align the list and detailed view to follow similar pattern in the same plugin.

#### Test cases
- Manual API test
- Manual UI test
- Unit tests changes

#### UI changes
**List instance**
![image](https://user-images.githubusercontent.com/56133634/79229868-b85fba00-7e31-11ea-86f2-153aa9e96121.png)

**Detailed view  instance**
![image](https://user-images.githubusercontent.com/56133634/79229904-c6153f80-7e31-11ea-855a-68359de7e7a9.png)

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-azure-plugin/pull/186
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/129
- PR # https://github.com/cloudops/cloudmc-ui/pull/732