### PR TITLE
MC-10287: Added documentation of the product catalog and pricing

### DIFF
--- a/source/includes/administration/_monetization.md
+++ b/source/includes/administration/_monetization.md
@@ -1,0 +1,1 @@
+## Monetization

--- a/source/includes/administration/_pricings.md
+++ b/source/includes/administration/_pricings.md
@@ -1,0 +1,233 @@
+### Pricings
+
+The pricings determines the price for each product defines for a selected catalogs.
+
+<!-------------------- LIST PRICINGS -------------------->
+#### List pricings
+
+`GET /pricings`
+
+Retrieves a list of pricings configured in the system.
+
+```shell
+# Retrieve pricing list
+curl "https://cloudmc_endpoint/rest/pricings" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "supportedCurrencies": [
+        "CAD"
+      ],
+      "productCatalogs": [
+        {
+          "mode": "ALL_CONNECTIONS_OF_TYPE",
+          "serviceType": "cloudca",
+          "connectionIds": [],
+          "name": {
+            "en": "Default cloud.ca",
+            "fr": "Défaut cloud.ca"
+          },
+          "description": {
+            "en": "cloud.ca default product catalog",
+            "fr": "catalogue des produits cloud.ca par défaut"
+          },
+          "id": "5ba5df7c-1e60-4d99-869d-dd3d97826b2e"
+        },
+      ],
+      "organization": {
+        "id": "409c1162-a930-4207-bdf9-710580c3542b"
+      },
+      "pricingProducts": [
+        {
+          "unitPrice": 123.0,
+          "product": {
+            "metricType": "GAUGE",
+            "unit": {
+              "unit": "HOUR",
+              "name": {}
+            },
+            "period": "HOUR",
+            "name": {
+              "en": "vCPU",
+              "fr": "vCPU"
+            },
+            "transformer": {
+              "type": "PROPORTIONAL_TO_TIME"
+            },
+            "id": "342f0d9b-3c3c-456d-b853-31d713b79e72",
+            "attribute": "RAWUSAGE",
+            "source": "1",
+            "filters": [],
+            "sku": "vCPU",
+            "categoryId": "fcd8908d-e1a0-41f2-9c38-fed1d1f77f18"
+          },
+          "cogs": 321.0,
+          "currency": "CAD",
+          "id": "45425fe6-beb3-4c78-be68-f82eeb3976c6"
+        }
+      ],
+      "name": {
+        "en": "cloud.ca default pricing",
+        "fr": "prix par défaut cloud.ca"
+      },
+      "description": {
+        "en": "cloud.ca default pricing",
+        "fr": "prix par défaut cloud.ca"
+      },
+      "id": "096bbfee-a6e6-4373-8a4e-1a8b0f2bf484",
+      "effectiveDate": "2020-05-08T16:53:45Z"
+    }
+  ]
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the pricing.
+`name`<br/>*Object* | The name object in each language for the pricing (en, fr or es).
+`description`<br/>*string* | The description object in each language for the pricing (en, fr or es).
+`supportedCurrencies`<br/>*Array[string]* | List of the currency which are link to this pricing.
+`productCatalogs`<br/>*Object* | List of product catalog object which are attached to this pricing.
+`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the pricing.
+`pricingProducts`<br/>*Array[Object]* | The list of products assigned to the pricing.
+`pricingProducts.id`<br/>*UUID* | UUID of the product pricing.
+`pricingProducts.unitPrice`<br/>*double* | The unit price of the product.
+`pricingProducts.product`<br/>*Object* | The product attached to this product pricing element.
+`pricingProducts.cogs`<br/>*double* | The Cost Of Goods Sold (COGS) of the product.
+`pricingProducts.currency`<br/>*string* | The currency of the pricing.
+
+
+<!-------------------- GET PRICING -------------------->
+#### Retrieve a pricing
+
+`GET /pricings/:id`
+
+Retrieve a pricing's details.
+
+```shell
+# Retrieve an organization
+curl "https://cloudmc_endpoint/rest/pricings/03bc22bd-adc4-46b8-988d-afddc24c0cb5" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "supportedCurrencies": [
+      "CAD"
+    ],
+    "productCatalogs": [
+      {
+        "mode": "ALL_CONNECTIONS_OF_TYPE",
+        "serviceType": "cloudca",
+        "connectionIds": [],
+        "name": {
+          "en": "Default cloud.ca",
+          "fr": "Défaut cloud.ca"
+        },
+        "changes": [],
+         "description": {
+          "en": "cloud.ca default product catalog",
+          "fr": "catalogue des produits cloud.ca par défaut"
+        },
+        "id": "5ba5df7c-1e60-4d99-869d-dd3d97826b2e",
+        "categories": [
+          {
+            "name": {
+              "en": "Compute",
+              "fr": "Compute"
+            },
+            "id": "fcd8908d-e1a0-41f2-9c38-fed1d1f77f18"
+          }
+        ],
+        "products": [
+          {
+            "metricType": "GAUGE",
+            "unit": {
+              "unit": "HOUR",
+              "name": {}
+            },
+            "period": "HOUR",
+            "name": {
+              "en": "vCPU",
+              "fr": "vCPU"
+            },
+            "transformer": {
+              "type": "PROPORTIONAL_TO_TIME"
+            },
+            "id": "342f0d9b-3c3c-456d-b853-31d713b79e72",
+            "attribute": "RAWUSAGE",
+            "source": "1",
+            "filters": [],
+            "sku": "vCPU",
+            "categoryId": "fcd8908d-e1a0-41f2-9c38-fed1d1f77f18"
+          }
+        ]
+      }
+    ],
+    "organization": {
+      "id": "409c1162-a930-4207-bdf9-710580c3542b"
+    },
+    "pricingProducts": [
+      {
+        "unitPrice": 123.0,
+        "product": {
+          "metricType": "GAUGE",
+          "unit": {
+            "unit": "HOUR",
+            "name": {}
+          },
+          "period": "HOUR",
+          "name": {
+            "en": "sfg",
+            "fr": "sdfg"
+          },
+          "transformer": {
+            "type": "PROPORTIONAL_TO_TIME"
+          },
+          "id": "342f0d9b-3c3c-456d-b853-31d713b79e72",
+          "attribute": "RAWUSAGE",
+          "source": "1",
+          "filters": [],
+          "sku": "sdfg",
+          "categoryId": "fcd8908d-e1a0-41f2-9c38-fed1d1f77f18"
+        },
+        "cogs": 321.0,
+        "currency": "USD",
+        "id": "45425fe6-beb3-4c78-be68-f82eeb3976c6"
+      }
+    ],
+    "name": {
+      "en": "testen",
+      "fr": "testfr"
+    },
+    "description": {
+      "en": "descen",
+      "fr": "testfr"
+    },
+    "id": "096bbfee-a6e6-4373-8a4e-1a8b0f2bf484",
+    "effectiveDate": "2020-05-08T16:53:45Z"
+  }
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the pricing.
+`name`<br/>*Object* | The name object in each language for the pricing (en, fr or es).
+`description`<br/>*string* | The description object in each language for the pricing (en, fr or es).
+`supportedCurrencies`<br/>*Array[string]* | List of the currency which are link to this pricing.
+`productCatalogs`<br/>*Object* | List of product catalog object which are attached to this pricing.
+`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the pricing. It is more detailed.
+`pricingProducts`<br/>*Array[Object]* | The list of products assigned to the pricing.
+`pricingProducts.id`<br/>*UUID* | UUID of the product pricing.
+`pricingProducts.unitPrice`<br/>*double* | The unit price of the product.
+`pricingProducts.product`<br/>*Object* | The product attached to this product pricing element.
+`pricingProducts.cogs`<br/>*double* | The Cost Of Goods Sold (COGS) of the product.
+`pricingProducts.currency`<br/>*string* | The currency of the pricing.

