### PR TITLE
MC-10744 (3): Format request and response examples

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,17 @@
 ### Fixes [MC-](https://cloud-ops.atlassian.net/browse/MC-)
 
 #### Changes made
+<!-- Changes should match the template provided below -->
 - ...
 
 #### Related PRs
 - []()
 
-<!-- CLOUDMC-API-DOCS TEMPLATE
+<!-- 
+CLOUDMC-API-DOCS TEMPLATE
+- all sentences should have periods
+- requests and responses should use an example like 'my-env' instead of ':environment'
+- use 'js' instead of 'json' when adding comments to json (else they appear in red)
 
 ### Upgrade release
 
@@ -19,15 +24,13 @@ curl -X POST \
 > Request body example(s):
 
 ```js
-// Add request descriptions (use 'js' instead of 'json', else comments appear in red)
+// Format as 'js' instead of 'json' if adding comments (else they appear in red)
 // Change to the latest version of a chart
 {
   "upgradeChart":  "stable/aerospike",
   "upgradeChart":  1 
 }
-```
 
-```js
 // Change to a specific version of a chart
 {
   "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
@@ -44,7 +47,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>
 
-Upgrade a release in a given [environment](#administration-environments)
+Upgrade a release in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------

--- a/source/includes/_getting_started.md
+++ b/source/includes/_getting_started.md
@@ -74,7 +74,7 @@ Verbs | Purpose
   "taskStatus": "PENDING"
 }
 ```
-When an API request is successful, the response body will contain the `data` field with the result of the API call. If you're using the [compute API](#compute-api), the `data` field might be empty since most of the operations are asynchronous. The response will contain the `taskId` and `taskStatus` fields so that you can retrieve the result of the operation you executed through the [task API](#tasks)
+When an API request is successful, the response body will contain the `data` field with the result of the API call. If you're using the [compute API](#compute-api), the `data` field might be empty since most of the operations are asynchronous. The response will contain the `taskId` and `taskStatus` fields so that you can retrieve the result of the operation you executed through the [task API](#tasks).
 
 Attributes | &nbsp;
 --- | ---
@@ -86,7 +86,7 @@ Attributes | &nbsp;
 -->
 
 <aside class="notice">
-If the response contains the "errors" field, the request was <strong>not</strong> successful
+If the response contains the "errors" field, the request was <strong>not</strong> successful.
 </aside>
 
 ### Error response

--- a/source/includes/_swift.md
+++ b/source/includes/_swift.md
@@ -1,3 +1,3 @@
 # SWIFT plugin
 
-The CloudMC SWIFT plugin provides endpoints for carrying out operations on SWIFT containers and objects.  It also enforces CloudMC's environment-centric multi-tenancy model and RBAC over top of SWIFT.
+The CloudMC SWIFT plugin provides endpoints for carrying out operations on SWIFT containers and objects. It also enforces CloudMC's environment-centric multi-tenancy model and RBAC over top of SWIFT.

--- a/source/includes/administration/_environments.md
+++ b/source/includes/administration/_environments.md
@@ -13,9 +13,9 @@ Environments allow you to manage resources of a specific service and to manage y
 # Retrieve visible environments
 curl "https://cloudmc_endpoint/v1/environments" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -71,9 +71,9 @@ Attributes | &nbsp;
 # Retrieve visible environment
 curl "https://cloudmc_endpoint/v1/environment/487a2745-bb8a-44bc-adb1-e3b048f6def2" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -136,9 +136,9 @@ curl -X POST "https://cloudmc_endpoint/v1/environments" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
-
-# Request body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "name": "glados",
@@ -191,9 +191,9 @@ curl -X POST "https://cloudmc_endpoint/v1/environments/f9dea588-d7ab-4f42-b6e6-4
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
-
-# Request body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "name": "skynet-beta",

--- a/source/includes/administration/_environments.md
+++ b/source/includes/administration/_environments.md
@@ -135,9 +135,9 @@ Attributes | &nbsp;
 curl -X POST "https://cloudmc_endpoint/v1/environments" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
-   -d "[request_body]"
+   -d "request_body"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {
@@ -190,9 +190,9 @@ The responses' `data` field contains the updated [environment](#administration-e
 curl -X POST "https://cloudmc_endpoint/v1/environments/f9dea588-d7ab-4f42-b6e6-4b85f273f3db" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
-   -d "[request_body]"
+   -d "request_body"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -76,7 +76,7 @@ Attributes | &nbsp;
 
 `GET /organizations/:id`
 
-Retrieve an organization's details
+Retrieve an organization's details.
 
 ```shell
 # Retrieve an organization
@@ -186,7 +186,7 @@ The responses' `data` field contains the created [organization](#administration-
 ### Update organization
 `PUT /organizations/:id`
 
-Update an organization. It's parent organization cannot be changed. It can be assigned service connections
+Update an organization. It's parent organization cannot be changed. It can be assigned service connections.
 
 ```shell
 # Update an organization

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -13,9 +13,9 @@ Retrieves a list of organizations visible to the caller. In most cases, only the
 # Retrieve visible organizations
 curl "https://cloudmc_endpoint/v1/organizations" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": [
@@ -82,9 +82,9 @@ Retrieve an organization's details
 # Retrieve an organization
 curl "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c0cb5" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": {
@@ -151,9 +151,9 @@ curl -X POST "https://cloudmc_endpoint/v1/organizations" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
-
-# Request body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "entryPoint":"umbrella",
@@ -194,9 +194,9 @@ curl -X PUT "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-a
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
-
-# Request body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "entryPoint":"umbrella",

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -150,9 +150,9 @@ Creates a new organization as a sub-organization of the caller's organization, o
 curl -X POST "https://cloudmc_endpoint/v1/organizations" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
-   -d "[request_body]"
+   -d "request_body"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {
@@ -193,9 +193,9 @@ Update an organization. It's parent organization cannot be changed. It can be as
 curl -X PUT "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c0cb5" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
-   -d "[request_body]"
+   -d "request_body"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/administration/_resource_commitments.md
+++ b/source/includes/administration/_resource_commitments.md
@@ -191,9 +191,9 @@ Attributes | &nbsp;
 curl -X POST "https://cloudmc_endpoint/v1/resource_commitments" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
-   -d "[request_body]"
+   -d "request_body"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {
@@ -262,9 +262,9 @@ The responses' `data` field contains the created [resource-commitment](#administ
 curl -X PUT "https://cloudmc_endpoint/v1/resource_commitments/fbgc7647-71e6-w69b-998a-c02rf58bf2e6" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
-   -d "[request_body]"
+   -d "request_body"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/administration/_resource_commitments.md
+++ b/source/includes/administration/_resource_commitments.md
@@ -12,9 +12,9 @@ Resource commitments allow you to set specific commitment levels on cloud resour
 # Retrieve visible resource commitments
 curl "https://cloudmc_endpoint/v1/resource_commitments" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -104,9 +104,9 @@ Attributes | &nbsp;
 
 curl "https://cloudmc_endpoint/v1/resource_commitments/fbgc7647-71e6-w69b-998a-c02rf58bf2e6" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -192,9 +192,9 @@ curl -X POST "https://cloudmc_endpoint/v1/resource_commitments" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
-
-# Request body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "displayName": "NEW-RESOURCE-COMMITMENT",
@@ -263,9 +263,9 @@ curl -X PUT "https://cloudmc_endpoint/v1/resource_commitments/fbgc7647-71e6-w69b
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request_body]"
-
-# Request body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "id": "ef17768a-c037-4a8a-8f12-f4595dd84ca0",
@@ -337,7 +337,6 @@ The responses' `data` field contains the created [resource-commitment](#administ
 
 curl "https://cloudmc_endpoint/v1/resource_commitments/fbgc7647-71e6-w69b-998a-c02rf58bf2e6" \
    -X DELETE -H "MC-Api-Key: your_api_key"
-
 ```
 
 Delete a specific resource commitment. You will need a [role](#administration-roles) with the `Commitments: Manage` permission to execute this operation.

--- a/source/includes/administration/_roles.md
+++ b/source/includes/administration/_roles.md
@@ -13,11 +13,10 @@ Example: If a user has a role with `env:<entity>:read` and `env:<entity>:create`
 # Retrieve all env-scoped roles applicable to this environment 
 curl "https://cloudmc_endpoint/rest/roles?v=v2&environment_id=4865a023-1dd5-45a3-a23d-e952ceb7a44a&filter_scope=ENV" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
-{
 {
    "data":[
       {

--- a/source/includes/administration/_service_connections.md
+++ b/source/includes/administration/_service_connections.md
@@ -66,15 +66,16 @@ Attributes | &nbsp;
 
 `GET /services/connections/:id/policies/descriptors`
 
+Query Parameters | &nbsp;
+---------- | -----
+`section`<br/>*string* | The name of the policy section to load. Only the policy section matching the section name provided will return all required FormElements and the connection entity.
+
 ```shell
 # Retrieve connection policy descriptors
 curl "https://cloudmc_endpoint/v1/services/connections/03bc22bd-adc4-46b8-988d-afddc24c0cb5/policies/descriptors?section=trials" \
    -H "MC-Api-Key: your_api_key"
 ```
-
-Query Parameters | &nbsp;
----------- | -----
-`section`<br/>*string* | The name of the policy section to load. Only the policy section matching the section name provided will return all required FormElements and the connection entity.
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -141,6 +142,8 @@ curl -X PUT \
    -d "[{"name": "serviceVersion", "value": "1.1"}, {"name": "cacheEnabled", "value": "true"}]" \
    "https://cloudmc_endpoint/v1/services/connections/03bc22bd-adc4-46b8-988d-afddc24c0cb5/policies"
 ```
+> The above command returns JSON structured like this:
+
 
 ```json
 {

--- a/source/includes/administration/_usage.md
+++ b/source/includes/administration/_usage.md
@@ -107,7 +107,7 @@ curl -X GET \
 }
 ```
 
-Retrieves the usage summary records for top level organization and it's sub-organizations for a specific period ensuring that usage is split between two buckets, resource commitment usage and utility usage. The response format will be in the JSON format
+Retrieves the usage summary records for top level organization and it's sub-organizations for a specific period ensuring that usage is split between two buckets, resource commitment usage and utility usage. The response format will be in the JSON format.
 
 ##### Resource Commitment Usage:
 The usage that is counted toward a pre assigned pool of resources defined by the Resource Commitment of the organization on a specified service connection. The resource commitment usage is capped by the resource commitment capacity which is the total amount of resource allocated to the organization.

--- a/source/includes/administration/_usage.md
+++ b/source/includes/administration/_usage.md
@@ -10,9 +10,9 @@
 # Retrieve usage summary in JSON
 curl "https://cloudmc_endpoint/v1/usage_summary/organizations/03bc22bd-adc4-46b8-988d-afddc24c0cb5?start_date=2017-05-01&end_date=2017-05-15&format=json" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -28,12 +28,15 @@ curl "https://cloudmc_endpoint/v1/usage_summary/organizations/03bc22bd-adc4-46b8
   }]
 }
 ```
+
 ```shell
 # Retrieve usage summary in CSV
 curl "https://cloudmc_endpoint/v1/usage_summary/organizations/03bc22bd-adc4-46b8-988d-afddc24c0cb5?start_date=2017-05-01&end_date=2017-05-15&format=csv" \
    -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
 
-# Response body example
+```
 organizationId,serviceConnectionId,startDate,endDate,usageType,secondaryType,serviceConnectionPricingId,utilityCost,utilityUsage
 52fd201e-aa82-4a27-86b3-ea9650a7fb1e,beeba736-0451-49b0-8020-8b93ed5abb35,2017-05-01T00:00:00.000Z,2017-05-01T01:00:00.000Z,1,RAM,e37cc44a-47b6-4a26-81f5-1dbf85433e36,0.660000,5.49999878
 ```
