### PR TITLE
MC-11131: Change the documentation to match the new api call

### DIFF
--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -285,21 +285,19 @@ curl -X POST \
 
 ```json
 {
-  "username": "johndoe",
   "password": "SomePassw0rdVal!d"
 }
 ```
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=reset_password</code>
 
-For Linux instances, reset the credentials of an existing user or create a new user with sudo privileges and reset the SSH configuration.
-For Windows instances, reset the built-in administrator account and reset the Remote Desktop service configuration.
+For Linux instances, reset the administrator account.
+For Windows instances, reset the administrator account and reset the Remote Desktop service configuration.
 
 
-Required | &nbsp;
+Optional | &nbsp;
 ------ | -----------
-`username`<br/>*string* | The administrator username of the instance or a new username. It cannot be a reserve user such as admin, root or administrator and must not be more than 20 characters.
-`password`<br/>*string* | The password of the account. It must be between between 12 and 72 characters and must be a combination of 3 of the following patterns : Special characters, Uppercase, Lowercase and Numbers.
+`password`<br/>*string* | The password of the administator account. It must be between between 12 and 72 characters and must be a combination of 3 of the following patterns : Special characters, Uppercase, Lowercase and Numbers. If not provided, a new password is generated.
 
 
 <!-------------------- START AN INSTANCE -------------------->


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
### Improvement [MC-11131](https://cloud-ops.atlassian.net/browse/MC-11131)

#### Code walkthrough : @lamminade 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
The password reset API was not working if no information was provided. The user had to provide the username.

#### Solution
Change the view and the api to use the administrator configure account configured at creation and to render a password when not provided. The view does not prompt for information and return the generated password as sensitive information.

#### Test cases
- Manual UI tests
- Unit test
- Manually API tested

#### UI changes
**Change password confirmation**
![image](https://user-images.githubusercontent.com/56133634/79133745-8b9c9b80-7d7a-11ea-95a3-836babc2182b.png)

Event sensitive data
![image](https://user-images.githubusercontent.com/56133634/79133796-9e16d500-7d7a-11ea-889f-c5038b967a40.png)

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-azure-plugin/pull/187
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/130