--- a/source/includes/administration/_pricings.md
+++ b/source/includes/administration/_pricings.md
@@ -1,6 +1,6 @@
 ### Pricings
 
-The pricings determines the price for each product defines for a selected catalogs.
+The pricing determines the price for each product defined for a selected catalog.
 
 <!-------------------- LIST PRICINGS -------------------->
 #### List pricings
@@ -89,12 +89,12 @@ curl "https://cloudmc_endpoint/rest/pricings" \
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the pricing.
-`name`<br/>*Object* | The name object in each language for the pricing (en, fr or es).
-`description`<br/>*string* | The description object in each language for the pricing (en, fr or es).
-`supportedCurrencies`<br/>*Array[string]* | List of the currency which are link to this pricing.
-`productCatalogs`<br/>*Object* | List of product catalog object which are attached to this pricing.
+`name`<br/>*Object* | The name object in each language for the pricing.
+`description`<br/>*string* | The description object in each language for the pricing.
+`supportedCurrencies`<br/>*Array[string]* | List of the currencies which are supported by this pricing.
+`productCatalogs`<br/>*Object* | List of product catalog objects which are attached to this pricing.
 `organization.id`<br/>*UUID* | UUID of the organisation to which belongs the pricing.
-`pricingProducts`<br/>*Array[Object]* | The list of products assigned to the pricing.
+`pricingProducts`<br/>*Array[Object]* | The list of product pricings assigned to the pricing.
 `pricingProducts.id`<br/>*UUID* | UUID of the product pricing.
 `pricingProducts.unitPrice`<br/>*double* | The unit price of the product.
 `pricingProducts.product`<br/>*Object* | The product attached to this product pricing element.