@@ -83,9 +86,9 @@ curl -X GET \
   'https://cloudmc_endpoint/rest/usage_summary/top_level/organizations/52fd201e-aa82-4a27-86b3-ea9650a7fb1e?start_date=2019-03-12&end_date=2019-03-13' \
   -H 'content-type: application/json' \
   -H 'mc-api-key: your_api_key' \
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [

--- a/source/includes/administration/_users.md
+++ b/source/includes/administration/_users.md
@@ -139,9 +139,9 @@ Attributes | &nbsp;
 curl -X POST "https://cloudmc_endpoint/v1/users" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
-   -d "[request-body]"
+   -d "request-body"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {
@@ -191,9 +191,9 @@ The responses' `data` field contains the created [user](#administration-users) w
 curl -X PUT "https://cloudmc_endpoint/v1/users/fdf60a19-980d-4380-acab-914485111305" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
-   -d "[request-body]"
+   -d "request-body"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/administration/_users.md
+++ b/source/includes/administration/_users.md
@@ -13,9 +13,9 @@ A user account allows users to authenticate to an [organization](#administration
 
 curl "https://cloudmc_endpoint/v1/users" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data":[{
@@ -72,9 +72,9 @@ Attributes | &nbsp;
 # Retrieve visible user
 curl "https://cloudmc_endpoint/v1/users/fdf60a19-980d-4380-acab-914485111305" \
    -H "MC-Api-Key: your_api_key"
-
-# Response body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data":{
@@ -140,9 +140,9 @@ curl -X POST "https://cloudmc_endpoint/v1/users" \
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request-body]"
-
-# Request body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "userName": "vader42",
@@ -192,9 +192,9 @@ curl -X PUT "https://cloudmc_endpoint/v1/users/fdf60a19-980d-4380-acab-914485111
    -H "MC-Api-Key: your_api_key" \
    -H "Content-Type: application/json" \
    -d "[request-body]"
-
-# Request body example
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "userName": "spidey1",

--- a/source/includes/azure/_disks.md
+++ b/source/includes/azure/_disks.md
@@ -58,7 +58,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/disks</code>
 
-Retrieve a list of all the disks in a given [environment](#administration-environments)
+Retrieve a list of all the disks in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -99,7 +99,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/disks/:id</code>
 
-Retrieve a specific disk in a given [environment](#administration-environments)
+Retrieve a specific disk in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -153,7 +153,7 @@ curl -X POST \
 
 _(Use the [task API](#tasks) to get the status of the operation)_
 
-Create a disk in an [environment](#administration-environments)
+Create a disk in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -202,7 +202,7 @@ curl -X POST \
 
 _(Use the [task API](#tasks) to get the status of the operation)_
 
-Edit a disk in an [environment](#administration-environments)
+Edit a disk in an [environment](#administration-environments).
 
 Optional | &nbsp;
 ---------- | -----
@@ -277,7 +277,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/disks/:id?operation=attach</code>
 
-Attach a disk to an instance
+Attach a disk to an instance.
 
 Optional | &nbsp;
 ---------- | -----

--- a/source/includes/azure/_disks.md
+++ b/source/includes/azure/_disks.md
@@ -12,9 +12,8 @@ For information regarding azure disks, please see [azure docs](https://docs.micr
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure-conn/test_env/disks"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -75,9 +74,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure-conn/test_env/disks/subscriptions/60a3c9eebe64-55c1-4b1d-969b-60a3c/resourceGroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.Compute/disks/the-sheep_disk1_c0cbe27c49aa928525e93bd2519aac4"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "id": "/subscriptions/6b6a1f27-55c1-4b1d-969b-60a3c9eebe64/resourceGroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.Compute/disks/the-sheep_disk1_e93bd2519aac4c0cbe27c49aa928525e",
@@ -128,9 +127,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body"
    "https://cloudmc_endpoint/v1/services/azure/example/disks"
-
-# Request Example:
 ```
+> Request body example:
+
 ```json
 {
   "name":"ad_root_smean",
@@ -141,9 +140,8 @@ curl -X POST \
   "throughputInMBps": "200"
 }
 ```
-```shell
-# Response Example
-```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "taskId": "802c5ae0-8431-47dc-9abe-7e10a9badddc",
@@ -176,8 +174,9 @@ curl -X POST \
    -d "request_body"
    "https://cloudmc_endpoint/v1/services/azure-conn/test_env/disks/subscriptions/60a3c9eebe64-55c1-4b1d-969b-60a3c/resourceGroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.Compute/disks/the-sheep_disk1_c0cbe27c49aa928525e93bd2519aac4"
 
-# Request Example:
 ```
+> Request body examples:
+
 ```json
 {
   "type":"standardssd_lrs",
@@ -190,9 +189,8 @@ curl -X POST \
   "throughputInMBps": "200"
 }
 ```
-```shell
-# Response Example
-```
+> The above commands return JSON structured like this:
+
 ```json
 {
   "taskId": "802c5ae0-8431-47dc-9abe-7e10a9badddc",
@@ -239,9 +237,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/azure-conn/test_env/disks/subscriptions/60a3c9eebe64-55c1-4b1d-969b-60a3c/resourceGroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.Compute/disks/the-sheep_disk1_c0cbe27c49aa928525e93bd2519aac4?operation=detach"
-
-# Request should look like this
 ```
+
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/disks/:id?operation=detach</code>
 
 Detach an existing disk from a given [instance](#azure-instances).
@@ -255,32 +252,22 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/azure-conn/test_env/disks/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}?operation=attach"
-
-# Request should look like this
 ```
-```shell
-# Request Example:
-```
+> Request body examples:
 
 ```json
 {
   "instance" : "cool-instance",
 }
 ```
-```shell
-# Request Example 2:
-```
-
 ```json
 {
   "instance" : "cool-instance",
   "lun" : 10
 }
 ```
+> The above command returns JSON structured like this:
 
-```shell
-# Response Example
-```
 ```json
 {
   "taskId": "802c5ae0-8431-47dc-9abe-7e10a9badddc",

--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -10,9 +10,8 @@ Deploy and manage your instances.
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/instances"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -96,9 +95,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/instances/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Compute/virtualMachines/example-small-server"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -178,12 +176,11 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/azure/example/instances"
-
-# Request example:
 ```
+> Request body examples:
 
-```json
-Create an instance using ssh key authentication
+```js
+// Create an instance using ssh key authentication
 {
   "name": "new-server",
   "machineType": "Standard_B1ls",
@@ -197,7 +194,7 @@ Create an instance using ssh key authentication
   "sshkey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCguvgDRuUF/wijOJCNmYlQHujCmUHl/i0Ubos4nHy5uCBdn1LGF+PG3TpJqO1LUWqpHaPl4yN7bpsdXyq6a9nxe0C1bQ4FK6P5qm0X320uvqv34jwTPsIbnhw9I317df+xJyXXsL/P5vS4ULPMC5UZjWm4BYe7did4zmXXhA/zmLY6cUg19sZp5r5SUQcf5xHAqO3cQVZwzBhBMwroflZZ59zNpxy+xXPBqC3IdusF2yTDW7bwCQHESUOsd9XhwrzCB+1wETKjLpk0wkWj8G2j1pkKGRpv60QcG85lbZvQAg54v3HYD7fVJCaz9gJJoiyRBnqQ6XVxam5bZgiMKa0J johndoe@machine.local"
 }
 
-Create an instance using password authentication
+// Create an instance using password authentication
 {
   "name": "new-server",
   "machineType": "Standard_B1ls",
@@ -260,9 +257,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/azure/example/instances/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Compute/virtualMachines/example-small-server?operation=resize"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -303,9 +299,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/azure/example/instances/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Compute/virtualMachines/example-small-server?operation=reset_password"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -365,12 +360,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
  "https://cloudmc_endpoint/v1/services/azure-conn/test_env/instances/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/instances/{instanceName}?operation=attach_disk"
-
-# Request should look like this
 ```
-```shell
-# Request Example:
-```
+> Request body example:
 
 ```json
 {
@@ -378,11 +369,8 @@ curl -X POST \
   "diskLun": 10
 }
 ```
+> The above command returns JSON structured like this:
 
-
-```shell
-# Response Example
-```
 ```json
 {
   "taskId": "802c5ae0-8431-47dc-9abe-7e10a9badddc",

--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -56,7 +56,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances</code>
 
-Retrieve a list of all instances in a given [environment](#administration-environments)
+Retrieve a list of all instances in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -136,7 +136,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id</code>
 
-Retrieve an instance in a given [environment](#administration-environments)
+Retrieve an instance in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -211,7 +211,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances</code>
 
-Create a new instance
+Create a new instance.
 
 Required | &nbsp;
 ------- | -----------
@@ -243,7 +243,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id</code>
 
-Delete an existing instance
+Delete an existing instance.
 
 <!-------------------- CHANGE MACHINE TYPE -------------------->
 

--- a/source/includes/azure/_network_security_groups.md
+++ b/source/includes/azure/_network_security_groups.md
@@ -63,7 +63,7 @@ Attributes | &nbsp;
 
 ```shell
 curl -X POST \
-  'http://cloudmc_endpoint/v1/services/azure/co-emcilroy-eastasia/networkSecurityGroups' \
+  'http://cloudmc_endpoint/v1/services/azure/my-azure/networkSecurityGroups' \
   -H 'mc-api-key: your_api_key' \
   -d '{
 	"name": "network-security-group", 
@@ -84,7 +84,7 @@ Required | &nbsp;
 
 ```shell 
 curl -X DELETE \
-  'http://cloudmc_endpoint/v1/services/azure/co-emcilroy-eastasia/networkSecurityGroups/subscriptions/6b6a1f27-55c1-4b1d-969b-60a3c9eebe64/resourceGroups/azure-system-co-cloudmc-eastus/providers/Microsoft.Network/networkSecurityGroups/test' \
+  'http://cloudmc_endpoint/v1/services/azure/my-azure/networkSecurityGroups/subscriptions/6b6a1f27-55c1-4b1d-969b-60a3c9eebe64/resourceGroups/azure-system-co-cloudmc-eastus/providers/Microsoft.Network/networkSecurityGroups/test' \
   -H 'mc-api-key: your_api_key'
   ```
 

--- a/source/includes/azure/_network_security_groups.md
+++ b/source/includes/azure/_network_security_groups.md
@@ -10,9 +10,9 @@ A network security group is a group of security rules that allow or deny inbound
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/networksecuritygroups"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [

--- a/source/includes/azure/_network_security_groups.md
+++ b/source/includes/azure/_network_security_groups.md
@@ -42,7 +42,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networksecuritygroups</code>
 
-Retrieve a list of all network security groups in an [environment](#administration-environments)
+Retrieve a list of all network security groups in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -90,4 +90,4 @@ curl -X DELETE \
 
   <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkSecurityGroups/:id</code>
 
-  Delete an existing network security group
+  Delete an existing network security group.

--- a/source/includes/azure/_networks.md
+++ b/source/includes/azure/_networks.md
@@ -10,9 +10,9 @@ A virtual network is an isolated network where you can place groups of resources
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/networks"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -59,9 +59,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body"
    "https://cloudmc_endpoint/v1/services/azure/example/networks"
-
-# Request Example:
 ```
+> Request body example:
+
 ```json
 {
 	"name": "simpleNetwork",

--- a/source/includes/azure/_networks.md
+++ b/source/includes/azure/_networks.md
@@ -34,7 +34,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks</code>
 
-Retrieve a list of all virtual networks in an [environment](#administration-environments)
+Retrieve a list of all virtual networks in an [environment](#administration-environments).
 
 Optional query parameters | &nbsp;
 ---------- | -----
@@ -74,7 +74,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks</code>
 
-Create a virtual network in an [environment](#administration-environments)
+Create a virtual network in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----

--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -10,9 +10,8 @@ Deploy and manage your public ip addresses.
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -63,9 +62,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/publicIPAddresses/some-public-ip"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -112,9 +110,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body"
    "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses"
-
-# Request Example:
 ```
+> Request body example:
 
 ```json
 {
@@ -152,9 +149,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body"
    "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses?operation=associate"
-
-# Request Example:
 ```
+> Request body example:
 
 ```json
 {
@@ -194,9 +190,8 @@ curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body"
    "https://cloudmc_endpoint/v1/services/azure/example/publicipaddresses//subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/publicIPAddresses/some-public-ip"
-
-# Request Example:
 ```
+> Request body example:
 
 ```json
 {

--- a/source/includes/azure/_public_ip_addresses.md
+++ b/source/includes/azure/_public_ip_addresses.md
@@ -85,7 +85,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses/:id</code>
 
-Retrieve a public IP address in a given [environment](#administration-environments)
+Retrieve a public IP address in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -126,7 +126,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses</code>
 
-Create a public IP address in a given [environment](#administration-environments)
+Create a public IP address in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
@@ -160,7 +160,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses?operation=associate</code>
 
-Associate a public IP address in a given [environment](#administration-environments) to a network interface
+Associate a public IP address in a given [environment](#administration-environments) to a network interface.
 
 Required | &nbsp;
 ------- | -----------
@@ -203,7 +203,7 @@ curl -X PUT \
 
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/publicipaddresses/:id</code>
 
-Update a public IP address in a given [environment](#administration-environments)
+Update a public IP address in a given [environment](#administration-environments).
 
 Attribute | &nbsp;
 ------- | -----------

--- a/source/includes/azure/_regions.md
+++ b/source/includes/azure/_regions.md
@@ -8,9 +8,9 @@ A region is location where Azure resources are physically deployed. They can be 
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/regions"
-
-# Example response: 
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -41,9 +41,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/regions/useast"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {

--- a/source/includes/azure/_security_rules.md
+++ b/source/includes/azure/_security_rules.md
@@ -10,9 +10,9 @@ A security rule in Azure is a filter which controls both inbound and outbound tr
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/securityrules"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -76,9 +76,9 @@ Attributes | &nbsp;
 curl -X GET \
   -H 'mc-api-key: your_api_key' \
   "https://cloudmc_endpoint/v1/services/azure/example/securityrules/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkSecurityGroups/:example-securityGroup/securityRules/example-securityRule"
-  
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -99,7 +99,7 @@ curl -X GET \
 }
 ```
 
-  <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/securityrules/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/securityrules/:id</code>
 
 Retrieve a specific security rule by rule id.
 
@@ -126,9 +126,9 @@ curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body"
     "https://cloudmc_endpoint/v1/services/azure/example/securityrules"
-  
-# Request Example:
 ```
+> Request body example:
+
 ```json
 {
   "securityGroupId": "/subscriptions/subscription/resourceGroups/example-system-azure-example/providers/Microsoft.Network/networksecuritygroups/sample-network-security-group",
@@ -181,9 +181,9 @@ Optional | &nbsp;
 curl -X DELETE \
   -H 'mc-api-key: your_api_key' \
   "https://cloudmc_endpoint/v1/services/azure/example/securityrules/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/sample-network-security-group/securityRules/securityRule1"
- ```
+```
 
-  <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/securityrules/:id</code>
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/securityrules/:id</code>
 
 Delete an existing security rule.
 
@@ -196,31 +196,30 @@ curl -X POST \
   -H 'mc-api-key: your_api_key' \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/azure/example/securityrules/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkSecurityGroups/:example-securityGroup/securityRules/example-securityRule?operation=edit"
-  
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
-      "access": "Allow",
-      "priority": 180,
-      "protocol": "Tcp",
-      "sourcePortRanges": [],
-      "sources": [
-        "10.0.0.0/24"
-      ],
-      "destinationPortRanges": [
-        "8080"
-      ],
-      "destinations": [
-        "192.168.99.0"
-      ]
+  "access": "Allow",
+  "priority": 180,
+  "protocol": "Tcp",
+  "sourcePortRanges": [],
+  "sources": [
+    "10.0.0.0/24"
+  ],
+  "destinationPortRanges": [
+    "8080"
+  ],
+  "destinations": [
+    "192.168.99.0"
+  ]
 }
 ```
 
-  <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/securityrules/:id?operation=edit</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/securityrules/:id?operation=edit</code>
 
-  Update a specific security rule.
+Update a specific security rule.
 
 Attributes | &nbsp;
 ---------- | -----

--- a/source/includes/azure/_security_rules.md
+++ b/source/includes/azure/_security_rules.md
@@ -75,14 +75,14 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
   -H 'mc-api-key: your_api_key' \
-  "https://cloudmc_endpoint/v1/services/azure/example/securityrules/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkSecurityGroups/:example-securityGroup/securityRules/example-securityRule"
+  "https://cloudmc_endpoint/v1/services/azure/example/securityrules/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkSecurityGroups/mySecurityGroup/securityRules/mySeccurityRule"
 ```
 > The above command returns JSON structured like this:
 
 ```json
 {
   "data": {
-    "id": "/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkSecurityGroups/sample-network-security-group/defaultSecurityRules/SampleRuleInBound",
+    "id": "/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkSecurityGroups/mySecurityGroup/defaultSecurityRules/SampleRuleInBound",
     "name": "SampleRuleInBound",
     "direction": "Inbound",
     "access": "Allow",
@@ -195,7 +195,7 @@ Delete an existing security rule.
 curl -X POST \
   -H 'mc-api-key: your_api_key' \
   -d "request_body" \
-  "https://cloudmc_endpoint/v1/services/azure/example/securityrules/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkSecurityGroups/:example-securityGroup/securityRules/example-securityRule?operation=edit"
+  "https://cloudmc_endpoint/v1/services/azure/example/securityrules/subscriptions/subscriptionId/resourceGroups/cmc-example/providers/Microsoft.Network/networkSecurityGroups/mySecurityGroup/securityRules/mySecurityRule?operation=edit"
 ```
 > Request body example:
 

--- a/source/includes/azure/_subnets.md
+++ b/source/includes/azure/_subnets.md
@@ -10,9 +10,9 @@ A subnet is a child of a virtual network. It is a subset of a network in which I
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/subnets"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -73,9 +73,9 @@ Additional Attributes: Network filter included | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -135,9 +135,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/azure/example/subnets"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -171,14 +170,15 @@ curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
   "addressPrefix":"This is my updated template description"
 }
 ```
+
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnets/:subnet_id</code>
 
 Update a subnet. 
@@ -196,7 +196,6 @@ Optional | &nbsp;
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet"
-
 ```
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnets/:subnet_id</code>

--- a/source/includes/azure/_subnets.md
+++ b/source/includes/azure/_subnets.md
@@ -18,12 +18,12 @@ curl -X GET \
   "data": [
     {
       "addressPrefix": "10.1.2.0/24",
-      "parentNetworkId": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet",
-      "parentNetworkName": ":example-vnet",
+      "parentNetworkId": "/subscriptions/:subscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/example-vnet",
+      "parentNetworkName": "example-vnet",
       "allocatedIpAddresses": 3,
       "availableAddresses": 248,
       "totalNumberIps": 251,
-      "id": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet",
+      "id": "/subscriptions/:subscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/example-vnet/subnets/example-subnet",
       "region": "eastus",
       "name": "example-subnet"
     }
@@ -72,7 +72,7 @@ Additional Attributes: Network filter included | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet"
+   "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/example-vnet/subnets/example-subnet"
 ```
 > The above command returns JSON structured like this:
 
@@ -80,12 +80,12 @@ curl -X GET \
 {
   "data": {
     "addressPrefix": "10.1.2.0/24",
-    "parentNetworkId": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet",
-    "parentNetworkName": ":example-vnet",
+    "parentNetworkId": "/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/example-vnet",
+    "parentNetworkName": "example-vnet",
     "allocatedIpAddresses": 3,
     "availableAddresses": 248,
     "totalNumberIps": 251,
-    "id": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet",
+    "id": "/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/example-vnet/subnets/example-subnet",
     "region": "eastus",
     "name": "example-subnet",
     "networkSecurityGroupName": "test-rg",
@@ -93,9 +93,9 @@ curl -X GET \
       {
         "name": "sample-nic",
         "subnetName": "example-subnet",
-        "subnetName": ":example-vnet",
+        "subnetName": "example-vnet",
         "primaryPrivateIp": "10.1.2.4",
-        "id": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/networkInterfaces/virtualNetworks/sample-nic"
+        "id": "/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/networkInterfaces/virtualNetworks/sample-nic"
       }
     ]
   }
@@ -142,7 +142,7 @@ curl -X POST \
 {
   "name": "default",
   "addressPrefix": "10.0.1.0/24",
-  "parentNetworkId": "/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet"
+  "parentNetworkId": "/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/example-vnet"
 }
 ```
 
@@ -169,7 +169,7 @@ curl -X PUT \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
-   "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet"
+   "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/example-vnet/subnets/example-subnet"
 ```
 > Request body example:
 
@@ -195,7 +195,7 @@ Optional | &nbsp;
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/:subscription/resourceGroups/:resourceGroup/providers/Microsoft.Network/virtualNetworks/:example-vnet/subnets/example-subnet"
+   "https://cloudmc_endpoint/v1/services/azure/example/subnets/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/example-vnet/subnets/example-subnet"
 ```
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnets/:subnet_id</code>

--- a/source/includes/cloudstack/_affinity_groups.md
+++ b/source/includes/cloudstack/_affinity_groups.md
@@ -8,11 +8,11 @@ Affinity groups are a way of influencing on which host an [instance](#cloudstack
 
 ```shell
 curl -X GET \
-   -H "MC-Api-Key: your_api_key" \
-"https://cloudmc_endpoint/v1/services/compute-on/test_area/affinitygroups"
-
-# Example:
+  -H "MC-Api-Key: your_api_key" \
+  "https://cloudmc_endpoint/v1/services/compute-on/test_area/affinitygroups"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -49,9 +49,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/affinitygroups/d4fd794f-66e1-4906-a720-d0afb04bd517"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -88,9 +88,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/affinitygroups"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "name": "gnr",
@@ -125,9 +125,9 @@ curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/affinitygroups/d4fd794f-66e1-4906-a720-d0afb04bd517"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "instanceIds": [

--- a/source/includes/cloudstack/_affinity_groups.md
+++ b/source/includes/cloudstack/_affinity_groups.md
@@ -31,7 +31,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/affinitygroups</code>
 
-Retrieve a list of all affinity groups in an [environment](#administration-environments)
+Retrieve a list of all affinity groups in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----

--- a/source/includes/cloudstack/_bare_metal_instances.md
+++ b/source/includes/cloudstack/_bare_metal_instances.md
@@ -20,9 +20,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances"
-
-# Request should look like this
 ```
+> Request body example:
 
 ```json
 {
@@ -61,9 +60,8 @@ curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29?operation=releaseBareMetal"
-
-# Request should look like this
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {

--- a/source/includes/cloudstack/_bare_metal_instances.md
+++ b/source/includes/cloudstack/_bare_metal_instances.md
@@ -59,9 +59,10 @@ Optional | &nbsp;
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29?operation=releaseBareMetal"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/cloudstack/_compute_offerings.md
+++ b/source/includes/cloudstack/_compute_offerings.md
@@ -8,9 +8,8 @@ Compute offerings determine the number of vCPUs and the size of the memory alloc
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/computeofferings"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -69,9 +68,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/computeofferings/40a2e5f7-22e6-4d1e-b03b-4a4b7c9cbc6f"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {

--- a/source/includes/cloudstack/_disk_offerings.md
+++ b/source/includes/cloudstack/_disk_offerings.md
@@ -8,9 +8,9 @@ Disk offerings determine the size and the performance (IOPS) of [data volumes](#
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/diskofferings"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -53,9 +53,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/diskofferings/18bbab50-8d85-4b34-8361-0dc223ffd7e5"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {

--- a/source/includes/cloudstack/_egress_rules.md
+++ b/source/includes/cloudstack/_egress_rules.md
@@ -6,9 +6,9 @@ Manage outbound traffic rules for isolated networks
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/egressrules"
-
-# Response example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -75,9 +75,9 @@ Query Parameters | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/egressrules/f1863d10-e7ec-4f17-8cdd-0e4046643b0b"
-
-# Response example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {

--- a/source/includes/cloudstack/_ingress_rules.md
+++ b/source/includes/cloudstack/_ingress_rules.md
@@ -6,9 +6,9 @@ Manage inbound traffic rules for isolated networks.
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/ingressrules"
-
-# Response example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -79,9 +79,9 @@ Query Parameters | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/ingressrules/f1863d10-e7ec-4f17-8cdd-0e4046643b0b"
-
-# Response example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {

--- a/source/includes/cloudstack/_instances.md
+++ b/source/includes/cloudstack/_instances.md
@@ -50,7 +50,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances</code>
 
-Retrieve a list of all instances in a given [environment](#administration-environments)
+Retrieve a list of all instances in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/cloudstack/_instances.md
+++ b/source/includes/cloudstack/_instances.md
@@ -12,9 +12,8 @@ For information regarding bare metal instances, please see [bare metal instances
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -85,10 +84,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29"
-
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -172,15 +169,13 @@ Attributes | &nbsp;
 ```shell
 
 # Here is the absolute minimum information required to create a new instance:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances"
-
-# Request should look like this
 ```
+> Request body example:
 
 ```json
 {
@@ -236,15 +231,13 @@ Optional | &nbsp;
 ```shell
 
 # Here is the absolute minimum information required to create a new instance:
-
 curl -X PUT \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -272,10 +265,9 @@ Optional | &nbsp;
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint:443/v1/services/compute-on/test_area/instances/5bf7352c-eed2-43dc-83f1-89917fb893ca" \
-
-# Request example:
+   "https://cloudmc_endpoint:443/v1/services/compute-on/test_area/instances/5bf7352c-eed2-43dc-83f1-89917fb893ca" 
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -308,13 +300,10 @@ Optional | &nbsp;
 #### Start an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29?operation=start"
-
 ```
 
  <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=start</code>
@@ -326,15 +315,12 @@ Start an existing instance. The instance must be in the *Stopped* state for this
 #### Stop an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29?operation=stop"
-
-# Request example:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -355,8 +341,6 @@ Optional | &nbsp;
 #### Reboot an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
@@ -372,8 +356,6 @@ Reboot an existing instance. The instance must be in the *Running* or *Stopped* 
 #### Purge an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
@@ -389,8 +371,6 @@ Purges an existing instance (i.e. completely remove it from the environment). Th
 #### Recover an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
@@ -406,8 +386,6 @@ Recover an existing instance that was previously destroyed. The instance must be
 #### Change the compute offering of an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
@@ -436,8 +414,6 @@ Required | (if custom compute offering)
 #### Reset the password of an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
@@ -453,8 +429,6 @@ Reset the password of the default user of an existing instance. The new password
 #### Change network of an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
@@ -474,15 +448,12 @@ Required | &nbsp;
 #### Associate an SSH key to an instance
 
 ```shell
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29?operation=associateSSHKey"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -506,9 +477,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/testing/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29?operation=attachIso"
-
-# Request should look like this
 ```
+> Request body example:
 
 ```json
 {

--- a/source/includes/cloudstack/_instances.md
+++ b/source/includes/cloudstack/_instances.md
@@ -265,9 +265,10 @@ Optional | &nbsp;
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint:443/v1/services/compute-on/test_area/instances/5bf7352c-eed2-43dc-83f1-89917fb893ca" 
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {
@@ -318,9 +319,10 @@ Start an existing instance. The instance must be in the *Stopped* state for this
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/instances/5951c2b8-e901-4c01-8ae0-cb8d7c508d29?operation=stop"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/cloudstack/_isos.md
+++ b/source/includes/cloudstack/_isos.md
@@ -37,7 +37,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/isos</code>
 
-Retrieve a list of all ISOs of an [environment](#administration-environments)
+Retrieve a list of all ISOs of an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -88,7 +88,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/isos/:id</code>
 
-Retrieve information about a public or private ISO of an [environment](#administration-environments)
+Retrieve information about a public or private ISO of an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -128,7 +128,7 @@ curl -X POST \
 ```
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/isos</code>
 
-Import an ISO
+Import an ISO.
 
 Required                   | &nbsp;
 ---------------------------|-------
@@ -196,4 +196,4 @@ curl -X DELETE \
 ```
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/isos/:id</code>
 
-Delete an ISO
+Delete an ISO.

--- a/source/includes/cloudstack/_isos.md
+++ b/source/includes/cloudstack/_isos.md
@@ -7,9 +7,9 @@ An ISO is a disk image that is a copy of a file system. A bootable ISO can be us
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/isos"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -61,9 +61,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
 "https://cloudmc_endpoint/v1/services/compute-on/test_area/isos/162cdfcb-45e5-4aa6-81c4-124c94621bdb"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -115,9 +115,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/isos"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "name": "windows",
@@ -151,9 +151,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/testing/isos/e922e5fc-8fee-4688-ad93-c9ef5d7eb685?operation=attach"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "instanceId": "c043e651-8b3f-4941-b47f-5ecb77f3423b"

--- a/source/includes/cloudstack/_load_balancer_rules.md
+++ b/source/includes/cloudstack/_load_balancer_rules.md
@@ -9,6 +9,8 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/loadbalancerrules?public_ip_id=eb763d03-9935-4cd4-8a42-99134e242ccb"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -74,6 +76,8 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/loadbalancerrules/f8ed7f44-449c-4510-848c-dc18e6665db1"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -129,8 +133,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/loadbalancerrules"
-# Request example:
 ```
+> Request body example:
+
 ```json
 {
    "name": "test",
@@ -207,8 +212,9 @@ curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/loadbalancerrules/3247167a-e7e7-11e3-9187-06669c0000ad"
-   # Request example:
 ```
+> Request body example:
+
 ```json
 {
    "name": "test",
@@ -233,8 +239,9 @@ curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/loadbalancerrules/3247167a-e7e7-11e3-9187-06669c0000ad"
-   # Request example:
 ```
+> Request body example:
+
 ```json
 {
    "instanceIds": [
@@ -258,8 +265,9 @@ curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/loadbalancerrules/3247167a-e7e7-11e3-9187-06669c0000ad"
-   # Request example:
 ```
+> Request body example:
+
 ```json
 {
    "stickinessMethod": "LbCookie",

--- a/source/includes/cloudstack/_network_acls.md
+++ b/source/includes/cloudstack/_network_acls.md
@@ -11,6 +11,8 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networkacls?vpc_id=eb763d03-9935-4cd4-8a42-99134e242ccb"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -59,6 +61,8 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networkacls/736d0c2e-d6b5-43fc-bcf0-732fce9a509e"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -118,6 +122,8 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networkaclrules?network_acl_id=3246de94-e7e7-11e3-9187-06669c0000ad"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -176,6 +182,8 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networkaclrules/3247167a-e7e7-11e3-9187-06669c0000ad"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {

--- a/source/includes/cloudstack/_network_offerings.md
+++ b/source/includes/cloudstack/_network_offerings.md
@@ -8,9 +8,9 @@ Network offerings determine which services are available to each provisioned [ne
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networkofferings"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -86,9 +86,9 @@ Attributes                     | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networkofferings/89724d35-b69c-418c-be81-7d83fcfc9da9"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {

--- a/source/includes/cloudstack/_networks.md
+++ b/source/includes/cloudstack/_networks.md
@@ -42,7 +42,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks</code>
 
-Retrieve a list of all networks of an [environment](#administration-environments)
+Retrieve a list of all networks of an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -155,7 +155,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks</code>
 
-Create a network in an [environment](#administration-environments)
+Create a network in an [environment](#administration-environments).
 
 If the network offering is a VPC subnet offering (indicated by the `vpcOnly` flag on the offering), the vpcId and networkAclId are required fields.
 
@@ -202,7 +202,7 @@ curl -X PUT \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks/:id</code>
 
-Update an existing network in an [environment](#administration-environments)
+Update an existing network in an [environment](#administration-environments).
 
 Required | &nbsp;
 ------ | -----------

--- a/source/includes/cloudstack/_networks.md
+++ b/source/includes/cloudstack/_networks.md
@@ -11,9 +11,9 @@ A network is an isolated network with its own VLANs and CIDR list, where you can
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networks"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -78,9 +78,9 @@ Query Parameters | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networks/ad5bcae8-ee8b-4ee8-a7a4-381c25444b8e"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -135,17 +135,14 @@ Attributes | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networks"
-
-# Request example:
 ```
+> Request body example:
+
 ```json
 {
   "name": "my_network",
@@ -184,22 +181,18 @@ For isolated networks  | &nbsp;
 
 <!-------------------- UPDATE A NETWORK -------------------->
 
-
 #### Update a network
 
 
 ```shell
-
-# Example:
-
 curl -X PUT \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networks/9572d2ea-a60d-478a-a75e-8ed31f2641f1"
-
-# Request example:
 ```
+> Request body example:
+
 ```json
 {
   "name": "my_updated_network",
@@ -224,9 +217,6 @@ Required | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networks/9572d2ea-a60d-478a-a75e-8ed31f2641f1"
@@ -244,17 +234,14 @@ Delete an existing network in an [environment](#administration-environments) To 
 
 
 ```shell
-
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/networks/9572d2ea-a60d-478a-a75e-8ed31f2641f1?operation=replace"
-
-# Request example:
 ```
+> Request body example:
+
 ```json
 {
   "name": "my_updated_network",

--- a/source/includes/cloudstack/_nics.md
+++ b/source/includes/cloudstack/_nics.md
@@ -136,7 +136,7 @@ curl -X POST \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/nics"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/cloudstack/_nics.md
+++ b/source/includes/cloudstack/_nics.md
@@ -11,9 +11,9 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/nics"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -76,9 +76,9 @@ Query Parameters | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/nics/fff1f45a-8350-4c87-be43-947b96d01ebd"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -130,17 +130,14 @@ Attributes | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/nics"
-
-# Request example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "networkId": "d67e986d-fe04-4827-836e-1697ede8ed30",
@@ -166,9 +163,6 @@ Required | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/nics/63ef1efe-225f-4e05-bc79-b3e457a041e2"
@@ -186,9 +180,6 @@ Delete an existing NIC. The NIC you're trying to delete must not be the default 
 
 
 ```shell
-
-# Example:
-
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/nics/63ef1efe-225f-4e05-bc79-b3e457a041e2?operation=setDefault"

--- a/source/includes/cloudstack/_port_forwarding_rules.md
+++ b/source/includes/cloudstack/_port_forwarding_rules.md
@@ -10,9 +10,9 @@ Port forwarding allows traffic from external hosts to services offered by applic
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/portforwardingrules"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -70,9 +70,9 @@ Query Parameters | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/portforwardingrules/ad5bcae8-ee8b-4ee8-a7a4-381c25444b8e"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -123,17 +123,14 @@ Attributes | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/portforwardingrules"
-
-# Request example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "ipAddressId": "4daf6ce5-a8b1-47d2-96b3-8edda63d891c",
@@ -172,9 +169,6 @@ Optional | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/portforwardingrules/7d22b390-cbb3-4df6-96c6-52901ccb63c0"

--- a/source/includes/cloudstack/_port_forwarding_rules.md
+++ b/source/includes/cloudstack/_port_forwarding_rules.md
@@ -129,7 +129,7 @@ curl -X POST \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/portforwardingrules"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/cloudstack/_public_ips.md
+++ b/source/includes/cloudstack/_public_ips.md
@@ -6,9 +6,9 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/publicipaddresses"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": [
@@ -79,9 +79,9 @@ Query Parameters | &nbsp;
 ```shell
 curl -X GET -H "MC-Api-Key: your_api_key"
 "https://cloudmc_endpoint/v1/services/compute-on/test_area/publicipaddresses/10001e7d-b4ef-489b-836e-0619a383bc8d"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": {
@@ -125,9 +125,9 @@ curl -X POST \
    -H "Content-Type: application/json" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/publicipaddresses"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "vpcId": "0687f5ce-89f9-47c8-9f58-c522455d56eb"
@@ -163,9 +163,9 @@ curl -X POST \
    -H "Content-Type: application/json" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/publicipaddresses/a723b2b1-e343-4ea1-afe0-bf345a99a92b?operation=enableStaticNat"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "privateIpId": "5e30609d-7098-4d93-8317-3ecfe316ed00"

--- a/source/includes/cloudstack/_remote_access_vpns.md
+++ b/source/includes/cloudstack/_remote_access_vpns.md
@@ -6,9 +6,9 @@ Remote access VPNs allow users to connect to [VPCs](#cloudstack-vpcs) through se
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/remoteaccessvpns"
-
-# Response example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -53,9 +53,9 @@ Query Parameters | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/remoteaccessvpns/10001e7d-b4ef-489b-836e-0619a383bc8d"
-
-# Response example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {

--- a/source/includes/cloudstack/_s2s_vpns.md
+++ b/source/includes/cloudstack/_s2s_vpns.md
@@ -44,7 +44,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sitetositevpns</code>
 
-Retrieve a list of all site-to-site VPNs in an [environment](#administration-environments)
+Retrieve a list of all site-to-site VPNs in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -164,7 +164,7 @@ curl -X POST \
 ```
  <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sitetositevpns</code>
 
-Create a site-to-site VPN
+Create a site-to-site VPN.
 
 Required | &nbsp;
 ------ | -----------
@@ -222,7 +222,7 @@ curl -X PUT \
 ```
  <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sitetositevpns/:id</code>
 
-Update a site-to-site VPN
+Update a site-to-site VPN.
 
 Optional | &nbsp;
 ------ | -----------

--- a/source/includes/cloudstack/_s2s_vpns.md
+++ b/source/includes/cloudstack/_s2s_vpns.md
@@ -10,9 +10,9 @@ A site-to-site VPN allows multiple sites to establish a secure connection over t
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/sitetositevpns"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -78,9 +78,9 @@ Query Parameters | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/sitetositevpns/d49b2922-0581-4587-94df-6fe719327d0f"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -134,17 +134,15 @@ Attributes | &nbsp;
 #### Create a site-to-site VPN
 
 ```shell
-
 # Here is the absolute minimum information required to create a new site-to-site VPN:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/sitetositevpns"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
       "name": "stargate",
@@ -195,17 +193,15 @@ Optional | &nbsp;
 #### Update a site-to-site VPN
 
 ```shell
-
 # Here is the absolute minimum information required to update a site-to-site VPN:
-
 curl -X PUT \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/sitetositevpns/d49b2922-0581-4587-94df-6fe719327d0f"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
       "name": "stargate",
@@ -252,9 +248,6 @@ Optional | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/sitetositevpns/d49b2922-0581-4587-94df-6fe719327d0f"
@@ -270,12 +263,10 @@ Delete an existing site-to-site VPN.
 #### Reset the connection of a site-to-site VPN
 
 ```shell
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/sitetositevpns/ca86b14f-20db-463d-b58a-9d3fa5959af2?operation=reset"
-
 ```
  <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sitetositevpns/:id?operation=reset</code>
 

--- a/source/includes/cloudstack/_snapshots.md
+++ b/source/includes/cloudstack/_snapshots.md
@@ -34,7 +34,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/snapshots</code>
 
-Retrieve a list of all snapshots in an [environment](#administration-environments)
+Retrieve a list of all snapshots in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----

--- a/source/includes/cloudstack/_snapshots.md
+++ b/source/includes/cloudstack/_snapshots.md
@@ -10,9 +10,9 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/snapshots"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -58,9 +58,9 @@ Query Parameters | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/snapshots/1bd672f4-b274-4371-a792-b0a6c6778cc7"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -101,9 +101,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/testing/snapshots?operation=create"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
   "volumeId": "4fe54594-a788-442c-b7a8-0237f7a4f70d",

--- a/source/includes/cloudstack/_ssh_keys.md
+++ b/source/includes/cloudstack/_ssh_keys.md
@@ -9,9 +9,9 @@ SSH keys can be assigned to default users of instances by using the [associate S
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/sshkeys"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -43,9 +43,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/sshkeys/mellon"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {

--- a/source/includes/cloudstack/_ssh_keys.md
+++ b/source/includes/cloudstack/_ssh_keys.md
@@ -26,7 +26,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys</code>
 
-Retrieve a list of all SSH keys in an [environment](#administration-environments)
+Retrieve a list of all SSH keys in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -57,7 +57,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys/:name</code>
 
-Retrieve information about an SSH key of an [environment](#administration-environments)
+Retrieve information about an SSH key of an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----

--- a/source/includes/cloudstack/_templates.md
+++ b/source/includes/cloudstack/_templates.md
@@ -7,9 +7,9 @@ A template is a virtual disk image that can be used on the creation of an [insta
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/templates"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -77,9 +77,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
 "https://cloudmc_endpoint/v1/services/compute-on/test_area/templates/162cdfcb-45e5-4aa6-81c4-124c94621bdb"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -146,9 +146,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/templates"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
   "name": "debian",
@@ -199,9 +199,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/templates/162cdfcb-45e5-4aa6-81c4-124c94621bdb?operation=update"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
   "description":"This is my updated template description"

--- a/source/includes/cloudstack/_templates.md
+++ b/source/includes/cloudstack/_templates.md
@@ -112,7 +112,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/templates/:id</code>
 
-Retrieve information about a public or private template of an [environment](#administration-environments)
+Retrieve information about a public or private template of an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -165,7 +165,7 @@ curl -X POST \
 ```
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/templates</code>
 
-Import a template
+Import a template.
 
 Required | &nbsp;
 -------- | ------
@@ -209,7 +209,7 @@ curl -X POST \
 ```
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/templates/:id/operation=update</code>
 
-Update a template
+Update a template.
 
 Required | &nbsp;
 -------- | ------
@@ -237,4 +237,4 @@ curl -X DELETE \
 ```
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/templates/:id</code>
 
-Delete a private template
+Delete a private template.

--- a/source/includes/cloudstack/_volumes.md
+++ b/source/includes/cloudstack/_volumes.md
@@ -10,9 +10,9 @@ A volume is a virtual disk that provide storage for your instances. An OS volume
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/volumes"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -67,9 +67,9 @@ Query Parameters | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/volumes/1bd672f4-b274-4371-a792-b0a6c6778cc7"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -118,9 +118,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/testing/volumes"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "name": "my_volume",
@@ -146,9 +146,6 @@ instanceId<br/>*UUID* | The id of the [instance](#cloudstack-instances) to which
 #### Delete a volume
 
 ```shell
-
-# Example:
-
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/volumes/e922e5fc-8fee-4688-ad93-c9ef5d7eb685"
@@ -170,9 +167,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/testing/volumes/e922e5fc-8fee-4688-ad93-c9ef5d7eb685?operation=attachToInstance"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "instanceId": "c043e651-8b3f-4941-b47f-5ecb77f3423b"
@@ -217,9 +214,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/testing/volumes/4fe54594-a788-442c-b7a8-0237f7a4f70d?operation=createSnapshotFromVolume"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "snapshot": {
@@ -237,4 +234,3 @@ Optional | &nbsp;
 ------ | -----------
 `name`<br/>*string* | A ***unique name*** to be given to the newly created **snapshot**. If this parameter is not provided then by default the concatenation of the *instance name*, *volume name* and the *current timestamp* is used. <br/><br/>*Eg:*<br/>&nbsp;&nbsp;&nbsp;&nbsp;*[instance.name]\_[volume.name]\_[timestamp]*<br/>&nbsp;&nbsp;&nbsp;&nbsp;***i-root-6E7_RapidVol_20190117153537***
 `rapid`<br/>*boolean* | Indicates the ***location*** as to where the snapshot is supposed to be made. <br/><br/>Setting this to **true** will ensure that the snapshot is created in the same primary storage as where the volume is. If **false**, then the snapshot is created in a secondary storage. <br/><br/>*Note: Rapid snapshots enable much faster volume and template creation than from regular snapshots, but at a higher expense. Not all volumes support the* **rapid** *snapshot option.*
-

--- a/source/includes/cloudstack/_vpc_offerings.md
+++ b/source/includes/cloudstack/_vpc_offerings.md
@@ -8,9 +8,9 @@ VPC offerings determine which services are available to provisioned [VPCs](#clou
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpcofferings"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -54,9 +54,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpcofferings/41ac6ba0-6172-4bc4-bff6-b0831b91677c"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {

--- a/source/includes/cloudstack/_vpcs.md
+++ b/source/includes/cloudstack/_vpcs.md
@@ -11,9 +11,9 @@ A Virtual Private Cloud (VPC) is a logically isolated section of CloudMC, where 
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpcs"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [{
@@ -64,9 +64,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpcs/ad5bcae8-ee8b-4ee8-a7a4-381c25444b8e"
-
-# Example response:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -112,17 +112,14 @@ Attributes | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X POST \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpcs"
-
-# Request example:
 ```
+> Request body example:
+
 ```json
 {
   "name": "my_vpc",
@@ -154,17 +151,14 @@ Optional | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X PUT \
    -H "Content-Type: application/json" \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpcs/d77e1ab1-0320-4504-83c5-e78b431c7577"
-
-# Request example:
 ```
+> Request body example:
+
 ```json
 {
   "name": "my_updated_vpc",
@@ -189,9 +183,6 @@ Optional | &nbsp;
 
 
 ```shell
-
-# Example:
-
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpcs/ad5bcae8-ee8b-4ee8-a7a4-381c25444b8e"
@@ -208,9 +199,6 @@ Destroy an existing VPC. To delete a VPC, you must first delete all the [network
 
 
 ```shell
-
-# Example:
-
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpcs/ad5bcae8-ee8b-4ee8-a7a4-381c25444b8e?operation=restart"

--- a/source/includes/cloudstack/_vpcs.md
+++ b/source/includes/cloudstack/_vpcs.md
@@ -38,7 +38,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/vpcs</code>
 
-Retrieve a list of all VPCs of an [environment](#administration-environments)
+Retrieve a list of all VPCs of an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -131,7 +131,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/vpcs</code>
 
-Create a VPC in an [environment](#administration-environments)
+Create a VPC in an [environment](#administration-environments).
 
 Required | &nbsp;
 ------ | -----------
@@ -168,7 +168,7 @@ curl -X PUT \
 
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/vpcs</code>
 
-Update an existing VPC in your [environment](#administration-environments)
+Update an existing VPC in your [environment](#administration-environments).
 
 Optional | &nbsp;
 ------ | ---- | -----------

--- a/source/includes/cloudstack/_vpn_users.md
+++ b/source/includes/cloudstack/_vpn_users.md
@@ -52,7 +52,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/vpnusers/:id</code>
 
-Retrieve a VPN user
+Retrieve a VPN user.
 
 Attributes | &nbsp;
 ---------- | -----

--- a/source/includes/cloudstack/_vpn_users.md
+++ b/source/includes/cloudstack/_vpn_users.md
@@ -7,9 +7,9 @@ VPN users are the accounts that are allowed to connect to [remote access VPNs](#
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpnusers"
-
-# Response example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -38,9 +38,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/vpnusers/5de76bf5-9f61-487a-a989-042b52882da4"
-
-# Response example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {

--- a/source/includes/cloudstack/_zones.md
+++ b/source/includes/cloudstack/_zones.md
@@ -8,9 +8,9 @@ Each zone consists of physically isolated hosts, storage, and networking infrast
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/zones"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -40,9 +40,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/compute-on/test_area/zones/ea901007-056b-4c50-bb3a-2dd635fce2ab"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {
@@ -50,7 +50,6 @@ curl -X GET \
         "name": "ON-1"
     }
 }
-
 ```
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/zones/:id</code>

--- a/source/includes/gcp/_backend_services.md
+++ b/source/includes/gcp/_backend_services.md
@@ -10,9 +10,8 @@ A backend service directs traffic to backends, such as [instance groups](#gcp-in
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/backendservices"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -92,9 +91,8 @@ Retrieve a list of all backend services in an [environment](#administration-envi
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/backendservices"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -168,10 +166,10 @@ Retrieve a backend service in an [environment](#administration-environments).
 ```shell
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/backendservices"
-
-# Example:
 ```
+> Request body example:
 
 ```json
 {

--- a/source/includes/gcp/_backend_services.md
+++ b/source/includes/gcp/_backend_services.md
@@ -189,7 +189,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/backendservices</code>
 
-Create a new backend service
+Create a new backend service.
 
 | Required | &nbsp;|
 | --- | --- |

--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -1,5 +1,5 @@
 ### Clusters
-List your Kubernetes clusters
+List your Kubernetes clusters.
 
 <!-------------------- LIST CLUSTERS -------------------->
 

--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -9,9 +9,9 @@ List your Kubernetes clusters
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/clusters"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -60,9 +60,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {

--- a/source/includes/gcp/_disks.md
+++ b/source/includes/gcp/_disks.md
@@ -46,7 +46,7 @@ curl -X GET \
 ```
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/disks</code>
 
-Retrieve a list of all disks in a given [environment](#administration-environments)
+Retrieve a list of all disks in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -110,7 +110,7 @@ curl -X GET \
 ```
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/disks/:id</code>
 
-Retrieve a disk in a given [environment](#administration-environments)
+Retrieve a disk in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_disks.md
+++ b/source/includes/gcp/_disks.md
@@ -9,9 +9,9 @@ Deploy and manage your disks.
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/disks"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -78,9 +78,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/disks/5333546534174463697"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -144,9 +144,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/disks"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
   "name": "my-disk",
@@ -197,9 +197,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/disks/5333546534174463697?operation=attach"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "shortUsers": "5611478403377505138",
@@ -226,9 +226,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/disks/5333546534174463697?operation=detach"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "shortUsers": "5611478403377505138"
@@ -251,9 +251,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/disks/5333546534174463697?operation=resize"
-
-# Request should look like this
 ```
+> Request body example:
+
 ```json
 {
    "sizeGb": "50"

--- a/source/includes/gcp/_external_ips.md
+++ b/source/includes/gcp/_external_ips.md
@@ -10,9 +10,8 @@ External IP address to an instance or a forwarding rule if you need to communica
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/externalips"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -85,9 +84,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/externalips/8516891730356002156"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -150,9 +148,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/externalips?operation=reserve"
-
-# Request example:
 ```
+> Request body example:
+
 ```json
 {
   "name": "my-static-ip",

--- a/source/includes/gcp/_external_ips.md
+++ b/source/includes/gcp/_external_ips.md
@@ -55,7 +55,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/externalips</code>
 
-Retrieve a list of all external IPs in a given [environment](#administration-environments)
+Retrieve a list of all external IPs in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_firewall_rules.md
+++ b/source/includes/gcp/_firewall_rules.md
@@ -1,6 +1,6 @@
 ### Firewall rules
 
-Firewall allows you to control inbound and outbound traffic to your [environment](#administration-environments)
+Firewall allows you to control inbound and outbound traffic to your [environment](#administration-environments).
 
 #### List firewall rules
 
@@ -53,7 +53,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/firewallrules</code>
 
-Retrieve a list of all firewall rules in a given [environment](#administration-environments)
+Retrieve a list of all firewall rules in a given [environment](#administration-environments).
 
  Attributes | &nbsp;
 ------- | -----------
@@ -120,7 +120,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/firewallrules/:id</code>
 
-Retrieve a firewall rules in a given [environment](#administration-environments)
+Retrieve a firewall rules in a given [environment](#administration-environments).
 
  Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_firewall_rules.md
+++ b/source/includes/gcp/_firewall_rules.md
@@ -8,9 +8,9 @@ Firewall allows you to control inbound and outbound traffic to your [environment
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/firewallrules"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -80,9 +80,9 @@ Retrieve a list of all firewall rules in a given [environment](#administration-e
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/firewallrules/4890726785951782638"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -151,6 +151,8 @@ curl -X POST \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/gcp/test-area/firewallrule"
 ```
+> Request body example:
+
 ```json
 {
   "action": "allow",

--- a/source/includes/gcp/_forwarding_rules.md
+++ b/source/includes/gcp/_forwarding_rules.md
@@ -9,8 +9,8 @@ A forwarding rule and its corresponding IP address represent the frontend config
 curl -X GET \
   -H 'MC-Api-key: your_api_key'
   "https://cloudmc_endpoint/v1/services/gcp/test-area/forwardingrules"
-  # The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -69,9 +69,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/forwardingrules/4724455712741277576"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -124,25 +123,30 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -d "request _body" \
   "https://cloudmc_endpoint/v1/services/gcp/test-area/forwardingrules"
-# Request example:
 ```
-```json
-Creating a forwarding rule with ephemeral IP
+> Request body examples:
+
+```js
+// Creating a forwarding rule with ephemeral IP
 {
   "portRange": "80",
   "name": "my-forwarding-name",
   "shortTarget": "my-target-proxy"
 }
+```
 
-Creating a forwarding rule with new static IP
+```js
+// Creating a forwarding rule with new static IP
 {
   "portRange": "80",
   "name": "my-forwarding-name",	
   "shortTarget": "my-target-proxy",
   "reserveStaticIP": true
 }
+```
 
-Creating a forwarding rule with ephemeral IP
+```js
+// Creating a forwarding rule with ephemeral IP
 {
   "portRange": "80",  
   "name": "my-forwarding-name",

--- a/source/includes/gcp/_forwarding_rules.md
+++ b/source/includes/gcp/_forwarding_rules.md
@@ -42,7 +42,7 @@ curl -X GET \
    GET /service/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/forwardingrules
 </code>
 
-Retrieve a list of all forwarding rules
+Retrieve a list of all forwarding rules.
 
 Attributes | &nbsp;
 ------- | -----------
@@ -95,7 +95,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/forwardingrules/:id</code>
 
-Retrieve a forwarding rule in a given [environment](#administration-environments)
+Retrieve a forwarding rule in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -133,9 +133,7 @@ curl -X POST \
   "name": "my-forwarding-name",
   "shortTarget": "my-target-proxy"
 }
-```
 
-```js
 // Creating a forwarding rule with new static IP
 {
   "portRange": "80",
@@ -143,9 +141,7 @@ curl -X POST \
   "shortTarget": "my-target-proxy",
   "reserveStaticIP": true
 }
-```
 
-```js
 // Creating a forwarding rule with ephemeral IP
 {
   "portRange": "80",  
@@ -157,7 +153,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/forwardingrules</code>
 
-Create a new forwarding rule
+Create a new forwarding rule.
 
 Required | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -46,7 +46,7 @@ curl -X GET \
    GET /service/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks
 </code>
 
-Retrieve a list of all healtch checks
+Retrieve a list of all healtch checks.
 
 Attributes | &nbsp;
 ------- | -----------
@@ -104,7 +104,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks/:id</code>
 
-Retrieve a health check in a given [environment](#administration-environments)
+Retrieve a health check in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -8,8 +8,8 @@ Health checking mechanisms determine whether VM instances respond properly to tr
 curl -X GET \
   -H 'MC-Api-key: your_api_key'
   "https://cloudmc_endpoint/v1/services/gcp/test-area/healthchecks"
-  # The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -73,9 +73,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/healthchecks/5930212998788364011"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -170,8 +169,10 @@ Destroy an existing health check. A health check can only be deleted if it's not
 ```shell
 curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/healthchecks/6938691570659391640"
 ```
+> Request body example:
 
 ```json
 {

--- a/source/includes/gcp/_images.md
+++ b/source/includes/gcp/_images.md
@@ -9,9 +9,9 @@ Images are virtual machine images that have a virtual disk which contains a boot
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/gcp/test-area/images"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -113,9 +113,9 @@ Attributes | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/gcp/test-area/images/4658005417542122143"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": {

--- a/source/includes/gcp/_images.md
+++ b/source/includes/gcp/_images.md
@@ -150,7 +150,7 @@ curl -H "MC-Api-Key: your_api_key" \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/images/:id</code>
 
-Retrieve information about an image
+Retrieve information about an image.
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_instance_groups.md
+++ b/source/includes/gcp/_instance_groups.md
@@ -46,7 +46,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instancegroups</code>
 
-Retrieve a list of all instance groups in a given [environment](#administration-environments)
+Retrieve a list of all instance groups in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -104,7 +104,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instancegroups/:id</code>
 
-Retrieve an instance group in a given [environment](#administration-environments)
+Retrieve an instance group in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -149,7 +149,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instancegroups</code>
 
-Create a new instance group
+Create a new instance group.
 
 Required | &nbsp;
 ------- | -----------
@@ -175,7 +175,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instancegroups/:id</code>
 
-Delete an existing instance group
+Delete an existing instance group.
 
 <!-------------------- MANAGE INSTANCE MEMBERS -------------------->
 
@@ -198,7 +198,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instancegroups/:id?operation=manage_instance_members</code>
 
-Manage instance members in an existing instance group
+Manage instance members in an existing instance group.
 
 <aside class="notice">
 An instance can only belong to one load balanced instance group. But you can add an instance to multiple non-load balanced instance groups

--- a/source/includes/gcp/_instance_groups.md
+++ b/source/includes/gcp/_instance_groups.md
@@ -10,9 +10,8 @@ An instance group is a collection of [VM instances](#gcp-instances) that you can
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instancegroups"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -74,9 +73,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instancegroups/2986056884972096897"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -135,9 +133,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instancegroups"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -187,10 +184,10 @@ Delete an existing instance group
 ```shell
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instancegroups/2986056884972096897?operation=manage_instance_members"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -106,7 +106,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances</code>
 
-Retrieve a list of all instances in a given [environment](#administration-environments)
+Retrieve a list of all instances in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -241,7 +241,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id</code>
 
-Retrieve an instance in a given [environment](#administration-environments)
+Retrieve an instance in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -303,9 +303,7 @@ curl -X POST \
   "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
   "shortIP": "my-ip-name"
 }
-```
 
-```js
 // Create an instance with a new static IP
 {
   "name": "my-instance",
@@ -318,9 +316,7 @@ curl -X POST \
   "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
   "reserveStaticIP": true
 }
-```
 
-```js
 // Create an instance with an ephemeral IP
 {
   "name": "my-instance",
@@ -336,7 +332,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances</code>
 
-Create a new instance
+Create a new instance.
 
 Required | &nbsp;
 ------- | -----------
@@ -366,7 +362,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id</code>
 
-Delete an existing instance
+Delete an existing instance.
 
 <!-------------------- CHANGE MACHINE TYPE -------------------->
 
@@ -429,16 +425,12 @@ curl -X POST \
 ```js
 // Changing the IP to an ephemeral IP, just leave it empty
 { }
-```
 
-```js
 // Changing the IP to a new static IP
 {
   "reserveStaticIP" : true
 }
-```
 
-```js
 // Changing the IP to an existing IP
 {
   "shortIP" : "your-ip-name"
@@ -475,7 +467,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=get_ssh</code>
 
-Retrieve a command to allow you to SSH into a give running instance
+Retrieve a command to allow you to SSH into a give running instance.
 
 Required | &nbsp;
 ------ | -----------
@@ -503,7 +495,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=set_windows_password</code>
 
-Set and retrieve a generated password to a given user on a running Windows instance
+Set and retrieve a generated password to a given user on a running Windows instance.
 
 Required | &nbsp;
 ------ | -----------
@@ -528,10 +520,10 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instancegroups/:id?operation=manage_group_membership</code>
 
-Manage an instance's membership to groups
+Manage an instance's membership to groups.
 
 <aside class="notice">
-An instance can only belong to one load balanced instance group. But you can add an instance to multiple non-load balanced instance groups
+An instance can only belong to one load balanced instance group. But you can add an instance to multiple non-load balanced instance groups.
 </aside>
 
 Required | &nbsp;

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -10,9 +10,8 @@ Deploy and manage your instances.
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -151,9 +150,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/5611478403377505138"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -289,12 +287,11 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances"
-
-# Request example:
 ```
+> Request body example:
 
-```json
-Create an instance with an existing IP
+```js
+// Create an instance with an existing IP
 {
   "name": "my-instance",
   "shortRegion": "northamerica-northeast1",
@@ -306,8 +303,10 @@ Create an instance with an existing IP
   "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
   "shortIP": "my-ip-name"
 }
+```
 
-Create an instance with a new static IP
+```js
+// Create an instance with a new static IP
 {
   "name": "my-instance",
   "shortRegion": "northamerica-northeast1",
@@ -319,8 +318,10 @@ Create an instance with a new static IP
   "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
   "reserveStaticIP": true
 }
+```
 
-Create an instance with an ephemeral IP
+```js
+// Create an instance with an ephemeral IP
 {
   "name": "my-instance",
   "shortRegion": "northamerica-northeast1",
@@ -379,9 +380,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/6564997542943928188?operation=resize"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -423,23 +423,23 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/6564997542943928188?operation=change_external_ip"
-   
-# Request example:
 ```
-Changing the IP to an ephemeral IP, just leave it empty
-```json
+> Request body examples:
+
+```js
+// Changing the IP to an ephemeral IP, just leave it empty
 { }
 ```
 
-Changing the IP to a new static IP
-```json
+```js
+// Changing the IP to a new static IP
 {
   "reserveStaticIP" : true
 }
 ```
 
-Changing the IP to an existing IP
-```json
+```js
+// Changing the IP to an existing IP
 {
   "shortIP" : "your-ip-name"
 }
@@ -464,8 +464,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/6564997542943928188?operation=get_ssh"
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -492,8 +492,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/6564997542943928188?operation=set_windows_password"
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -517,9 +517,8 @@ Required | &nbsp;
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/2986056884972096897?operation=manage_group_membership"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -288,7 +288,7 @@ curl -X POST \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances"
 ```
-> Request body example:
+> Request body examples:
 
 ```js
 // Create an instance with an existing IP

--- a/source/includes/gcp/_k8_charts.md
+++ b/source/includes/gcp/_k8_charts.md
@@ -78,7 +78,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts?cluster_id=:cluster_id</code>
 
-Retrieve a list of all charts in a given [environment](#administration-environments)
+Retrieve a list of all charts in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
@@ -183,7 +183,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts/:id?cluster_id=cluster_id</code>
 
-Retrieve a specific chart in a given [environment](#administration-environments)
+Retrieve a specific chart in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
@@ -250,7 +250,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts?cluster_id=:cluster_id</code>
 
-Install a chart in a given [environment](#administration-environments)
+Install a chart in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_k8_charts.md
+++ b/source/includes/gcp/_k8_charts.md
@@ -9,9 +9,9 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/charts?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -119,9 +119,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/charts/stable/aerospike?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -225,9 +225,9 @@ Attributes | &nbsp;
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/charts?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
 	"relationships": {

--- a/source/includes/gcp/_k8_pods.md
+++ b/source/includes/gcp/_k8_pods.md
@@ -9,9 +9,9 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/pods?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -242,9 +242,9 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/pods/my-aerospike-0/default?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -476,9 +476,9 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/pods/my-aerospike-0/default?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",

--- a/source/includes/gcp/_k8_pods.md
+++ b/source/includes/gcp/_k8_pods.md
@@ -208,7 +208,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods?cluster_id=:cluster_id</code>
 
-Retrieve a list of all pods in a given [environment](#administration-environments)
+Retrieve a list of all pods in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
@@ -441,7 +441,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id?cluster_id=:cluster_id</code>
 
-Retrieve a pod and all its info in a given [environment](#administration-environments)
+Retrieve a pod and all its info in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
@@ -490,7 +490,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id?cluster_id=:cluster_id</code>
 
-Delete a pod from a given [environment](#administration-environments)
+Delete a pod from a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_k8_releases.md
+++ b/source/includes/gcp/_k8_releases.md
@@ -9,9 +9,9 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -152,9 +152,9 @@ The information is not totally returned in the list. We filter out the manifest 
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -326,9 +326,8 @@ Attributes | &nbsp;
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=rollback&cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -369,34 +368,33 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954?operation=upgrade&cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
    -d "request_body"
-
-
-# Request body examples:
 ```
-```json
-# Change to the latest version of a chart
+> Request body examples:
+
+```js
+// Change to the latest version of a chart
 {
   "upgradeChart":  "stable/aerospike" 
 }
 ```
 
-```json
-# Change to a specific version of a chart
+```js
+// Change to a specific version of a chart
 {
   "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
 }
 ```
 
-```json
-# Change the values for the latest version
+```js
+// Change the values for the latest version
 {
   "upgradeChart" : "stable/aerospike",
   "values": "---\n\"replicaCount\": 3\n"
 }
 ```
+> The above commands return JSON structured like this:
 
 ```json
-# The above command returns JSON structured like this
 {
   "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
   "taskStatus": "SUCCESS"
@@ -429,17 +427,17 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=uninstall&cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
    -d "request_body"
-
-# Request body example
 ```
+> Request body example:
+
 ```json
 {
    "keepHistory": true
 }
 ```
+> The above command returns JSON structured like this:
 
 ```json
-# The above command returns JSON structured like this
 {
   "data": {
       "version": 0,

--- a/source/includes/gcp/_k8_releases.md
+++ b/source/includes/gcp/_k8_releases.md
@@ -101,7 +101,7 @@ Or
 
 
 
-Retrieve a list of all releases in a given [environment](#administration-environments)
+Retrieve a list of all releases in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
@@ -278,7 +278,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases?cluster_id=:cluster_id</code>
 
-Retrieve a release in a given [environment](#administration-environments)
+Retrieve a release in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
@@ -376,16 +376,12 @@ curl -X POST \
 {
   "upgradeChart":  "stable/aerospike" 
 }
-```
 
-```js
 // Change to a specific version of a chart
 {
   "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
 }
-```
 
-```js
 // Change the values for the latest version
 {
   "upgradeChart" : "stable/aerospike",
@@ -403,7 +399,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade&cluster_id=:cluster_id</code>
 
-Upgrade a release in a given [environment](#administration-environments)
+Upgrade a release in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_load_balancer.md
+++ b/source/includes/gcp/_load_balancer.md
@@ -41,7 +41,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/loadbalancers</code>
 
-Retrieve a list of all load balancers in a given [environment](#administration-environments)
+Retrieve a list of all load balancers in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -86,7 +86,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/loadbalancers/:id</code>
 
-Retrieve a load balancer in a given [environment](#administration-environments)
+Retrieve a load balancer in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -117,9 +117,7 @@ curl -X POST \
 	"shortProtocol": "HTTP",
 	"shortPort": "80"
 }
-```
 
-```js
 // Creating loadbalancer with existing IP
 {
 	"name":"my-loadbalancer-name",
@@ -128,9 +126,7 @@ curl -X POST \
 	"shortPort": "80",
     "shortIP": "my-ip-name",
 }
-```
 
-```js
 // Creating loadbalancer with new static IP
 {
 	"name":"my-loadbalancer-name",
@@ -139,9 +135,7 @@ curl -X POST \
 	"shortPort": "80",
     "reserveStaticIP": true
 }
-```
 
-```js
 // Creating loadbalancer with HTTPS protocol
 {
 	...
@@ -152,7 +146,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/loadbalancers</code>
 
-Create a new load balancer
+Create a new load balancer.
 
 Required | &nbsp;
 ------- | -----------
@@ -188,7 +182,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/loadbalancers/:id</code>
 
-Delete an existing load balancer
+Delete an existing load balancer.
 
 <aside class="notice">
 By default the forwarding rules, target proxies and url map will be deleted.

--- a/source/includes/gcp/_load_balancer.md
+++ b/source/includes/gcp/_load_balancer.md
@@ -10,9 +10,8 @@ HTTP(S) load balancing can balance HTTP and HTTPS traffic across multiple backen
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/loadbalancers"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -61,9 +60,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/loadbalancers/8268558443601303519"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -106,20 +104,23 @@ Attributes | &nbsp;
 curl -X POST \
   -H 'MC-Api-Key: your_api_key' \
   -H "Content-Type: application/json" \
-  -d "request _body" \
+  -d "request_body" \
   "https://cloudmc_endpoint/v1/services/gcp/test-area/loadbalancers"
 ```
+> Request body examples:
 
-```json
-Creating loadbalancer with ephemeral IP
+```js
+// Creating loadbalancer with ephemeral IP
 {
 	"name":"my-loadbalancer-name",
 	"shortBackend": "my-backend-backend",
 	"shortProtocol": "HTTP",
 	"shortPort": "80"
 }
+```
 
-Creating loadbalancer with existing IP
+```js
+// Creating loadbalancer with existing IP
 {
 	"name":"my-loadbalancer-name",
 	"shortBackend": "my-backend-backend",
@@ -127,8 +128,10 @@ Creating loadbalancer with existing IP
 	"shortPort": "80",
     "shortIP": "my-ip-name",
 }
+```
 
-Creating loadbalancer with new static IP
+```js
+// Creating loadbalancer with new static IP
 {
 	"name":"my-loadbalancer-name",
 	"shortBackend": "my-backend-backend",
@@ -136,8 +139,10 @@ Creating loadbalancer with new static IP
 	"shortPort": "80",
     "reserveStaticIP": true
 }
+```
 
-Creating loadbalancer with HTTPS protocol
+```js
+// Creating loadbalancer with HTTPS protocol
 {
 	...
     "shortPort": "443",
@@ -171,6 +176,7 @@ curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/loadbalancers/8268558443601303519"
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {

--- a/source/includes/gcp/_networks.md
+++ b/source/includes/gcp/_networks.md
@@ -45,7 +45,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks</code>
 
-Retrieve a list of all networks in an [environment](#administration-environments)
+Retrieve a list of all networks in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -96,7 +96,7 @@ curl -H "MC-Api-Key: your_api_key" \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks/:id</code>
 
-Retrieve information about a network
+Retrieve information about a network.
 
 Attributes | &nbsp;
 ---------- | -----

--- a/source/includes/gcp/_networks.md
+++ b/source/includes/gcp/_networks.md
@@ -10,9 +10,9 @@ A network is an isolated network where you can place groups of resources, such a
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/networks"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -66,9 +66,9 @@ Attributes | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/gcp/test-area/networks/6402509859159933821"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": {

--- a/source/includes/gcp/_regions.md
+++ b/source/includes/gcp/_regions.md
@@ -107,7 +107,7 @@ curl -H "MC-Api-Key: your_api_key" \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/regions/:id</code>
 
-Retrieve information about a region
+Retrieve information about a region.
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_regions.md
+++ b/source/includes/gcp/_regions.md
@@ -9,9 +9,9 @@ A region is a geographical area where a resource is located. Regions contains mu
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/gcp/test-area/regions"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -71,9 +71,9 @@ Attributes | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/gcp/test-area/regions/1330"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": {

--- a/source/includes/gcp/_ssh_keys.md
+++ b/source/includes/gcp/_ssh_keys.md
@@ -10,9 +10,9 @@ SSH keys are managed at the [environment](#administration-environments) level.
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/sshkeys"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -46,9 +46,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/sshkeys/user1"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -78,9 +78,9 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/sshkeys"
-
-# Request example:
 ```
+> Request body example:
+
 ```json
 {
   "name": "user1",

--- a/source/includes/gcp/_ssh_keys.md
+++ b/source/includes/gcp/_ssh_keys.md
@@ -30,7 +30,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys</code>
 
-Retrieve a list of all SSH keys in an [environment](#administration-environments)
+Retrieve a list of all SSH keys in an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -61,7 +61,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys/:id</code>
 
-Retrieve information about an SSH key of an [environment](#administration-environments)
+Retrieve information about an SSH key of an [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -90,7 +90,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys</code>
 
-Add an SSH key to the [environment](#administration-environments)
+Add an SSH key to the [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
@@ -109,4 +109,4 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sshkeys/:name</code>
 
-Delete an existing SSH key from the [environment](#administration-environments)
+Delete an existing SSH key from the [environment](#administration-environments).

--- a/source/includes/gcp/_ssl_certificates.md
+++ b/source/includes/gcp/_ssl_certificates.md
@@ -10,9 +10,8 @@ Represents an SSL Certificate resource.
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/sslcertificates"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -83,9 +82,8 @@ Retrieve a list of all ssl certificates in an [environment](#administration-envi
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/sslcertificates/6911678730334723784"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -134,24 +132,24 @@ Retrieve a ssl certificate in an [environment](#administration-environments).
 ```shell
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/sslcertificates"
-
-# Example:
 ```
+> Request body example:
 
 ```json
 {
-	"name":"ssl-root-rny",
-	"privateKey":"-----BEGIN RSA PRIVATE KEY-----
+	"name": "ssl-root-rny",
+	"privateKey": "-----BEGIN RSA PRIVATE KEY-----
   (encoded private key body in here)
   -----END RSA PRIVATE KEY-----",
-	"certificate":"-----BEGIN CERTIFICATE-----
+	"certificate": "-----BEGIN CERTIFICATE-----
   (encoded certificate body in here)
   -----END CERTIFICATE-----",
-	"chainCertificate":"-----BEGIN CERTIFICATE-----
+	"chainCertificate": "-----BEGIN CERTIFICATE-----
   (encoded chain certificate body in here)
   -----END CERTIFICATE-----",
-	"description":"Api docs demo certificate"
+	"description": "Api docs demo certificate"
 }
 ```
 

--- a/source/includes/gcp/_ssl_certificates.md
+++ b/source/includes/gcp/_ssl_certificates.md
@@ -155,7 +155,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sslcertificates</code>
 
-Create a new ssl certificate
+Create a new ssl certificate.
 
 | Required | &nbsp;|
 | --- | --- |

--- a/source/includes/gcp/_target_proxies.md
+++ b/source/includes/gcp/_target_proxies.md
@@ -10,9 +10,8 @@ Target proxies route incoming request to either a URL map (HTTP(S) load balancin
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/targetproxies"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -58,9 +57,8 @@ Retrieve a list of all target proxies in an [environment](#administration-enviro
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/targetproxies/2137054791002409126"
-
-# Example:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -105,17 +103,31 @@ Retrieve a target proxy in an [environment](#administration-environments).
 # Example request: Specifying an existing URL map
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
-   -d '{ "name": "targetProxyName", "type": "HTTPS", "shortUrlMap": "urlMapName", "shortCertificates": "sslCertificateName" }' \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/targetProxies"
+```
+> Request body examples:
+
+```js
+// Specifying an existing URL map
+{
+   "name": "targetProxyName",
+   "type": "HTTPS",
+   "shortUrlMap": "urlMapName",
+   "shortCertificates": "sslCertificateName"
+}
 ```
 
-```shell
-# Example request: Specifying a backend service. A default URL map will be created automatically.
-curl -X POST \
-   -H "MC-Api-Key: your_api_key" \
-   -d '{ "name": "targetProxyName", "type": "HTTPS", "shortBackend": "backendServicesName", "shortCertificates": "sslCertificateName" }' \
-   "https://cloudmc_endpoint/v1/services/gcp/test-area/targetProxies"
+```js
+// Specifying a backend service, a default URL map will be created automatically
+{
+   "name": "targetProxyName",
+   "type": "HTTPS",
+   "shortBackend": "backendServicesName",
+   "shortCertificates": "sslCertificateName"
+}
 ```
+
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/targetProxies</code>
 

--- a/source/includes/gcp/_target_proxies.md
+++ b/source/includes/gcp/_target_proxies.md
@@ -131,7 +131,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/targetProxies</code>
 
-Create a new target proxy
+Create a new target proxy.
 
 | Required                         | &nbsp; |
 | -------------------------------- | ------ |

--- a/source/includes/gcp/_vpn_gateways.md
+++ b/source/includes/gcp/_vpn_gateways.md
@@ -45,7 +45,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/vpngateways</code>
 
-Retrieve a list of all VPN gateways in a given [environment](#administration-environments)
+Retrieve a list of all VPN gateways in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_vpn_gateways.md
+++ b/source/includes/gcp/_vpn_gateways.md
@@ -10,9 +10,8 @@ With Classic VPN, your on-premises hosts communicate through one or more IPsec V
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/vpngateways"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -69,9 +68,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/vpngateways/3112849056897469664"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -125,9 +123,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/vpngateways"
-
-# Request examples:
 ```
+> Request body examples:
 
 ```json
 {
@@ -171,6 +168,7 @@ curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/vpngateways/3112849056897469664"
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {

--- a/source/includes/gcp/_vpn_tunnels.md
+++ b/source/includes/gcp/_vpn_tunnels.md
@@ -10,9 +10,8 @@ With Classic VPN, your on-premises hosts communicate through one or more IPsec V
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/vpngateways"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -83,9 +82,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/vpntunnels/8211895554244865771"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -153,9 +151,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/vpntunnels"
-
-# Request examples:
 ```
+> Request body example:
 
 ```json
 {
@@ -197,6 +194,7 @@ curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/vpntunnels/8211895554244865771"
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {

--- a/source/includes/gcp/_vpn_tunnels.md
+++ b/source/includes/gcp/_vpn_tunnels.md
@@ -54,7 +54,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/vpntunnels</code>
 
-Retrieve a list of all VPN tunnels in a given [environment](#administration-environments)
+Retrieve a list of all VPN tunnels in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -207,7 +207,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/vpntunnels/:id</code>
 
-Delete a Classic VPN tunnel in a given [environment](#administration-environments)
+Delete a Classic VPN tunnel in a given [environment](#administration-environments).
 
 Optional | &nbsp;
 ------- | -----------

--- a/source/includes/kubernetes/_k8_charts.md
+++ b/source/includes/kubernetes/_k8_charts.md
@@ -9,9 +9,9 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/charts"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -114,9 +114,9 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/charts/stable/aerospike"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -215,9 +215,9 @@ Attributes | &nbsp;
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/charts"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
 	"relationships": {

--- a/source/includes/kubernetes/_k8_charts.md
+++ b/source/includes/kubernetes/_k8_charts.md
@@ -78,7 +78,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts</code>
 
-Retrieve a list of all charts in a given [environment](#administration-environments)
+Retrieve a list of all charts in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -178,7 +178,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts/:id</code>
 
-Retrieve a specific chart in a given [environment](#administration-environments)
+Retrieve a specific chart in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -240,7 +240,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts</code>
 
-Install a chart in a given [environment](#administration-environments)
+Install a chart in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -208,7 +208,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods</code>
 
-Retrieve a list of all pods in a given [environment](#administration-environments)
+Retrieve a list of all pods in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -437,7 +437,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id</code>
 
-Retrieve a pod and all its info in a given [environment](#administration-environments)
+Retrieve a pod and all its info in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -481,7 +481,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id</code>
 
-Delete a pod from a given [environment](#administration-environments)
+Delete a pod from a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -9,9 +9,9 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/pods"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -238,9 +238,9 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/pods/my-aerospike-0/default"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": [
@@ -467,9 +467,9 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/pods/my-aerospike-0/default"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -355,36 +355,35 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954?operation=upgrade"
    -d "request_body"
-
-
-# Request body examples:
 ```
 
-```json
-# Change to the latest version of a chart
+> Request body examples:
+
+```js
+// Change to the latest version of a chart
 {
-  "upgradeChart":  "stable/aerospike" 
+  "upgradeChart":  "stable/aerospike",
+  "upgradeChart":  1 
 }
 ```
 
-```json
-# Change to a specific version of a chart
+```js
+// Change to a specific version of a chart
 {
   "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
 }
 ```
 
-```json
-# Change the values for the latest version
+```js
+// Change the values for the latest version
 {
   "upgradeChart" : "stable/aerospike",
   "values": "---\n\"replicaCount\": 3\n"
 }
 ```
-
+> The above commands return JSON structured like this
 
 ```json
-# The above command returns JSON structured like this
 {
   "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
   "taskStatus": "SUCCESS"
@@ -426,8 +425,8 @@ curl -X POST \
 }
 ```
 
-```json
-# The above command returns JSON structured like this
+```js
+// The above command returns JSON structured like this
 {
   "data": {
       "version": 0,

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -101,7 +101,7 @@ Or
 
 
 
-Retrieve a list of all releases in a given [environment](#administration-environments)
+Retrieve a list of all releases in a given [environment](#administration-environments).
 
 	 
 Optional | &nbsp;
@@ -363,23 +363,19 @@ curl -X POST \
   "upgradeChart":  "stable/aerospike",
   "upgradeChart":  1 
 }
-```
 
-```js
 // Change to a specific version of a chart
 {
   "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
 }
-```
 
-```js
 // Change the values for the latest version
 {
   "upgradeChart" : "stable/aerospike",
   "values": "---\n\"replicaCount\": 3\n"
 }
 ```
-> The above commands return JSON structured like this
+> The above commands return JSON structured like this:
 
 ```json
 {
@@ -390,7 +386,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>
 
-Upgrade a release in a given [environment](#administration-environments)
+Upgrade a release in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -9,9 +9,8 @@
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -148,9 +147,9 @@ The information is not totally returned in the list. We filter out the manifest 
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {
@@ -316,9 +315,8 @@ Attributes | &nbsp;
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=rollback"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -416,17 +414,17 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/anenvironment/releases/pspensieri/aerospike-1579797954&operation=uninstall"
    -d "request_body"
-
-# Request body example
 ```
+> Request body example:
+
 ```json
 {
    "keepHistory": true
 }
 ```
+> The above command returns JSON structured like this:
 
 ```js
-// The above command returns JSON structured like this
 {
   "data": {
       "version": 0,

--- a/source/includes/masterportal/_applications.md
+++ b/source/includes/masterportal/_applications.md
@@ -5,7 +5,6 @@ Applications' login can be automated by MasterPortal. It has an entrypoint that 
 #### Add Credentials
 
 ```shell
-Example Request: 
 curl -X POST \
   'https://cloudmc_endpoint/v2/services/mp-devel/test-applications/apps/b6c4ca5b-e85a-41d3-80b2-5d21d6ce7060?operation=addCredentials' \
   -H 'mc-api-key: your_api_key' \
@@ -14,8 +13,9 @@ curl -X POST \
 	"password": "sample_password"
 }'
 ```
+> The above command returns JSON structured like this:
+
 ```json
-Example Response: 
 {
   "taskId": "ac3144ab-03c8-4564-afbf-fabf5fc68199",
   "taskStatus": "SUCCESS"
@@ -33,7 +33,6 @@ Required | &nbsp;
 #### Add Credentials for Another User
 
 ```shell
-Example Request: 
 curl -X POST \
   'https://cloudmc_endpoint/v2/services/mp-devel/test-applications/appUser/1a578977-5744-4832-bae3-d91ad2939adf:b6c4ca5b-e85a-41d3-80b2-5d21d6ce7060?operation=addUserCredentials' \
   -H 'content-type: application/json' \
@@ -46,10 +45,10 @@ curl -X POST \
 		"password": "sample_password"
 	}
 }'
-
 ```
+> The above command returns JSON structured like this:
+
 ```json
-Example Response: 
 {
   "taskId": "ecdd71ea-1648-44d2-a9cf-71b160acab17",
   "taskStatus": "SUCCESS"
@@ -71,14 +70,13 @@ Required | &nbsp;
 #### Login to An Application
 
 ```shell
-Example Request: 
 curl -X POST \
   'https://cloudmc_endpoint/v2/services/mp-devel/test-applications/apps/d5484354-28a3-45be-a536-0b02ef3c8e23?operation=login' \
   -H 'mc-api-key: your_api_key' 
 ```
+> The above command returns JSON structured like this:
 
 ```json
-Example Response: 
 {    
   "data": "https://mp_proxy_endpoint/portal/login-path/427f5873-7edf-4bba-ba65-8c927776da81/d5484354-28a3-45be-a536-0b02ef3c8e23/datadog-ukqrqhie/f59139e1-82e5-4526-bd5d-04c777a55f2a/b7f0bdd5-b544-d07e-ee56-4ee0d1a8a9c3",
   "taskId": "38805aa4-0a30-4197-8ce9-f79872080773",

--- a/source/includes/openstack/_flavors.md
+++ b/source/includes/openstack/_flavors.md
@@ -7,9 +7,9 @@ Flavors are available hardware configurations for instances. They store the info
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/flavors"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": [
@@ -42,9 +42,9 @@ Attributes | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/flavors/1d547941-1738-4d7b-a70b-b52a44ff18e5"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": {

--- a/source/includes/openstack/_floatingIps.md
+++ b/source/includes/openstack/_floatingIps.md
@@ -72,9 +72,11 @@ Attributes | &nbsp;
 ```shell
 curl -X POST \
     -H "MC-Api-Key: your_api_key" \ 
+    -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/floatingips"
-# Request should look like this:
 ```
+> Request body example:
+
 ```json
 {
     "externalNetworkId": "networkId",

--- a/source/includes/openstack/_floatingIps.md
+++ b/source/includes/openstack/_floatingIps.md
@@ -8,6 +8,8 @@ Floating IPs are public IP addresses that a user can acquire and use in an envir
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/floatingips"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -41,6 +43,8 @@ Attributes | &nbsp;
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/floatingips/287a3963-983b-4602-9dea-4dff89e9dc10"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {

--- a/source/includes/openstack/_images.md
+++ b/source/includes/openstack/_images.md
@@ -7,9 +7,9 @@ Images are virtual machine images that have a virtual disk that contains a boota
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/images"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": [
@@ -42,9 +42,9 @@ Attributes | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/images/22f53310-798d-4029-bb00-747a52d2a376"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": {

--- a/source/includes/openstack/_instances.md
+++ b/source/includes/openstack/_instances.md
@@ -8,6 +8,8 @@ Deploy and manage your instances. Instances are virtual machines or physical mac
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/instances"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -61,6 +63,8 @@ Attributes | &nbsp;
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/instances/30fca349-68b0-48c2-9ada-1f60f57fa44e"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": {
@@ -111,8 +115,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/instances"
-# Request body example:
 ```
+> Request body example:
+
 ```json
 {
     "name": "web1",
@@ -147,8 +152,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/instances/30fca349-68b0-48c2-9ada-1f60f57fa44e?operation=associate"
-# Request body should look like
 ```
+> Request body example:
+
 ```json
 {
   "floatingIpId": "287a3963-983b-4602-9dea-4dff89e9dc10"
@@ -170,8 +176,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/instances/30fca349-68b0-48c2-9ada-1f60f57fa44e?operation=changeSecurityGroups"
-# Request body should look like
 ```
+> Request body example:
+
 ```json
 {
   "securityGroupNames": [ "securityGroupNameA", "securityGroupNameB"]

--- a/source/includes/openstack/_networks.md
+++ b/source/includes/openstack/_networks.md
@@ -8,6 +8,8 @@ Networks are provisioned to be able to control data flow to instances. To commun
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/networks"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -44,6 +46,8 @@ Retrieve a list of all networks in an environment.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/networks/a9e8861d-64a1-4126-b385-6e4db9a5814f"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {
@@ -77,8 +81,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/networks"
-# Request should look like this:
 ```
+> Request body example:
+
 ```json
 {
     "name": "web",

--- a/source/includes/openstack/_networks.md
+++ b/source/includes/openstack/_networks.md
@@ -1,6 +1,6 @@
 ### Networks
 
-Networks are provisioned to be able to control data flow to instances. To communicate with the external network, the network must be connected to a [router](#openstack-routers)
+Networks are provisioned to be able to control data flow to instances. To communicate with the external network, the network must be connected to a [router](#openstack-routers).
 
 #### List networks
 

--- a/source/includes/openstack/_routerInterfaces.md
+++ b/source/includes/openstack/_routerInterfaces.md
@@ -8,6 +8,8 @@ Router interfaces connect a router to a network.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/routerinterfaces?routerid=3de4f523-06ce-4955-acb0-b8e3d61ec582"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
 	"data": [
@@ -45,6 +47,8 @@ Retrieve a list of router interfaces associated with a router in an OpenStack en
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/routerinterfaces/b5f0cbbf-45f3-4e77-8a5c-90351f83e5f9"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
 	"data": {
@@ -79,8 +83,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/routerinterfaces"
-# Request should look like this:
 ```
+> Request body example:
+
 ```json
 {
 	"networkId": "d507486c-eacb-48ff-841e-e3938213d95f",

--- a/source/includes/openstack/_routers.md
+++ b/source/includes/openstack/_routers.md
@@ -8,6 +8,8 @@ Routers route traffic between networks, including the public internet.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/routers"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -51,6 +53,8 @@ Retrieve a list of routers in an OpenStack environment.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/routers/212eb8d8-80ee-4edd-8bae-1efed8bc5c71"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {
@@ -91,8 +95,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/routers"
-# Request should look like this:
 ```
+> Request body example:
+
 ```json
 {
     "name": "external-router",
@@ -117,8 +122,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/routers/212eb8d8-80ee-4edd-8bae-1efed8bc5c71?operation=addRouterInterface"
-# Request should look like this:
 ```
+> Request body example:
+
 ```json
 {
     "networkId": "471eb361-c028-45f5-bd1a-6d05a057624f",

--- a/source/includes/openstack/_securityGroupRules.md
+++ b/source/includes/openstack/_securityGroupRules.md
@@ -8,6 +8,8 @@ Security group rules define the type of traffic that can access the instances as
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/securitygrouprules?securitygroupid=f54f050b-01b2-4a73-b6e1-4e13a5566323"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -60,6 +62,8 @@ Retrieve a list of all security group rules in a security group.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/securitygrouprules/655d3bcb-3f8a-4738-b50a-53bca43469b5"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
 	 "data": {
@@ -100,8 +104,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/securitygrouprules"
-# Request should look like this:
 ```
+> Request body example:
+
 ```json
 {
     "ingress": true,

--- a/source/includes/openstack/_securityGroups.md
+++ b/source/includes/openstack/_securityGroups.md
@@ -8,6 +8,8 @@ Security groups manage network access to instances.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/securitygroups"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": [
@@ -39,6 +41,8 @@ Retrieve a list of all security groups in an environment.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/securitygroups/1bd672f4-b274-4371-a792-b0a6c6778cc7"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {
@@ -67,8 +71,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/securitygroups"
-# Request should look like this:
 ```
+> Request body example:
+
 ```json
 {
     "name": "security-group-1",

--- a/source/includes/openstack/_snapshots.md
+++ b/source/includes/openstack/_snapshots.md
@@ -7,9 +7,9 @@ Snapshots are point in time copies of volumes that can be used to create other v
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/snapshots"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": [
@@ -46,9 +46,9 @@ Attributes | &nbsp;
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/snapshots/4b41c7de-b2a8-4cb7-82ce-46685b07921d"
-
-Response body:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
   "data": {

--- a/source/includes/openstack/_sshKeys.md
+++ b/source/includes/openstack/_sshKeys.md
@@ -84,7 +84,7 @@ curl -X POST \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/sshkeys"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/openstack/_sshKeys.md
+++ b/source/includes/openstack/_sshKeys.md
@@ -8,6 +8,8 @@ SSH keys can be assigned on instance creation to provide SSH access.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/sshkeys"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
 	"data": [
@@ -47,6 +49,8 @@ Retrieve a list of SSH keys in an OpenStack domain.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/sshkeys/ssh-key-a"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
 	"data": {
@@ -79,8 +83,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/sshkeys"
-# Request should look like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "name": "ssh-key-c",

--- a/source/includes/openstack/_volumes.md
+++ b/source/includes/openstack/_volumes.md
@@ -8,6 +8,8 @@ Volumes are block-level storage devices that can be attached to instances.
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/volumes"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "data": [
@@ -43,6 +45,8 @@ Attributes | &nbsp;
 curl -H "MC-Api-Key: your_api_key" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/volumes/52cfc2f8-5b1f-4833-83cd-a77f55c5ed24"
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
     "data": {
@@ -75,8 +79,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/volumes"
-# Request should look like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "name": "mysql",
@@ -120,8 +125,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/volumes/52cfc2f8-5b1f-4833-83cd-a77f55c5ed24?operation=attach"
-# Request should look like this:
 ```
+> The above command returns JSON structured like this:
+
 ```json
 {
    "instanceId": "449efafc-0a6f-4f9e-9602-4b9ac2400abd",

--- a/source/includes/openstack/_volumes.md
+++ b/source/includes/openstack/_volumes.md
@@ -80,7 +80,7 @@ curl -X POST \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/volumes"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {
@@ -126,7 +126,7 @@ curl -X POST \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/volumes/52cfc2f8-5b1f-4833-83cd-a77f55c5ed24?operation=attach"
 ```
-> The above command returns JSON structured like this:
+> Request body example:
 
 ```json
 {

--- a/source/includes/openstack/_volumes.md
+++ b/source/includes/openstack/_volumes.md
@@ -164,8 +164,9 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -d "request_body" \
     "https://api.your.cloudmc/v1/services/compute-os/devel/volumes/52cfc2f8-5b1f-4833-83cd-a77f55c5ed24?operation=extend"
-# Request should look like this:
 ```
+> Request body example:
+
 ```json
 {
    "sizeInGB": 40

--- a/source/includes/swift/_containers.md
+++ b/source/includes/swift/_containers.md
@@ -10,9 +10,8 @@ Create and manage your containers/buckets.
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/swift/example/buckets"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -77,9 +76,8 @@ Attributes | &nbsp;
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/swift/example/buckets/private"
-
-# The above command returns JSON structured like this:
 ```
+> The above command returns JSON structured like this:
 
 ```json
 {
@@ -124,9 +122,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/swift/example/buckets"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {
@@ -173,9 +170,8 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/swift/example/buckets/containerToRename?operation=rename"
-
-# Request example:
 ```
+> Request body example:
 
 ```json
 {


### PR DESCRIPTION
### Fixes [MC-10744](https://cloud-ops.atlassian.net/browse/MC-10744)

Note this PR also contains the changes in #133, best to review that one first 

#### Changes made
Format request and response examples
- Use block quotes instead of comments to distinguish between request and response examples
- Use `js` formatting for request examples with comments, which show as an error when `json` is used
- This does not change the syntax highlighting, since slate does not colour key/value pairs differently in `json`

#### UI changes
*Before*
![4-response-api](https://user-images.githubusercontent.com/8960233/80100196-9fe05580-853d-11ea-971f-6b18bac95ad8.jpg)

*After*
![4 1-improvement](https://user-images.githubusercontent.com/8960233/80100206-a53da000-853d-11ea-8ca1-11fdae4092ff.jpg)

#### Related PRs
- #132 
- #133 