### PR TITLE
MC-8055: Fixed the API docs for S2S VPN. The `cidr` is now named `cidrList`

### DIFF
--- a/source/includes/cloudstack/_s2s_vpns.md
+++ b/source/includes/cloudstack/_s2s_vpns.md
@@ -22,7 +22,7 @@ curl -X GET \
         "state": "Connected",
         "vpcId": "3fe7d82a-f4c4-4552-ac3b-787fdafed4e7",
         "gateway":"19.19.19.19",
-        "cidr":"10.12.0.2/22",
+        "cidrList":"10.12.0.2/22,10.0.0.0/24",
         "ipSecPsk": "WtOBS9GRux2XtJPtHY2TUvrv",
         "ikeEncryptionAlgorithm": "aes256",
         "ikeHashAlgorithm": "sha1",
@@ -53,7 +53,7 @@ Attributes | &nbsp;
 `state`<br/>*string* | The state of the site-to-site VPN. Can be Connected, Pending, Disconnected or Error. If disconnected, you can try to use the [reset](#cloudstack-reset-the-connection-of-a-site-to-site-vpn) operation
 `vpcId`<br/>*UUID* | The VPC for which the site-to-site VPN was created.
 `gateway`<br/>*string*  | The gateway of the network you want to connect to. NOTE: you cannot use a gateway that has already been used by a site-to-site VPN in your environment
-`cidr`<br/>*string*  | CIDR of the network you want to connect to.
+`cidrList`<br/>*string*  | Comma-separated list of CIDRs of the networks you want to connect to.
 `ipSecPsk`<br/>*string*  | IPSec pre-shared key.
 `ikeEncryptionAlgorithm`<br/>*string*  | The Internet Key Exchange (IKE) policy for phase-1. The supported encryption algorithms are AES128, AES192, AES256, and 3DES.
 `ikeHashAlgorithm`<br/>*string*  | The IKE hash for phase-1. The supported hash algorithms are SHA1 and MD5.
@@ -89,7 +89,7 @@ curl -X GET \
       "state": "Connected",
       "vpcId": "3fe7d82a-f4c4-4552-ac3b-787fdafed4e7",
       "gateway":"19.19.19.19",
-      "cidr":"10.12.0.2/22",
+      "cidrList":"10.12.0.2/22,10.0.0.0/24",
       "ipSecPsk": "WtOBS9GRux2XtJPtHY2TUvrv",
       "ikeEncryptionAlgorithm": "aes256",
       "ikeHashAlgorithm": "sha1",
@@ -116,7 +116,7 @@ Attributes | &nbsp;
 `state`<br/>*string* | The state of the site-to-site VPN. Can be Connected, Pending, Disconnected or Error. If disconnected, you can try to use the [reset](#cloudstack-reset-the-connection-of-a-site-to-site-vpn) operation
 `vpcId`<br/>*UUID* | The VPC for which the site-to-site VPN was created.
 `gateway`<br/>*string*  | The gateway of the network you want to connect to. NOTE: you cannot use a gateway that has already been used by a site-to-site VPN in your environment
-`cidr`<br/>*string*  | CIDR of the network you want to connect to.
+`cidrList`<br/>*string*  | Comma-separated list of CIDRs of the networks you want to connect to.
 `ipSecPsk`<br/>*string*  | IPSec pre-shared key.
 `ikeEncryptionAlgorithm`<br/>*string*  | The Internet Key Exchange (IKE) policy for phase-1. The supported encryption algorithms are AES128, AES192, AES256, and 3DES.
 `ikeHashAlgorithm`<br/>*string*  | The IKE hash for phase-1. The supported hash algorithms are SHA1 and MD5.
@@ -148,7 +148,7 @@ curl -X POST \
       "name": "stargate",
       "vpcId": "3fe7d82a-f4c4-4552-ac3b-787fdafed4e7",
       "gateway":"19.19.19.19",
-      "cidr":"10.12.0.2/22",
+      "cidrList":"10.12.0.2/22,10.0.0.0/24",
       "ipSecPsk": "WtOBS9GRux2XtJPtHY2TUvrv",
       "ikeEncryptionAlgorithm": "aes256",
       "ikeHashAlgorithm": "sha1",
@@ -171,7 +171,7 @@ Required | &nbsp;
 `name`<br/>*string* | The name of the site-to-site VPN. Must be unique in the environment.
 `vpcId`<br/>*UUID* | The VPC for which the site-to-site VPN was created.
 `gateway`<br/>*string*  | The gateway of the network you want to connect to. NOTE: you cannot use a gateway that has already been used by a site-to-site VPN in your environment
-`cidr`<br/>*string*  | CIDR of the network you want to connect to.
+`cidrList`<br/>*string*  | Comma-separated list of CIDRs of the networks you want to connect to.
 `ipSecPsk`<br/>*string*  | IPSec pre-shared key.
 `ikeEncryptionAlgorithm`<br/>*string*  | The Internet Key Exchange (IKE) policy for phase-1. The supported encryption algorithms are AES128, AES192, AES256, and 3DES.
 `ikeHashAlgorithm`<br/>*string*  | The IKE hash for phase-1. The supported hash algorithms are SHA1 and MD5.
@@ -206,7 +206,7 @@ curl -X PUT \
 {
       "name": "stargate",
       "gateway":"19.19.19.19",
-      "cidr":"10.12.0.2/22",
+      "cidrList":"10.12.0.2/22,10.0.0.0/24",
       "ipSecPsk": "WtOBS9GRux2XtJPtHY2TUvrv",
       "ikeEncryptionAlgorithm": "aes256",
       "ikeHashAlgorithm": "sha1",
@@ -228,7 +228,7 @@ Optional | &nbsp;
 ------ | -----------
 `name`<br/>*string* | The name of the site-to-site VPN. Must be unique in the environment.
 `gateway`<br/>*string*  | The gateway of the network you want to connect to. NOTE: you cannot use a gateway that has already been used by a site-to-site VPN in your environment
-`cidr`<br/>*string*  | CIDR of the network you want to connect to.
+`cidrList`<br/>*string*  | Comma-separated list of CIDRs of the networks you want to connect to.
 `ipSecPsk`<br/>*string*  | IPSec pre-shared key.
 `ikeEncryptionAlgorithm`<br/>*string*  | The Internet Key Exchange (IKE) policy for phase-1. The supported encryption algorithms are AES128, AES192, AES256, and 3DES.
 `ikeHashAlgorithm`<br/>*string*  | The IKE hash for phase-1. The supported hash algorithms are SHA1 and MD5.


### PR DESCRIPTION
### Fixes [MC-8055](https://cloud-ops.atlassian.net/browse/MC-8055)

#### Changes made
<!-- Changes should match the template provided below -->
- Fixed the API docs for S2S VPN. The `cidr` is now named `cidrList

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->