@@ -220,12 +220,12 @@ curl "https://cloudmc_endpoint/rest/pricings/03bc22bd-adc4-46b8-988d-afddc24c0cb
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the pricing.
-`name`<br/>*Object* | The name object in each language for the pricing (en, fr or es).
-`description`<br/>*string* | The description object in each language for the pricing (en, fr or es).
-`supportedCurrencies`<br/>*Array[string]* | List of the currency which are link to this pricing.
-`productCatalogs`<br/>*Object* | List of product catalog object which are attached to this pricing.
+`name`<br/>*Object* | The name object in each language for the pricing.
+`description`<br/>*string* | The description object in each language for the pricing.
+`supportedCurrencies`<br/>*Array[string]* | List of the currencies which are supported by this pricing.
+`productCatalogs`<br/>*Object* | List of product catalog objects which are attached to this pricing.
 `organization.id`<br/>*UUID* | UUID of the organisation to which belongs the pricing. It is more detailed.
-`pricingProducts`<br/>*Array[Object]* | The list of products assigned to the pricing.
+`pricingProducts`<br/>*Array[Object]* | The list of product pricings assigned to the pricing.
 `pricingProducts.id`<br/>*UUID* | UUID of the product pricing.
 `pricingProducts.unitPrice`<br/>*double* | The unit price of the product.
 `pricingProducts.product`<br/>*Object* | The product attached to this product pricing element.

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -1,6 +1,6 @@
 ### Product Catalogs
 
-The product catalogs determines the product configured for a service type and maybe specific connections.
+The product catalogs determine the product configured for a service type and optionally for specific connections.
 
 <!-------------------- LIST PRODUCT CATALOGS -------------------->
 #### List product catalogs
@@ -73,22 +73,22 @@ curl "https://cloudmc_endpoint/rest/product_catalogs" \
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the product catalog.
-`name`<br/>*Object* | The name object in each language for the product catalog (en, fr or es).
-`description`<br/>*string* | The description object in each language for the product catalog (en, fr or es).
+`name`<br/>*Object* | The name object in each language for the product catalog.
+`description`<br/>*string* | The description object in each language for the product catalog.
 `mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
-`serviceType`<br/>*Object* | The service connection type to which is bound the product catalog.
-`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection to which the catalog is bound to.
+`serviceType`<br/>*Object* | The service connection type the product catalog is bound to.
+`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
 `changes`<br/>*Array[Object]* | Array of all changes done on the product catalog.
 `categories`<br/>*Array[Object]* | The list of product categories object.
-`categories.id`<br/>*Array[Object]* | The list of product categories object.
-`categories.name`<br/>*Object* | The name object in each language for the category (en, fr or es).
+`categories.id`<br/>*string* | The id of product category object.
+`categories.name`<br/>*Object* | The name object in each language for the category.
 `products`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
 `products.unit`<br/>*Object* | The unit object of the product.
 `products.unit.unit`<br/>*string* | The unit value of the product.
 `products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
 `products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
-`products.name`<br/>*Object* | The name object in each language for the product name (en, fr or es).
+`products.name`<br/>*Object* | The name object in each language for the product name.
 `products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
 `products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
 `products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
@@ -175,22 +175,22 @@ curl "https://cloudmc_endpoint/rest/product_catalogs/03bc22bd-adc4-46b8-988d-afd
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the product catalog.
-`name`<br/>*Object* | The name object in each language for the product catalog (en, fr or es).
-`description`<br/>*string* | The description object in each language for the product catalog (en, fr or es).
+`name`<br/>*Object* | The name object in each language for the product catalog.
+`description`<br/>*string* | The description object in each language for the product catalog.
 `mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
-`serviceType`<br/>*Object* | The service connection type to which is bound the product catalog.
-`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection to which the catalog is bound to.
+`serviceType`<br/>*Object* | The service connection type the product catalog is bound to.
+`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
 `changes`<br/>*Array[Object]* | Array of all changes done on the product catalog.
 `categories`<br/>*Array[Object]* | The list of product categories object.
-`categories.id`<br/>*Array[Object]* | The list of product categories object.
-`categories.name`<br/>*Object* | The name object in each language for the category (en, fr or es).
+`categories.id`<br/>*string* | The id of product category object.
+`categories.name`<br/>*Object* | The name object in each language for the category.
 `products`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
 `products.unit`<br/>*Object* | The unit object of the product.
 `products.unit.unit`<br/>*string* | The unit value of the product.
 `products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
 `products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
-`products.name`<br/>*Object* | The name object in each language for the product name (en, fr or es).
+`products.name`<br/>*Object* | The name object in each language for the product name.
 `products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
 `products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
 `products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -1,0 +1,207 @@
+### Product Catalogs
+
+The product catalogs determines the product configured for a service type and maybe specific connections.
+
+<!-------------------- LIST PRODUCT CATALOGS -------------------->
+#### List product catalogs
+
+`GET /product_catalogs
+
+Retrieves a list of product catalogs configured in the system.
+
+```shell
+# Retrieve product catalog list
+curl "https://cloudmc_endpoint/rest/product_catalogs" \
+   -H "MC-Api-Key: your_api_key"
+```s
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "mode": "ALL_CONNECTIONS_OF_TYPE",
+      "serviceType": "cloudca",
+      "connectionIds": [],
+      "name": {
+        "en": "fgsfdg",
+        "fr": "sfdg"
+      },
+      "changes": [],
+      "description": {
+        "en": "sdfg",
+        "fr": "sdg"
+      },
+      "id": "5ba5df7c-1e60-4d99-869d-dd3d97826b2e",
+      "categories": [
+        {
+          "name": {
+            "en": "sdfg",
+            "fr": "sdfg"
+          },
+          "id": "fcd8908d-e1a0-41f2-9c38-fed1d1f77f18"
+        }
+      ],
+      "products": [
+        {
+          "metricType": "GAUGE",
+          "unit": {
+            "unit": "HOUR",
+            "name": {}
+          },
+          "period": "HOUR",
+          "name": {
+            "en": "vCPU",
+            "fr": "vCPU"
+          },
+          "transformer": {
+            "type": "PROPORTIONAL_TO_TIME"
+          },
+          "id": "342f0d9b-3c3c-456d-b853-31d713b79e72",
+          "attribute": "RAWUSAGE",
+          "source": "1",
+          "filters": [],
+          "sku": "vCPU",
+          "categoryId": "fcd8908d-e1a0-41f2-9c38-fed1d1f77f18"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the product catalog.
+`name`<br/>*Object* | The name object in each language for the product catalog (en, fr or es).
+`description`<br/>*string* | The description object in each language for the product catalog (en, fr or es).
+`mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
+`serviceType`<br/>*Object* | The service connection type to which is bound the product catalog.
+`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection to which the catalog is bound to.
+`changes`<br/>*Array[Object]* | Array of all changes done on the product catalog.
+`categories`<br/>*Array[Object]* | The list of product categories object.
+`categories.id`<br/>*Array[Object]* | The list of product categories object.
+`categories.name`<br/>*Object* | The name object in each language for the category (en, fr or es).
+`products`<br/>*Array[Object]* | The list of products assigned to the catalog.
+`products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
+`products.unit`<br/>*Object* | The unit object of the product.
+`products.unit.unit`<br/>*string* | The unit value of the product.
+`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
+`products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
+`products.name`<br/>*Object* | The name object in each language for the product name (en, fr or es).
+`products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
+`products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
+`products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
+`products.id`<br/>*UUID* | The ID of the product.
+`products.attribute`<br/>*string* | The attribute that will be used to compute usage from the service type usage.
+`products.source`<br/>*strubg* | The source of the usage to get from the service type.
+`products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
+`products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.
+`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION.
+`products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
+`products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
+`products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
+`products.sku`<br/>*string* | The SKU of the product information.
+`products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product.
+
+
+<!-------------------- GET PRODUCT CATALOG -------------------->
+#### Retrieve a product catalog
+
+`GET /product_catalogs/:id`
+
+Retrieve a product catalog's details.
+
+```shell
+# Retrieve an organization
+curl "https://cloudmc_endpoint/rest/product_catalogs/03bc22bd-adc4-46b8-988d-afddc24c0cb5" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "mode": "ALL_CONNECTIONS_OF_TYPE",
+    "serviceType": "cloudca",
+    "connectionIds": [],
+    "name": {
+      "en": "fgsfdg",
+      "fr": "sfdg"
+    },
+    "changes": [],
+    "description": {
+      "en": "sdfg",
+      "fr": "sdg"
+    },
+    "id": "5ba5df7c-1e60-4d99-869d-dd3d97826b2e",
+    "categories": [
+      {
+        "name": {
+          "en": "sdfg",
+          "fr": "sdfg"
+        },
+        "id": "fcd8908d-e1a0-41f2-9c38-fed1d1f77f18"
+      }
+    ],
+    "products": [
+      {
+        "metricType": "GAUGE",
+        "unit": {
+          "unit": "HOUR",
+          "name": {}
+        },
+        "period": "HOUR",
+        "name": {
+          "en": "vCPU",
+          "fr": "vCPU"
+        },
+        "transformer": {
+          "type": "PROPORTIONAL_TO_TIME"
+        },
+        "id": "342f0d9b-3c3c-456d-b853-31d713b79e72",
+        "attribute": "RAWUSAGE",
+        "source": "1",
+        "filters": [],
+        "sku": "vCPU",
+        "categoryId": "fcd8908d-e1a0-41f2-9c38-fed1d1f77f18"
+      }
+    ]
+  }
+}
+
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the product catalog.
+`name`<br/>*Object* | The name object in each language for the product catalog (en, fr or es).
+`description`<br/>*string* | The description object in each language for the product catalog (en, fr or es).
+`mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
+`serviceType`<br/>*Object* | The service connection type to which is bound the product catalog.
+`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection to which the catalog is bound to.
+`changes`<br/>*Array[Object]* | Array of all changes done on the product catalog.
+`categories`<br/>*Array[Object]* | The list of product categories object.
+`categories.id`<br/>*Array[Object]* | The list of product categories object.
+`categories.name`<br/>*Object* | The name object in each language for the category (en, fr or es).
+`products`<br/>*Array[Object]* | The list of products assigned to the catalog.
+`products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
+`products.unit`<br/>*Object* | The unit object of the product.
+`products.unit.unit`<br/>*string* | The unit value of the product.
+`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
+`products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
+`products.name`<br/>*Object* | The name object in each language for the product name (en, fr or es).
+`products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
+`products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
+`products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
+`products.id`<br/>*UUID* | The ID of the product.
+`products.attribute`<br/>*string* | The attribute that will be used to compute usage from the service type usage.
+`products.source`<br/>*strubg* | The source of the usage to get from the service type.
+`products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
+`products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.
+`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION.
+`products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
+`products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
+`products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
+`products.sku`<br/>*string* | The SKU of the product information.
+`products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -15,6 +15,9 @@ includes:
   - administration/environments 
   - administration/resource_commitments
   - administration/usage
+  - administration/monetization
+  - administration/products
+  - administration/pricings
   - cloudstack
   - cloudstack/compute # Compute section
   - cloudstack/instances


### PR DESCRIPTION
### Fixes [MC-10287](https://cloud-ops.atlassian.net/browse/MC-10287)

#### Changes made
<!-- Changes should match the template provided below -->
- Added the product catalog api documentation for list and retrieve
- Added the pricing api documentation for list and retrieve

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->