### PR TITLE
MC-10744: AR fixes for docs template

### DIFF
--- a/source/includes/_getting_started.md
+++ b/source/includes/_getting_started.md
@@ -78,9 +78,9 @@ When an API request is successful, the response body will contain the `data` fie
 
 Attributes | &nbsp;
 --- | ---
-`data` | The data field contains the object requested by the API caller
-`taskId` | The [task id](#tasks) of an operation executed through the services API
-`taskStatus` | The status of a [task](#tasks) of an operation executed the services API
+`data` | The data field contains the object requested by the API caller.
+`taskId` | The [task id](#tasks) of an operation executed through the services API.
+`taskStatus` | The status of a [task](#tasks) of an operation executed the services API.
 <!--
 `metadata` | The metadata is an optionally returned field containing paging and sorting information
 -->
@@ -90,6 +90,7 @@ If the response contains the "errors" field, the request was <strong>not</strong
 </aside>
 
 ### Error response
+> The error JSON response is structured like this:
 
 ```json
 {
@@ -114,22 +115,22 @@ When an API request is unsuccessful, the response body will contain the `errors`
 
 Attributes | &nbsp;
 --- | ---
-`errors` | A list of errors objects that contain information about each error
+`errors` | A list of errors objects that contain information about each error.
 
 Each error has additional fields to describe it :
 
 Attributes | &nbsp;
 --- | ---
-`code` | The CloudMC error code
-`message` | A human readable explanation of the error code
-`context` | Additional information
+`code` | The CloudMC error code.
+`message` | A human readable explanation of the error code.
+`context` | Additional information.
 
 The HTTP status codes of error responses :
 
 Status code | Reason
 ----------- | -------
 `200` | The request was successful.
-`204` | The request was successful and the response body is empty
+`204` | The request was successful and the response body is empty.
 `400` | Bad request -- Occurs when invalid parameters are provided or when quota limit is exceeded.
 `403` | Forbidden -- Not authorized to perform this request.
 `404` | Not Found -- Cannot locate the specified endpoint.

--- a/source/includes/_getting_started.md
+++ b/source/includes/_getting_started.md
@@ -90,8 +90,9 @@ If the response contains the "errors" field, the request was <strong>not</strong
 </aside>
 
 ### Error response
-> The error JSON response is structured like this:
-
+```shell
+# Example of error response
+```
 ```json
 {
   "errors": [

--- a/source/includes/administration/_environments.md
+++ b/source/includes/administration/_environments.md
@@ -50,13 +50,13 @@ List environments that you have access to. It will only return environments that
 
 Attributes | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of the environment
-`name`<br/>*string* | The name of the environment
-`description`<br/>*string* | The description of the environment
+`id`<br/>*UUID* | The id of the environment.
+`name`<br/>*string* | The name of the environment.
+`description`<br/>*string* | The description of the environment.
 `membership`<br/>*string* | Type of membership of the environment. (e.g. ALL_ORG_USERS, MANY_USERS)
-`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the environment was created
-`organization`<br/>*[Organization](#administration-organizations)* | The organization of the environment<br/>*includes*: `id`, `name`, `entryPoint`
-`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection of the environment<br/>*includes*: `id`, `name`
+`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the environment was created.
+`organization`<br/>*[Organization](#administration-organizations)* | The organization of the environment.<br/>*includes*: `id`, `name`, `entryPoint`
+`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection of the environment.<br/>*includes*: `id`, `name`
 `roles`<br/>*Array[[Role](#administration-roles)]* | The roles of the environment with all the users assigned to them.<br/>*includes*: `id`, `name`, `isDefault`, `users.id`, `users.name`
 
 
@@ -108,18 +108,18 @@ curl "https://cloudmc_endpoint/v1/environment/487a2745-bb8a-44bc-adb1-e3b048f6de
 }
 ```
 
-Retrieve an environment you have access to. You can always retrieve environments that you're member of but to access other environments you will need the `Environments read` permission.
+Retrieve an environment you have access to. You can always retrieve environments that you're a member of but to access other environments you will need the `Environments read` permission.
 
 Attributes | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of the environment
-`name`<br/>*string* | The name of the environment
-`description`<br/>*string* | The description of the environment
+`id`<br/>*UUID* | The id of the environment.
+`name`<br/>*string* | The name of the environment.
+`description`<br/>*string* | The description of the environment.
 `membership`<br/>*string* | Type of membership of the environment. (e.g. ALL_ORG_USERS, MANY_USERS)
-`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the environment was created
-`organization`<br/>*[Organization](#administration-organizations)* | The organization of the environment<br/>*includes*: `id`, `name`, `entryPoint`
-`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection of the environment<br/>*includes*: `id`, `name`
-`users`<br/>*Array[[User](#administration-users)]* | The users that are members of the environment<br/>*includes*: `id`, `username`
+`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the environment was created.
+`organization`<br/>*[Organization](#administration-organizations)* | The organization of the environment.<br/>*includes*: `id`, `name`, `entryPoint`
+`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection of the environment.<br/>*includes*: `id`, `name`
+`users`<br/>*Array[[User](#administration-users)]* | The users that are members of the environment.<br/>*includes*: `id`, `username`
 `roles`<br/>*Array[[Role](#administration-roles)]* | The roles of the environment with all the users assigned to them.<br/>*includes*: `id`, `name`, `isDefault`, `users.id`, `users.name`
 
 <!-------------------- CREATE ENVIRONMENT -------------------->
@@ -166,12 +166,12 @@ Required | &nbsp;
 -------- | -----------
 `name`<br/>*string* | The name of the new environment. Should be unique in the environment and only contain lower case characters, numbers, dashes and underscores.
 `description`<br/>*string* | The description of the new environment.
-`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection that the environment should be created in<br/>*required*: `id`
+`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection that the environment should be created in.<br/>*required*: `id`
 
 Optional | &nbsp;
 -------- | -----------
-`organization`<br/>*[Organization](#administration-organizations)* | The organization that the environment should be created in. *Defaults to your organization*<br/>*required*: `id`
-`membership`<br/>*string* | Type of membership of the environment. ALL_ORG_USERS will add every user in the organization to this environment with the default role. MANY_USERS will allow you to  choose the users you want in the environment and assigned them specific roles. *Defaults to MANY_USERS*
+`organization`<br/>*[Organization](#administration-organizations)* | The organization that the environment should be created in. *Defaults to your organization*.<br/>*required*: `id`
+`membership`<br/>*string* | Type of membership of the environment. ALL_ORG_USERS will add every user in the organization to this environment with the default role. MANY_USERS will allow you to  choose the users you want in the environment and assigned them specific roles. *Defaults to MANY_USERS*.
 `roles`<br/>*Array[[Role](#administration-roles)]* | The roles of the environment and the users assigned to them. Also, defines the default role of the environment.<br/>*required*: `name`, `users.id`<br/>*optional*: `isDefault`
 
 
@@ -211,8 +211,8 @@ curl -X POST "https://cloudmc_endpoint/v1/environments/f9dea588-d7ab-4f42-b6e6-4
 Optional | &nbsp;
 -------- | -----------
 `name`<br/>*string* | The updated name of the environment. Should be unique in the environment and only contain lower case characters, numbers, dashes and underscores.
-`description`<br/>*string* | The updated description of the environment
-`membership`<br/>*string* | Type of membership of the environment. ALL_ORG_USERS will add every user in the organization to this environment with the default role. MANY_USERS will allow you to  choose the users you want in the environment and assigned them specific roles. *Defaults to MANY_USERS*
+`description`<br/>*string* | The updated description of the environment.
+`membership`<br/>*string* | Type of membership of the environment. ALL_ORG_USERS will add every user in the organization to this environment with the default role. MANY_USERS will allow you to choose the users you want in the environment and assigned them specific roles. *Defaults to MANY_USERS*.
 `roles`<br/>*Array[[Role](#administration-roles)]* | Update the users roles in the environment. Also, can also update the default role.<br/>*required*: `name`, `users.id`<br/>*optional*: `isDefault`
 
 

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -1,5 +1,5 @@
 ## Organizations
-Organizations are the largest logical grouping of users, environments and resources available in CloudMC. Each organization is isolated from other organizations. It has its own subdomain (`[entryPoint].CloudMC`) and is protected by its own customizable system [roles](#administration-roles). An administrator that must manage it's sub-organizations environments or provisioned resources can do so by having the `Access other levels` permission. Additionally, provisioned resource usage is metered at the organization level facilitating cost tracking.
+Organizations are the largest logical grouping of users, environments and resources available in CloudMC. Each organization is isolated from other organizations. It has its own subdomain (`[entryPoint].CloudMC`) and is protected by its own customizable system [roles](#administration-roles). An administrator that must manage its sub-organizations environments or provisioned resources can do so by having the `Access other levels` permission. Additionally, provisioned resource usage is metered at the organization level facilitating cost tracking.
 
 
 <!-------------------- LIST ORGANIZATIONS -------------------->
@@ -59,17 +59,17 @@ curl "https://cloudmc_endpoint/v1/organizations" \
 
 Attributes | &nbsp;
 ---- | -----------
-`id`<br/>*UUID* | ---
-`name`<br/>*string* | ---
-`entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL : `[entryPoint].CloudMC`
-`billableStartDate`<br/>*string* | The billable start date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) of the organization
-`isBillable`<br/>*boolean* | If the organization is billable this values is true, false otherwise
-`tags`<br/>*Array[string]* | Tags associated to the organization
-`parent`<br/>*[Organization](#administration-organizations)* | If the organization is a sub-organization, it will have it's `parent` organization. *includes*:`id`,`name`
-`environments`<br/>*Array[[Environment](#administration-environments)]* | The environments belonging to the organization<br/>*includes*: `id`
-`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environments roles belonging to the organization<br/>*includes*: `id`
-`serviceConnections`<br/>*Array[[ServiceConnection](#administration-service-connections)]* | The services for which the organization is allowed to provision resources<br/>*includes*: `id`,`serviceCode`
-`users`<br/>*Array[[User](#administration-users)]* | The users of the organization<br/>*includes*: `id`
+`id`<br/>*UUID* | The id of the organization.
+`name`<br/>*string* | The name of the organization.
+`entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL : `[entryPoint].CloudMC`.
+`billableStartDate`<br/>*string* | The billable start date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) of the organization.
+`isBillable`<br/>*boolean* | If the organization is billable this values is true, false otherwise.
+`tags`<br/>*Array[string]* | Tags associated to the organization.
+`parent`<br/>*[Organization](#administration-organizations)* | If the organization is a sub-organization, it will have its `parent` organization. *includes*:`id`,`name`.
+`environments`<br/>*Array[[Environment](#administration-environments)]* | The environments belonging to the organization.<br/>*includes*: `id`
+`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environments roles belonging to the organization.<br/>*includes*: `id`
+`serviceConnections`<br/>*Array[[ServiceConnection](#administration-service-connections)]* | The services for which the organization is allowed to provision resources.<br/>*includes*: `id`,`serviceCode`
+`users`<br/>*Array[[User](#administration-users)]* | The users of the organization.<br/>*includes*: `id`
 
 <!-------------------- FIND ORGANIZATION -------------------->
 ### Retrieve an organization
@@ -126,17 +126,17 @@ curl "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c
 
 Attributes | &nbsp;
 ---- | -----------
-`id`<br/>*UUID* | ---
-`name`<br/>*string* | ---
-`entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL :<br/>`[entryPoint].CloudMC`
-`billableStartDate`<br/>*string* | The billable start date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) of the organization
-`isBillable`<br/>*boolean* | If the organization is billable this values is true, false otherwise
-`tags`<br/>*Array[string]* | Tags associated to the organization
-`parent`<br/>*[Organization](#administration-organizations)* | If the organization is a sub-organization, it will have it's `parent` organization. *includes*:`id`,`name`
-`environments`<br/>*Array[[Environment](#administration-environments)]* | The environments belonging to the organization<br/>*includes*: `id`
-`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environments roles belonging to the organization<br/>*includes*: `id`
-`serviceConnections`<br/>*Array[[ServiceConnection](#administration-service-connections)]* | The services for which the organization is allowed to provision resources<br/>*includes*: `id`,`serviceCode`
-`users`<br/>*Array[[User](#administration-users)]* | The users of the organization<br/>*includes*: `id`
+`id`<br/>*UUID* | The id of the organization.
+`name`<br/>*string* | The name of the organization.
+`entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL :<br/>`[entryPoint].CloudMC`.
+`billableStartDate`<br/>*string* | The billable start date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) of the organization.
+`isBillable`<br/>*boolean* | If the organization is billable this values is true, false otherwise.
+`tags`<br/>*Array[string]* | Tags associated to the organization.
+`parent`<br/>*[Organization](#administration-organizations)* | If the organization is a sub-organization, it will have its `parent` organization. *includes*:`id`,`name`.
+`environments`<br/>*Array[[Environment](#administration-environments)]* | The environments belonging to the organization.<br/>*includes*: `id`
+`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environments roles belonging to the organization.<br/>*includes*: `id`
+`serviceConnections`<br/>*Array[[ServiceConnection](#administration-service-connections)]* | The services for which the organization is allowed to provision resources.<br/>*includes*: `id`,`serviceCode`
+`users`<br/>*Array[[User](#administration-users)]* | The users of the organization.<br/>*includes*: `id`
 
 <!-------------------- CREATE ORGANIZATION -------------------->
 ### Create organization
@@ -172,7 +172,7 @@ curl -X POST "https://cloudmc_endpoint/v1/organizations" \
 Required | &nbsp;
 ---- | ----
 `name`<br/>*string*  | The name of the organization. (Add info about restrictions)
-`entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL : `[entryPoint].CloudMC`
+`entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL : `[entryPoint].CloudMC`.
 
 
 Optional | &nbsp;
@@ -180,13 +180,13 @@ Optional | &nbsp;
 `serviceConnections`<br/>Array[[ServiceConnection](#administration-service-connections)] | A list of service connections for which the organization may provision resources.<br/>*required :*`id`
 `parent`<br/>[Organization](#administration-organization) | The organization that will be the parent of the new organization. By default, it will default to the caller's organization.<br/>*required :*`id`
 
-The responses' `data` field contains the created [organization](#administration-organizations) with it's `id`.
+The responses' `data` field contains the created [organization](#administration-organizations) with its `id`.
 
 <!-------------------- UPDATE ORGANIZATION -------------------->
 ### Update organization
 `PUT /organizations/:id`
 
-Update an organization. It's parent organization cannot be changed. It can be assigned service connections.
+Update an organization. Its parent organization cannot be changed. It can be assigned service connections.
 
 ```shell
 # Update an organization
@@ -212,7 +212,7 @@ curl -X PUT "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-a
 Required | &nbsp;
 ---- | ----
 `name`<br/>*string*  | The name of the organization. (Add info about restrictions)
-`entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL : `[entryPoint].CloudMC`
+`entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL : `[entryPoint].CloudMC`.
 
 Optional | &nbsp;
 ---- | ----

--- a/source/includes/administration/_resource_commitments.md
+++ b/source/includes/administration/_resource_commitments.md
@@ -77,20 +77,20 @@ An array of resource commitments with the following attributes are returned.
 
 Attributes | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of the resource commitment
-`displayName`<br/>*string* | The name of the resource commitment
-`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the resource commitment was created
-`startDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) from when the resource commitment becomes active
-`endDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) until when the resource commitment will be active<br/>*optional*: `if not present then the commitment has no end date`
-`pricingMethod`<br/>*string* | One of the two following options that define how the effective price for the resource commitment is calculated<br/>*FIXED_MONTHLY*: `a fixed price per billing cycle`<br/>*VARIABLE_UTILITY_DISCOUNT*: `pricing with custom discount on specific resources`
-`currency`<br/>*string* | The currency type based on which the pricing is defined
-`monthlyPrice`<br/>*number* | The effective monthly price for this resource commitment
-`effectiveDiscount`<br/>*number* | The effective discount percentage (%) on this resource commitment
-`billableHoursPerMonth`<br/>*number* | The number hours per month based on which the monthly price is calculated<br/>*optional*: `not present if the pricing method is FIXED_MONTHLY`
-`billingDay`<br/>*number* | The day of the month based on which the billing cycle is calculated
+`id`<br/>*UUID* | The id of the resource commitment.
+`displayName`<br/>*string* | The name of the resource commitment.
+`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the resource commitment was created.
+`startDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) from when the resource commitment becomes active.
+`endDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) until when the resource commitment will be active.<br/>*optional*: `if not present then the commitment has no end date`
+`pricingMethod`<br/>*string* | One of the two following options that define how the effective price for the resource commitment is calculated.<br/>*FIXED_MONTHLY*: `a fixed price per billing cycle`<br/>*VARIABLE_UTILITY_DISCOUNT*: `pricing with custom discount on specific resources`
+`currency`<br/>*string* | The currency type based on which the pricing is defined.
+`monthlyPrice`<br/>*number* | The effective monthly price for this resource commitment.
+`effectiveDiscount`<br/>*number* | The effective discount percentage (%) on this resource commitment.
+`billableHoursPerMonth`<br/>*number* | The number hours per month based on which the monthly price is calculated.<br/>*optional*: `not present if the pricing method is FIXED_MONTHLY`
+`billingDay`<br/>*number* | The day of the month based on which the billing cycle is calculated.
 `resourceCommitmentDetails`<br/>*Array [Commitment detail]* | The resources on which different commitment levels _(and discounts)_ have been set.<br/>*includes*: `id`, `name`, `primaryType`, `secondaryType`, `commitment`, `discountPercent`, `unit`, `labelKey`
-`organization`<br/>*[Organization](#administration-organizations)* | The organization on whose connection the resource commitment is defined<br/>*includes*: `id`, `name`
-`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection on which the resource commitment is defined<br/>*includes*: `id`, `name`, `type`
+`organization`<br/>*[Organization](#administration-organizations)* | The organization on whose connection the resource commitment is defined.<br/>*includes*: `id`, `name`
+`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection on which the resource commitment is defined.<br/>*includes*: `id`, `name`, `type`
 
 
 <!-------------------- GET A RESOURCE COMMITMENT -------------------->
@@ -163,20 +163,20 @@ Retrieve a specific resource commitment you have access to. You can only retriev
 
 Attributes | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of the resource commitment
-`displayName`<br/>*string* | The name of the resource commitment
-`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the resource commitment was created
-`startDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) from when the resource commitment becomes active
-`endDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) until when the resource commitment will be active<br/>*optional*: `if not present then the commitment has no end date`
-`pricingMethod`<br/>*string* | One of the two following options that define how the effective price for the resource commitment is calculated<br/>*FIXED_MONTHLY*: `a fixed price per billing cycle`<br/>*VARIABLE_UTILITY_DISCOUNT*: `pricing with custom discount on specific resources`
-`currency`<br/>*string* | The currency type based on which the pricing is defined
-`monthlyPrice`<br/>*number* | The effective monthly price for this resource commitment
-`effectiveDiscount`<br/>*number* | The effective discount on this resource commitment
-`billableHoursPerMonth`<br/>*number* | The number hours per month based on which the monthly price is calculated<br/>*optional*: `not present if the pricing method is FIXED_MONTHLY`
-`billingDay`<br/>*number* | The day of the month based on which the billing cycle is calculated
+`id`<br/>*UUID* | The id of the resource commitment.
+`displayName`<br/>*string* | The name of the resource commitment.
+`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the resource commitment was created.
+`startDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) from when the resource commitment becomes active.
+`endDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) until when the resource commitment will be active.<br/>*optional*: `if not present then the commitment has no end date`
+`pricingMethod`<br/>*string* | One of the two following options that define how the effective price for the resource commitment is calculated.<br/>*FIXED_MONTHLY*: `a fixed price per billing cycle`<br/>*VARIABLE_UTILITY_DISCOUNT*: `pricing with custom discount on specific resources`
+`currency`<br/>*string* | The currency type based on which the pricing is defined.
+`monthlyPrice`<br/>*number* | The effective monthly price for this resource commitment.
+`effectiveDiscount`<br/>*number* | The effective discount on this resource commitment.
+`billableHoursPerMonth`<br/>*number* | The number hours per month based on which the monthly price is calculated.<br/>*optional*: `not present if the pricing method is FIXED_MONTHLY`
+`billingDay`<br/>*number* | The day of the month based on which the billing cycle is calculated.
 `resourceCommitmentDetails`<br/>*Array [Commitment detail]* | The resources on which different commitment levels _(and discounts)_ have been set.<br/>*includes*: `id`, `name`, `primaryType`, `secondaryType`, `commitment`, `discountPercent`, `unit`, `labelKey`
-`organization`<br/>*[Organization](#administration-organizations)* | The organization on whose connection the resource commitment is defined<br/>*includes*: `id`, `name`
-`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection on which the resource commitment is defined<br/>*includes*: `id`, `name`, `type`
+`organization`<br/>*[Organization](#administration-organizations)* | The organization on whose connection the resource commitment is defined.<br/>*includes*: `id`, `name`
+`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection on which the resource commitment is defined.<br/>*includes*: `id`, `name`, `type`
 
 <!-------------------- CREATE A RESOURCE COMMITMENT -------------------->
 
@@ -234,17 +234,17 @@ Create a new resource commitment defined on a service connection. You will need 
 
 Required | &nbsp;
 -------- | -----------
-`displayName`<br/>*string* | The name of the resource commitment
-`startDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) from when the resource commitment becomes active
-`endDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) until when the resource commitment will be active<br/>*optional*: `if not present then the commitment has no end date`
-`pricingMethod`<br/>*string* | One of the two following options that define how the effective price for the resource commitment is calculated<br/>*FIXED_MONTHLY*: `a fixed price per billing cycle`<br/>*VARIABLE_UTILITY_DISCOUNT*: `pricing with custom discount on specific resources`
-`currency`<br/>*string* | The currency type based on which the pricing is defined
-`monthlyPrice`<br/>*number* | The effective monthly price for this resource commitment
-`billableHoursPerMonth`<br/>*number* | The number hours per month based on which the monthly price is calculated<br/>*optional*: `only required if the pricing method is VARIABLE_UTILITY_DISCOUNT`
-`billingDay`<br/>*number* | The day of the month based on which the billing cycle is calculated
+`displayName`<br/>*string* | The name of the resource commitment.
+`startDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) from when the resource commitment becomes active.
+`endDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) until when the resource commitment will be active.<br/>*optional*: `if not present then the commitment has no end date`
+`pricingMethod`<br/>*string* | One of the two following options that define how the effective price for the resource commitment is calculated.<br/>*FIXED_MONTHLY*: `a fixed price per billing cycle`<br/>*VARIABLE_UTILITY_DISCOUNT*: `pricing with custom discount on specific resources`
+`currency`<br/>*string* | The currency type based on which the pricing is defined.
+`monthlyPrice`<br/>*number* | The effective monthly price for this resource commitment.
+`billableHoursPerMonth`<br/>*number* | The number hours per month based on which the monthly price is calculated.<br/>*optional*: `only required if the pricing method is VARIABLE_UTILITY_DISCOUNT`
+`billingDay`<br/>*number* | The day of the month based on which the billing cycle is calculated.
 `resourceCommitmentDetails`<br/>*Array [Commitment detail]* | The resources on which different commitment levels _(and discounts)_ have been set.<br/>*must include*: `primaryType`, `secondaryType`, `commitment`, `discountPercent`
-`organization`<br/>*[Organization](#administration-organizations)* | The organization on whose connection the resource commitment is to be defined<br/>*must include*: `id`
-`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection on which the resource commitment is to be defined<br/>*must include*: `id`
+`organization`<br/>*[Organization](#administration-organizations)* | The organization on whose connection the resource commitment is to be defined.<br/>*must include*: `id`
+`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection on which the resource commitment is to be defined.<br/>*must include*: `id`
 
 
 The responses' `data` field contains the created [resource-commitment](#administration-retrieve-a-resource-commitment).
@@ -309,18 +309,18 @@ curl -X PUT "https://cloudmc_endpoint/v1/resource_commitments/fbgc7647-71e6-w69b
 
 Attributes | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of the resource commitment
-`displayName`<br/>*string* | The name of the resource commitment
-`startDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) from when the resource commitment becomes active
-`endDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) until when the resource commitment will be active<br/>*optional*: `if not present then the commitment has no end date`
-`pricingMethod`<br/>*string* | One of the two following options that define how the effective price for the resource commitment is calculated<br/>*FIXED_MONTHLY*: `a fixed price per billing cycle`<br/>*VARIABLE_UTILITY_DISCOUNT*: `pricing with custom discount on specific resources`
-`currency`<br/>*string* | The currency type based on which the pricing is defined
-`monthlyPrice`<br/>*number* | The effective monthly price for this resource commitment
-`billableHoursPerMonth`<br/>*number* | The number hours per month based on which the monthly price is calculated<br/>*optional*: `only required if the pricing method is VARIABLE_UTILITY_DISCOUNT`
-`billingDay`<br/>*number* | The day of the month based on which the billing cycle is calculated
+`id`<br/>*UUID* | The id of the resource commitment.
+`displayName`<br/>*string* | The name of the resource commitment.
+`startDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) from when the resource commitment becomes active.
+`endDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) until when the resource commitment will be active.<br/>*optional*: `if not present then the commitment has no end date`
+`pricingMethod`<br/>*string* | One of the two following options that define how the effective price for the resource commitment is calculated.<br/>*FIXED_MONTHLY*: `a fixed price per billing cycle`<br/>*VARIABLE_UTILITY_DISCOUNT*: `pricing with custom discount on specific resources`
+`currency`<br/>*string* | The currency type based on which the pricing is defined.
+`monthlyPrice`<br/>*number* | The effective monthly price for this resource commitment.
+`billableHoursPerMonth`<br/>*number* | The number hours per month based on which the monthly price is calculated.<br/>*optional*: `only required if the pricing method is VARIABLE_UTILITY_DISCOUNT`
+`billingDay`<br/>*number* | The day of the month based on which the billing cycle is calculated.
 `resourceCommitmentDetails`<br/>*Array [Commitment detail]* | The resources on which different commitment levels _(and discounts)_ have been set.<br/>*includes*: `id`, `primaryType`, `secondaryType`, `commitment`, `discountPercent`
-`organization`<br/>*[Organization](#administration-organizations)* | The organization on whose connection the resource commitment to be edited is defined<br/>*includes*: `id`
-`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection on which the resource commitment to be edited is defined<br/>*includes*: `id`
+`organization`<br/>*[Organization](#administration-organizations)* | The organization on whose connection the resource commitment to be edited is defined.<br/>*includes*: `id`
+`serviceConnection`<br/>*[ServiceConnection](#administration-service-connections)* | The service connection on which the resource commitment to be edited is defined.<br/>*includes*: `id`
 
 
 The responses' `data` field contains the created [resource-commitment](#administration-retrieve-a-resource-commitment). You will need the `Commitments: Manage` permission to execute this operation.

--- a/source/includes/administration/_roles.md
+++ b/source/includes/administration/_roles.md
@@ -59,10 +59,10 @@ curl "https://cloudmc_endpoint/rest/roles?v=v2&environment_id=4865a023-1dd5-45a3
 
 Query Params | &nbsp;
 ---- | -----------
-`filter_scope`<br/>*[ScopeQualifier](#administration-scopequalifier)* | Return only roles with this as the default scope
-`system_only`<br/>*boolean* | Return only system roles
-`organization_id`<br/>*UUID* | Return only roles requesting user can assign on this organization
-`environment_id`<br/>*UUID* | Filters out env-scoped roles applicated to this environment. If an environment is of a plugin type that has custom plugin roles it only returns the plugin's roles, if the environment has no plugin defined roles it returns only the default environment-scoped roles 
+`filter_scope`<br/>*[ScopeQualifier](#administration-scopequalifier)* | Return only roles with this as the default scope.
+`system_only`<br/>*boolean* | Return only system roles.
+`organization_id`<br/>*UUID* | Return only roles requesting user can assign on this organization.
+`environment_id`<br/>*UUID* | Filters out env-scoped roles applicated to this environment. If an environment is of a plugin type that has custom plugin roles it only returns the plugin's roles, if the environment has no plugin defined roles it returns only the default environment-scoped roles.
 
 ### ScopeQualifier 
 * `ENV`

--- a/source/includes/administration/_service_connections.md
+++ b/source/includes/administration/_service_connections.md
@@ -24,11 +24,11 @@ Service connections are the services that you can create resources for (e.g. com
 
 Attributes | &nbsp;
 ---- | -----------
-`id`<br/>*UUID* | The id of the service connection
+`id`<br/>*UUID* | The id of the service connection.
 `serviceCode`<br/>*string* | The service code of the service connection. It is used in the endpoint of the services API.
-`name`<br/>*string* | The name of the service connection
+`name`<br/>*string* | The name of the service connection.
 `type`<br/>*string* | The type of the service connection.
-`status`<br/>*Object* | Status of the service connection. Tells you if the service is up.<br/>*includes*: `lastUpdated`, `reachable`
+`status`<br/>*Object* | Status of the service connection. Tells you if the service is up.<br/>*includes*: `lastUpdated`, `reachable`.
 
 <!-------------------- GET SERVICE CONNECTION -------------------->
 
@@ -53,11 +53,11 @@ Attributes | &nbsp;
 
 Attributes | &nbsp;
 ---- | -----------
-`id`<br/>*UUID* | The id of the service connection
+`id`<br/>*UUID* | The id of the service connection.
 `serviceCode`<br/>*string* | The service code of the service connection. It is used in the endpoint of the services API.
-`name`<br/>*string* | The name of the service connection
+`name`<br/>*string* | The name of the service connection.
 `type`<br/>*string* | The type of the service connection.
-`status`<br/>*Object* | Status of the service connection. Tells you if the service is up.<br/>*includes*: `lastUpdated`, `reachable`
+`status`<br/>*Object* | Status of the service connection. Tells you if the service is up.<br/>*includes*: `lastUpdated`, `reachable`.
 
 <!-------------------- GET CONNECTION POLICY DESCRIPTORS -------------------->
 
@@ -121,11 +121,11 @@ curl "https://cloudmc_endpoint/v1/services/connections/03bc22bd-adc4-46b8-988d-a
 
 Attributes | &nbsp;
 ---- | -----------
-`name`<br/>*string* | The name of the policy section
+`name`<br/>*string* | The name of the policy section.
 `label`<br/>*string* | The label key for the policy section name.
 `formElements`<br/>*Array* | The FormElements returned by the policy section. Form elements are only returned for a given section if the query param `section` matches the name of a policy section.  
 `optional`<br/>*boolean* | Specifies if the policy section is required or not.
-`entity`<br/> *Object* | The service connection entity which includes a string to string map of the ServiceConnectionPolicy::name to ServiceConnectionPolicy::value
+`entity`<br/> *Object* | The service connection entity which includes a string to string map of the `ServiceConnectionPolicy::name` to `ServiceConnectionPolicy::value`.
 
 
 <!-------------------- UPDATE CONNECTION POLICIES -------------------->
@@ -197,8 +197,8 @@ Returns the list of organizations that are assigned to the service connection. O
 
 Attributes | &nbsp;
 ---- | -----------
-`id`<br/>*UUID* | The id of the organization
-`name`<br/>*string* | The name of the organization
-`entryPoint`<br/>*string* | The entry point of the organization. Also refered to as the organization code
+`id`<br/>*UUID* | The id of the organization.
+`name`<br/>*string* | The name of the organization.
+`entryPoint`<br/>*string* | The entry point of the organization. Also refered to as the organization code.
 `state`<br/>*string* | The provisioning state of the organization on the backend service. States: `PENDING`, `PROVISIONING`, `PROVISIONED`, `PENDING_PURGE`, `PURGING`, `PURGED`.
 `quota`<br/>*Object* | The quota assigned to the organization (may be null depending on if the connection supports quotas or not).<br/>*includes*: `id`, `name`

--- a/source/includes/administration/_usage.md
+++ b/source/includes/administration/_usage.md
@@ -47,13 +47,13 @@ Retrieve the usage summary records for an organization and all of its sub-organi
 
 Attributes | &nbsp;
 ---- | -----------
-`organizationId`<br/>*UUID* | Id of the [organization](#administration-organizations)
-`serviceConnectionId`<br/>*UUID* | Id of the [service connection](#administration-service-connections)
-`serviceConnectionPricingId`<br/>*UUID* | Id of the service connection pricing
-`utilityCost`<br/>*string* | Utility cost of the record (aggregated per the period)
-`utilityUsage`<br/>*string* | Utility usage of the record
-`startDate`<br/>*string* | Start date of the record in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-`endDate`<br/>*string* | End date of the record in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+`organizationId`<br/>*UUID* | Id of the [organization](#administration-organizations).
+`serviceConnectionId`<br/>*UUID* | Id of the [service connection](#administration-service-connections).
+`serviceConnectionPricingId`<br/>*UUID* | Id of the service connection pricing.
+`utilityCost`<br/>*string* | Utility cost of the record (aggregated per the period).
+`utilityUsage`<br/>*string* | Utility usage of the record.
+`startDate`<br/>*string* | Start date of the record in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
+`endDate`<br/>*string* | End date of the record in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
 `usageType`<br/>*string* | Usage type of the record.
 `secondaryType`<br/>*string* | Secondary type of the record.
 
@@ -66,14 +66,14 @@ Query Parameters (*required*) | &nbsp;
 
 Query Parameters | &nbsp;
 ---------- | -----
-`service_connection_id`<br/>*UUID* | Show usage summary for this service connection
+`service_connection_id`<br/>*UUID* | Show usage summary for this service connection.
 `include_sub_orgs`<br/>*boolean* | Include usage summary of all its sub-organizations. Defaults to false.
 `include_cost`<br/>*boolean* | Include the utility cost and service connection pricing id fields. Defaults to true.
 `include_free_usage`<br/>*boolean* | Include all summary records that has no cost associated to it (i.e. utilityCost == 0). Defaults to true.
-`combine_usage_types`<br/>*boolean* | Sums up the utility cost per organization and service connection. The following fields are removed from the output: `serviceConnectionPricingId`, `usageType`, `secondaryType`, `utilityUsage`
+`combine_usage_types`<br/>*boolean* | Sums up the utility cost per organization and service connection. The following fields are removed from the output: `serviceConnectionPricingId`, `usageType`, `secondaryType`, `utilityUsage`.
 `period`<br/>*String* | The period on which the aggregation is made. HOUR, DAY or PERIOD. The default is HOUR.
 `format`<br/>*String* | JSON or CSV. Defaults to JSON.
-`include_deleted`<br/>*boolean* | Will find usage of an organization that may have been deleted
+`include_deleted`<br/>*boolean* | Will find usage of an organization that may have been deleted.
 
 ### List top level organization usage summary
 
@@ -107,7 +107,7 @@ curl -X GET \
 }
 ```
 
-Retrieves the usage summary records for top level organization and it's sub-organizations for a specific period ensuring that usage is split between two buckets, resource commitment usage and utility usage. The response format will be in the JSON format.
+Retrieves the usage summary records for top level organization and its sub-organizations for a specific period ensuring that usage is split between two buckets, resource commitment usage and utility usage. The response format will be in the JSON format.
 
 ##### Resource Commitment Usage:
 The usage that is counted toward a pre assigned pool of resources defined by the Resource Commitment of the organization on a specified service connection. The resource commitment usage is capped by the resource commitment capacity which is the total amount of resource allocated to the organization.
@@ -120,14 +120,14 @@ The following will always hold:
 
 Attributes | &nbsp;
 ---- | -----------
-`organizationId`<br/>*UUID* | Id of the [organization](#administration-organizations)
-`serviceConnectionId`<br/>*UUID* | Id of the [service connection](#administration-service-connections)
-`serviceConnectionPricingId`<br/>*UUID* | Id of the service connection pricing
-`utilityCost`<br/>*string* | Utility cost of the record (aggregated per the period)
-`utilityUsage`<br/>*string* | Utility usage of the record
+`organizationId`<br/>*UUID* | Id of the [organization](#administration-organizations).
+`serviceConnectionId`<br/>*UUID* | Id of the [service connection](#administration-service-connections).
+`serviceConnectionPricingId`<br/>*UUID* | Id of the service connection pricing.
+`utilityCost`<br/>*string* | Utility cost of the record (aggregated per the period).
+`utilityUsage`<br/>*string* | Utility usage of the record.
 `resourceCommitmentUsage`<br/>*string* | The amount of usage that was counted toward the commitment capacity defined by the resource commitment.
-`startDate`<br/>*string* | Start date of the record in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-`endDate`<br/>*string* | End date of the record in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+`startDate`<br/>*string* | Start date of the record in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
+`endDate`<br/>*string* | End date of the record in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
 `usageType`<br/>*string* | Usage type of the record.
 `secondaryType`<br/>*string* | Secondary type of the record.
 
@@ -139,10 +139,10 @@ Query Parameters (*required*) | &nbsp;
 
 Query Parameters | &nbsp;
 ---------- | -----
-`service_connection_id`<br/>*UUID* | Show usage summary for this service connection
+`service_connection_id`<br/>*UUID* | Show usage summary for this service connection.
 `include_sub_orgs`<br/>*boolean* | Include usage summary of all its sub-organizations. Defaults to false.
 `include_cost`<br/>*boolean* | Include the utility cost and service connection pricing id fields. Defaults to true.
 `include_free_usage`<br/>*boolean* | Include all summary records that has no cost associated to it (i.e. utilityCost == 0). Defaults to true.
-`combine_usage_types`<br/>*boolean* | Sums up the utility cost per organization and service connection. The following fields are removed from the output: `serviceConnectionPricingId`, `usageType`, `secondaryType`, `utilityUsage`
+`combine_usage_types`<br/>*boolean* | Sums up the utility cost per organization and service connection. The following fields are removed from the output: `serviceConnectionPricingId`, `usageType`, `secondaryType`, `utilityUsage`.
 `period`<br/>*String* | The period on which the aggregation is made. HOUR, DAY or PERIOD. The default is HOUR.
-`include_deleted`<br/>*boolean* | Will find usage of an organization that may have been deleted
+`include_deleted`<br/>*boolean* | Will find usage of an organization that may have been deleted.

--- a/source/includes/administration/_users.md
+++ b/source/includes/administration/_users.md
@@ -51,15 +51,15 @@ Retrieve information about users you have access to. If you want access to other
 
 Attributes | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of the user
-`userName`<br/>*string* | The username of the user
-`firstName`<br/>*string* | The first name of the user
-`lastName`<br/>*string* | The last name of the user
-`email`<br/>*string* | The email of the user
-`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the user was created
+`id`<br/>*UUID* | The id of the user.
+`userName`<br/>*string* | The username of the user.
+`firstName`<br/>*string* | The first name of the user.
+`lastName`<br/>*string* | The last name of the user.
+`email`<br/>*string* | The email of the user.
+`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the user was created.
 `status`<br/>*string* | The current status of the user.
-`organization`<br/>*[Organization](#administration-organization)* | The organization to which the user belongs
-`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environments roles that are assigned to the user<br/>*includes*: `id`, `name` and `environment.id`
+`organization`<br/>*[Organization](#administration-organization)* | The organization to which the user belongs.
+`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environments roles that are assigned to the user.<br/>*includes*: `id`, `name` and `environment.id`
 
 
 <!-------------------- GET USER -------------------->
@@ -114,16 +114,16 @@ Retrieve information about a specific user. If you want access to other users in
 
 Attributes | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of the user
-`userName`<br/>*string* | The username of the user
-`firstName`<br/>*string* | The first name of the user
-`lastName`<br/>*string* | The last name of the user
-`email`<br/>*string* | The email of the user
-`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the user was created
+`id`<br/>*UUID* | The id of the user.
+`userName`<br/>*string* | The username of the user.
+`firstName`<br/>*string* | The first name of the user.
+`lastName`<br/>*string* | The last name of the user.
+`email`<br/>*string* | The email of the user.
+`creationDate`<br/>*string* | The date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) that the user was created.
 `status`<br/>*string* | The current status of the user.
-`organization`<br/>*[Organization](#administration-organization)* | The organization to which the user belongs
-`environments`<br/>*Array[[Environment](#administration-environments)]* | The environments the user is member of<br/>*includes*: `id`, `name`
-`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environments roles that are assigned to the user<br/>*includes*: `id`, `name` and `environment.id`
+`organization`<br/>*[Organization](#administration-organization)* | The organization to which the user belongs.
+`environments`<br/>*Array[[Environment](#administration-environments)]* | The environments the user is member of.<br/>*includes*: `id`, `name`
+`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environments roles that are assigned to the user.<br/>*includes*: `id`, `name` and `environment.id`
 
 
 <!-------------------- CREATE USER -------------------->
@@ -165,18 +165,18 @@ Create a user in a specific organization. There's two different types of [role](
 Required | &nbsp;
 -------- | -----------
 `userName`<br/>*string* | Username of the new user. Should be unique across the organization.
-`firstName`<br/>*string* | First name of the user
-`lastName`<br/>*string* | Last name of the user
+`firstName`<br/>*string* | First name of the user.
+`lastName`<br/>*string* | Last name of the user.
 `email`<br/>*string* | Email of the user. Should be unique across the organization.
 
 Optional | &nbsp;
 -------- | -----------
-`organization`</br>*[Organization](#administration-organization)* | Organization in which the user will be created. *Defaults to your organization*<br/>*required:* `id`
-`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environment roles to give to the user<br/>*required*: `id`
+`organization`</br>*[Organization](#administration-organization)* | Organization in which the user will be created. *Defaults to your organization*.<br/>*required:* `id`
+`roles`<br/>*Array[[Role](#administration-roles)]* | The system and environment roles to give to the user.<br/>*required*: `id`
 
 ##### Returns
 
-The responses' `data` field contains the created [user](#administration-users) with it's `id`.
+The responses' `data` field contains the created [user](#administration-users) with its `id`.
 
 
 <!-------------------- UPDATE USER -------------------->
@@ -214,8 +214,8 @@ Update a specific user. It is important to note that updating the list of roles 
 Optional | &nbsp;
 -------- | -----------
 `userName`<br/>*string* | The new username of the user. Should be unique across the organization.
-`firstName`<br/>*string* | The new first name of the user
-`lastName`<br/>*string* | The new last name of the user
+`firstName`<br/>*string* | The new first name of the user.
+`lastName`<br/>*string* | The new last name of the user.
 `email`<br/>*string* | The new email of the user. Should be unique across the organization.
 `roles`<br/>*Array[[Role](#administration-roles)]* | The new list of system or environment roles to give to the user. This will override the previous list of roles.<br/>*required*: `id`
 

--- a/source/includes/gcp/_backend_services.md
+++ b/source/includes/gcp/_backend_services.md
@@ -193,9 +193,9 @@ Create a new backend service.
 
 | Required | &nbsp;|
 | --- | --- |
-| `name`<br/>*string* | The display name of the backend service |
-| `shortBackends`<br/>*string* | A short version of the list of backends |
-| `shortHealthChecks`<br/>*string* | A short version of the health checks |
+| `name`<br/>*string* | The display name of the backend service. |
+| `shortBackends`<br/>*string* | A short version of the list of backends. |
+| `shortHealthChecks`<br/>*string* | A short version of the health checks. |
 
 <!-------------------- DELETE A BACKEND SERVICE -------------------->
 

--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -43,13 +43,13 @@ curl -X GET \
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`nodeCount`<br/>*number* | Number of nodes in the cluster
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`nodeCount`<br/>*number* | Number of nodes in the cluster.
 `endpoint`<br/>*string* | The IP address of the cluster's master node. All interactions with the Kubernetes API are done through the master node.
 `location` <br/> *string* | The zone or region in which the cluster is running. For regional clusters, your cluster nodes may span multiple zones within the region.
-`status` <br/> *string* | The status of the cluster
+`status` <br/> *string* | The status of the cluster.
 `id` <br/> *string* | The cluster is uniquely identified by the project name, location and cluster name.
-`name` <br/> *string* | The name of the cluster
+`name` <br/> *string* | The name of the cluster.
 `caCert` <br/> *string* | The *base64 encoded* certificate authority certificate for the cluster. 
 
 <!-------------------- RETRIEVE A CLUSTER -------------------->
@@ -80,11 +80,11 @@ curl -X GET \
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`nodeCount`<br/>*number* | Number of nodes in the cluster
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`nodeCount`<br/>*number* | Number of nodes in the cluster.
 `endpoint`<br/>*string* | The IP address of the cluster's master node. All interactions with the Kubernetes API are done through the master node.
 `location` <br/> *string* | The zone or region in which the cluster is running. For regional clusters, your cluster nodes may span multiple zones within the region.
-`status` <br/> *string* | The status of the cluster
+`status` <br/> *string* | The status of the cluster.
 `id` <br/> *string* | The cluster is uniquely identified by the project name, location and cluster name.
-`name` <br/> *string* | The name of the cluster
+`name` <br/> *string* | The name of the cluster.
 `caCert` <br/> *string* | The *base64 encoded* certificate authority certificate for the cluster. 

--- a/source/includes/gcp/_disks.md
+++ b/source/includes/gcp/_disks.md
@@ -50,25 +50,25 @@ Retrieve a list of all disks in a given [environment](#administration-environmen
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
 `sizeGb` <br/>*string* | The size of the disk in GB. Acceptable values are 1 to 65536, inclusive.
 `zone`<br/>*string* | URL of the zone where the instance resides. 
 `status`<br/>*string* | The status of the disk. One of the following values: READY, CREATING, ATTACHING, ATTACHED, DETACHING, RESIZING, DELETING, and DEPRECATED.
-`selfLink`<br/>*string* | Server-defined URL for this resource
+`selfLink`<br/>*string* | Server-defined URL for this resource.
 `type`<br/>*string* | URL of the disk type resource describing which disk type to use to create the disk. Choices are ':url/pd-standard' or ':url/pd-ssd'.
 `lastAttachTimestamp`<br/>*string* | Timestamp representing the last time the disk was attached.
 `users`<br/>*Array[string]* | Links to the instances the disk is attached to.
-`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking.
 `physicalBlockSizeBytes`<br/>*string* | Physical block size of the persistent disk, in bytes. Currently supported sizes are 4096 and 16384.
 `kind`<br/>*string* | Type of the resource.
 `shortUsers`<br/>*string* | The names of the instances the disk is attached to.
 `shortType`<br/>*string* | The disk type. Choices are 'pd-standard' or 'pd-ssd'.
 `attach_mode`<br/>*string* | The mode used to attach the disk to instances. Valid modes are READ_WRITE or READ_ONLY.
 `autoDelete`<br/>*boolean* | Whether the resource should be deleted when the instance it's attached to are deleted.
-`id`<br/>*UUID* | The id of the instance
-`name`<br/>*string* | The display name of the instance
-`shortZone`<br/>*string* | A short version of the zone name
-`shortRegion`<br/>*string* | A short version of the region name
+`id`<br/>*UUID* | The id of the instance.
+`name`<br/>*string* | The display name of the instance.
+`shortZone`<br/>*string* | A short version of the zone name.
+`shortRegion`<br/>*string* | A short version of the region name.
 
 <!-------------------- RETRIEVE A DISK -------------------->
 
@@ -114,25 +114,25 @@ Retrieve a disk in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
 `sizeGb` <br/>*string* | The size of the disk in GB. Acceptable values are 1 to 65536, inclusive.
 `zone`<br/>*string* | URL of the zone where the instance resides. 
 `status`<br/>*string* | The status of the disk. One of the following values: READY, CREATING, ATTACHING, ATTACHED, DETACHING, RESIZING, DELETING, and DEPRECATED.
-`selfLink`<br/>*string* | Server-defined URL for this resource
+`selfLink`<br/>*string* | Server-defined URL for this resource.
 `type`<br/>*string* | URL of the disk type resource describing which disk type to use to create the disk. Choices are ':url/pd-standard' or ':url/pd-ssd'.
 `lastAttachTimestamp`<br/>*string* | Timestamp representing the last time the disk was attached.
 `users`<br/>*Array[string]* | Links to the instances the disk is attached to.
-`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking.
 `physicalBlockSizeBytes`<br/>*string* | Physical block size of the persistent disk, in bytes. Currently supported sizes are 4096 and 16384.
 `kind`<br/>*string* | Type of the resource.
 `shortUsers`<br/>*string* | The names of the instances the disk is attached to.
 `shortType`<br/>*string* | The disk type. Choices are 'pd-standard' or 'pd-ssd'.
 `attachMode`<br/>*string* | The mode used to attach the disk to instances. Valid modes are READ_WRITE or READ_ONLY.
 `autoDelete`<br/>*boolean* | Whether the resource should be deleted when the instance it's attached to are deleted.
-`id`<br/>*UUID* | The id of the instance
-`name`<br/>*string* | The display name of the instance
-`shortZone`<br/>*string* | A short version of the zone name
-`shortRegion`<br/>*string* | A short version of the region name
+`id`<br/>*UUID* | The id of the instance.
+`name`<br/>*string* | The display name of the instance.
+`shortZone`<br/>*string* | A short version of the zone name.
+`shortRegion`<br/>*string* | A short version of the region name.
 
 <!-------------------- CREATE A DISK -------------------->
 
@@ -163,9 +163,9 @@ Create a new disk
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the instance
-`shortRegion`<br/>*string* | A short version of the region name
-`shortZone`<br/>*string* | A short version of the zone name
+`name`<br/>*string* | The display name of the instance.
+`shortRegion`<br/>*string* | A short version of the region name.
+`shortZone`<br/>*string* | A short version of the zone name.
 `shortType`<br/>*string* | The disk type. Choices are 'pd-standard' or 'pd-ssd'.
 `sizeGb` <br/>*string* | The size of the disk in GB. Acceptable values are 1 to 65536, inclusive.
 
@@ -240,7 +240,7 @@ Detach an existing disk from a given [instance](#gcp-instances).
 
 Required | &nbsp;
 ---------- | -----
-`shortUsers`<br/>*string* | The id of the [instance](#gcp-instances) to which the created disk should be attached
+`shortUsers`<br/>*string* | The id of the [instance](#gcp-instances) to which the created disk should be attached.
 
 <!-------------------- RESIZE A DISK -------------------->
 

--- a/source/includes/gcp/_external_ips.md
+++ b/source/includes/gcp/_external_ips.md
@@ -73,7 +73,7 @@ Attributes | &nbsp;
 `addressType`<br/>*string* | The type of address to reserve, either INTERNAL or EXTERNAL. We only list EXTERNAL addresses.
 `kind`<br/>*string* | Type of the resource. Always compute#address for addresses.
 `shortUsers`<br/>*Array[string]* | The names of the instances the IP address is attached to.
-`shortRegion`<br/>*string* | A short version of the region name
+`shortRegion`<br/>*string* | A short version of the region name.
 `type`<br/>*string* | One of EPHEMERAL or STATIC. EPHEMERAL are linked to an instance and are released automatically when an instance is deleted.
 
 <!-------------------- RETRIEVE AN EXTERNAL IP -------------------->
@@ -135,7 +135,7 @@ Attributes | &nbsp;
 `addressType`<br/>*string* | The type of address to reserve, either INTERNAL or EXTERNAL. We only list EXTERNAL addresses.
 `kind`<br/>*string* | Type of the resource. Always compute#address for addresses.
 `shortUsers`<br/>*Array[string]* | The names of the instances the IP address is attached to.
-`shortRegion`<br/>*string* | A short version of the region name
+`shortRegion`<br/>*string* | A short version of the region name.
 `type`<br/>*string* | One of EPHEMERAL or STATIC. EPHEMERAL are linked to an instance and are released automatically when an instance is deleted.
 
 <!-------------------- RESERVE AN EXTERNAL IP -------------------->
@@ -166,12 +166,12 @@ If `shortInstance` is provided, the IP will be reserved and attached to this ins
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the external ip
-`shortRegion`<br/>*string* | A short version of the region name
+`name`<br/>*string* | The display name of the external ip.
+`shortRegion`<br/>*string* | A short version of the region name.
 
 Optional | &nbsp;
 ------- | -----------
-`shortInstance`<br/>*string* | The instance name to attach the new external ip address to
+`shortInstance`<br/>*string* | The instance name to attach the new external ip address to.
 
 <!-------------------- RELEASE AN EXTERNAL IP -------------------->
 

--- a/source/includes/gcp/_firewall_rules.md
+++ b/source/includes/gcp/_firewall_rules.md
@@ -66,13 +66,13 @@ Retrieve a list of all firewall rules in a given [environment](#administration-e
 `id`<br/>*string* | The unique identifier for the resource.
 `kind`<br/>*string* | Type of the resource.
 `logConfig`<br/>*object* | This field denotes the logging options for a particular firewall rule. If logging is enabled, logs will be exported to Stackdriver.
-`name`<br/>*string* | The display name of the firewall rule
+`name`<br/>*string* | The display name of the firewall rule.
 `network`<br/>*string* | URL of the network resource for this firewall rule.
 `priority`<br/>*integer* | Priority for this rule. This is an integer between 0 and 65535, both inclusive. The default value is 1000. Relative priorities determine which rule takes effect if multiple rules apply. Lower values indicate higher priority. For example, a rule with priority 0 has higher precedence than a rule with priority 1. DENY rules take precedence over ALLOW rules if they have equal priority. Note that VPC networks have implied rules with a priority of 65535. To avoid conflicts with the implied rules, use a priority number less than 65535.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
 `sourceRanges`<br/>*Array[string]* | Server-defined URL for the resource.
 `targetTags`<br/>*Array[string]* | A list of tags that controls which instances the firewall rule applies to. If targetTags are specified, then the firewall rule applies only to instances in the VPC network that have one of those tags. If no targetTags are specified, the firewall rule applies to all instances on the specified network.
-`action`<br/>*string* | The firewall rule type: 'allow' (allow traffic) or 'deny' (deny traffic)
+`action`<br/>*string* | The firewall rule type: 'allow' (allow traffic) or 'deny' (deny traffic).
 
 #### Retrieve a firewall rule
 
@@ -133,13 +133,13 @@ Retrieve a firewall rules in a given [environment](#administration-environments)
 `id`<br/>*string* | The unique identifier for the resource.
 `kind`<br/>*string* | Type of the resource.
 `logConfig`<br/>*object* | This field denotes the logging options for a particular firewall rule. If logging is enabled, logs will be exported to Stackdriver.
-`name`<br/>*string* | The display name of the firewall rule
+`name`<br/>*string* | The display name of the firewall rule.
 `network`<br/>*string* | URL of the network resource for this firewall rule.
 `priority`<br/>*integer* | Priority for this rule. This is an integer between 0 and 65535, both inclusive. The default value is 1000. Relative priorities determine which rule takes effect if multiple rules apply. Lower values indicate higher priority. For example, a rule with priority 0 has higher precedence than a rule with priority 1. DENY rules take precedence over ALLOW rules if they have equal priority. Note that VPC networks have implied rules with a priority of 65535. To avoid conflicts with the implied rules, use a priority number less than 65535.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
 `sourceRanges`<br/>*Array[string]* | Server-defined URL for the resource.
 `targetTags`<br/>*Array[string]* | A list of tags that controls which instances the firewall rule applies to. If targetTags are specified, then the firewall rule applies only to instances in the VPC network that have one of those tags. If no targetTags are specified, the firewall rule applies to all instances on the specified network.
-`action`<br/>*string* | The firewall rule type: 'allow' (allow traffic) or 'deny' (deny traffic)
+`action`<br/>*string* | The firewall rule type: 'allow' (allow traffic) or 'deny' (deny traffic).
 
 <!-------------------- CREATE A FIREWALL RULE -------------------->
 
@@ -170,19 +170,19 @@ Create a new firewall rule.
 
 Required | &nbsp;
 ------- | -----------
-`action`<br/>*string* | The firewall rule type: 'allow' (allow traffic) or 'deny' (deny traffic)
+`action`<br/>*string* | The firewall rule type: 'allow' (allow traffic) or 'deny' (deny traffic).
 `direction`<br/>*string* | Direction of traffic to which this firewall applies, either INGRESS or EGRESS. The default is INGRESS.
-`name`<br/>*string* | The display name of the firewall rule
+`name`<br/>*string* | The display name of the firewall rule.
 `priority`<br/>*string* | Priority for this rule. This is an integer between 0 and 65535, both inclusive. The default value is 1000.
 `range`<br/>*string* | The source or destination range depending on the `direction` specified. The firewall rule applies only to traffic that has a source/destination IP address in these ranges. These ranges must be expressed in CIDR format.
 
 
 Optional | &nbsp;
 ------- | -----------
-`all`<br/>*boolean* | Specifies if the firewall rule is an allow all or deny all rule
-`tcpPorts`<br/>*string* | The tcp ports on which to apply the rule. These must be in the range [0, 65535). They may be specified as combination of comma seperated values and port ranges i.e. 3,6,9,10-22
-`udpPorts`<br/>*string* | The udp ports on which to apply the rule. These must be in the range [0, 65535). They may be specified as combination of comma seperated values and port ranges i.e. 3,6,9,10-22
-`protocols`<br/>*string* | Supported protocols are: icmp, esp, ah, sctp, ipip or a valid [decimal IP protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
+`all`<br/>*boolean* | Specifies if the firewall rule is an allow all or deny all rule.
+`tcpPorts`<br/>*string* | The tcp ports on which to apply the rule. These must be in the range [0, 65535). They may be specified as combination of comma seperated values and port ranges i.e. 3,6,9,10-22.
+`udpPorts`<br/>*string* | The udp ports on which to apply the rule. These must be in the range [0, 65535). They may be specified as combination of comma seperated values and port ranges i.e. 3,6,9,10-22.
+`protocols`<br/>*string* | Supported protocols are: icmp, esp, ah, sctp, ipip or a valid [decimal IP protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
 
 
 <!-------------------- DELETE A FIREWALL RULE -------------------->

--- a/source/includes/gcp/_forwarding_rules.md
+++ b/source/includes/gcp/_forwarding_rules.md
@@ -157,8 +157,8 @@ Create a new forwarding rule.
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the forwarding rule
-`portRange`<br/>*string* | The port which will be allocated to the forwarding rule. Supported ports are: 80 or 8080 (HTTP) and 443 (HTTPS)
+`name`<br/>*string* | The display name of the forwarding rule.
+`portRange`<br/>*string* | The port which will be allocated to the forwarding rule. Supported ports are: 80 or 8080 (HTTP) and 443 (HTTPS).
 `shortTarget`<br/>*string* | The name of the target resource.
 
 Optional | &nbsp;

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -50,12 +50,12 @@ Retrieve a list of all healtch checks.
 
 Attributes | &nbsp;
 ------- | -----------
-`checkIntervalSec`<br/>*int* | How often (in seconds) to send a health check. The default value is 5 seconds
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`checkIntervalSec`<br/>*int* | How often (in seconds) to send a health check. The default value is 5 seconds.
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
 `description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
 `healthyThreshold`ç | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
-`httpHealthCheck` <br/>*object* | When the type is set to HTTP, this object represents the health check
-`httpSHealthCheck` <br/>*object* | When the type is set to HTTPS, this object represents the health check
+`httpHealthCheck` <br/>*object* | When the type is set to HTTP, this object represents the health check.
+`httpSHealthCheck` <br/>*object* | When the type is set to HTTPS, this object represents the health check.
 `id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
 `kind`<br/>*string* | Type of the resource.
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
@@ -63,7 +63,7 @@ Attributes | &nbsp;
 `timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
 `type`<br/>*string* | Specifies the type of the health check, either HTTP or HTTPS. If not specified, the default is HTTP. Exactly one of the protocol-specific health check field must be specified, which must match type field.
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
-`portNumber`<br/>*string* | The port number for health check
+`portNumber`<br/>*string* | The port number for health check.
 
 <!-------------------- RETRIEVE A HEALTH CHECK -------------------->
 
@@ -108,12 +108,12 @@ Retrieve a health check in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
-`checkIntervalSec`<br/>*int* | How often (in seconds) to send a health check. The default value is 5 seconds
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`checkIntervalSec`<br/>*int* | How often (in seconds) to send a health check. The default value is 5 seconds.
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
 `description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
 `healthyThreshold`<br/>*int* | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
-`httpHealthCheck` <br/>*object* | When the type is set to HTTP, this object represents the health check
-`httpSHealthCheck` <br/>*object* | When the type is set to HTTPS, this object represents the health check
+`httpHealthCheck` <br/>*object* | When the type is set to HTTP, this object represents the health check.
+`httpSHealthCheck` <br/>*object* | When the type is set to HTTPS, this object represents the health check.
 `id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
 `kind`<br/>*string* | Type of the resource.
 `name`<br/>*string* | Name of the resource. Provided by the client when the resource is created.
@@ -121,7 +121,7 @@ Attributes | &nbsp;
 `timeoutSec`<br/>*int* | How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
 `type`<br/>*string* | Specifies the type of the health check, either HTTP or HTTPS. If not specified, the default is HTTP. Exactly one of the protocol-specific health check field must be specified, which must match type field.
 `unhealthyThreshold`<br/>*int* | A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2.
-`portNumber`<br/>*string* | The port number for health check
+`portNumber`<br/>*string* | The port number for health check.
 
 <!-------------------- CREATE A HEALTH CHECK -------------------->
 #### Create a health check
@@ -140,13 +140,13 @@ Create a new health check
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the health check
+`name`<br/>*string* | The display name of the health check.
 
 Optional | &nbsp;
 ------- | -----------
 `type`<br/>*string* | Specifies the type of the health check, either HTTP or HTTPS. If not specified, the default is HTTP.
 `portNumber`<br/>*string* | The port number for the health check. The default is 80 for HTTP, 443 for HTTPS.
-`description`<br/>*string* | Description of the health check
+`description`<br/>*string* | Description of the health check.
 
 <!-------------------- DELETE A HEALTH CHECK -------------------->
 
@@ -188,9 +188,9 @@ Edit an existing health check.
 
 Required | &nbsp;
 ------- | -----------
-`portNumber`<br/>*integer* | The port number of the health check
+`portNumber`<br/>*integer* | The port number of the health check.
 
 Optional | &nbsp;
 ------- | -----------
 `type`<br/>*string* | Specifies the type of the health check, either HTTP or HTTPS. The type should be valided (If not specified, the default is HTTP).
-`description`<br/>*string* | Description of the health check
+`description`<br/>*string* | Description of the health check.

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -1,7 +1,7 @@
 ### Health checks
 
 Health checking mechanisms determine whether VM instances respond properly to traffic.
-<!-------------------- LIST HEALTH CHECK -------------------->
+
 #### List health checks
 
 ```shell
@@ -46,7 +46,7 @@ curl -X GET \
    GET /service/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/healthchecks
 </code>
 
-Retrieve a list of all healtch checks.
+Retrieve a list of all health checks.
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_images.md
+++ b/source/includes/gcp/_images.md
@@ -87,24 +87,24 @@ Retrieve a list of available images.
 
 Attributes | &nbsp;
 ------- | -----------
-`archiveSizeBytes`<br/>*string* | Size of the image tar.gz archive stored in Google Cloud Storage (in bytes)
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`description`<br/>*string* | An optional description of this resource
-`diskSizeGb`<br/>*string* | Size of the image when restored onto a persistent disk (in GB)
-`family`<br/>*string* | The name of the image family to which this image belongs
-`kind`<br/>*string* | Type of the resource
-`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
-`licenseCodes`<br/>*Array[integer]* | License codes indicating which licenses are attached to this image.
-`licenses`<br/>*Array[URI]* | Any applicable license URI
-`rawDisk`<br/>*Object* | The parameters of the raw disk image
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`sourceType`<br/>*string* | The type of the image used to create this disk. The default and only value is RAW
+`archiveSizeBytes`<br/>*string* | Size of the image tar.gz archive stored in Google Cloud Storage (in bytes).
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`description`<br/>*string* | An optional description of this resource.
+`diskSizeGb`<br/>*string* | Size of the image when restored onto a persistent disk (in GB).
+`family`<br/>*string* | The name of the image family to which this image belongs.
+`kind`<br/>*string* | Type of the resource.
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking.
+`licenseCodes`<br/>*Array[integer]* | License codes indicating which licenses are attached to this image..
+`licenses`<br/>*Array[URI]* | Any applicable license URI.
+`rawDisk`<br/>*Object* | The parameters of the raw disk image.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`sourceType`<br/>*string* | The type of the image used to create this disk. The default and only value is RAW.
 `status`<br/>*string* | The status of the image. An image can be used to create other resources, such as instances, only after the image has been successfully created and the status is set to READY. Possible values are FAILED, PENDING, or READY.
-`vendorFamily`<br/>*string* | Image family's vendor name
-`shortName`<br/>*string* | A short version of the OS image's name
-`iconUrl`<br/>*string* | Icon representing the OS image
-`id`<br/>*UUID* | The image's id
-`name`<br/>*string* | The image's name
+`vendorFamily`<br/>*string* | Image family's vendor name.
+`shortName`<br/>*string* | A short version of the OS image's name.
+`iconUrl`<br/>*string* | Icon representing the OS image.
+`id`<br/>*UUID* | The image's id.
+`name`<br/>*string* | The image's name.
 
 <!-------------------- RETRIEVE AN IMAGE -------------------->
 
@@ -154,21 +154,21 @@ Retrieve information about an image.
 
 Attributes | &nbsp;
 ------- | -----------
-`archiveSizeBytes`<br/>*string* | Size of the image tar.gz archive stored in Google Cloud Storage (in bytes)
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`description`<br/>*string* | An optional description of this resource
-`diskSizeGb`<br/>*string* | Size of the image when restored onto a persistent disk (in GB)
-`family`<br/>*string* | The name of the image family to which this image belongs
-`kind`<br/>*string* | Type of the resource
-`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
+`archiveSizeBytes`<br/>*string* | Size of the image tar.gz archive stored in Google Cloud Storage (in bytes).
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`description`<br/>*string* | An optional description of this resource.
+`diskSizeGb`<br/>*string* | Size of the image when restored onto a persistent disk (in GB).
+`family`<br/>*string* | The name of the image family to which this image belongs.
+`kind`<br/>*string* | Type of the resource.
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking.
 `licenseCodes`<br/>*Array[integer]* | License codes indicating which licenses are attached to this image.
-`licenses`<br/>*Array[URI]* | Any applicable license URI
-`rawDisk`<br/>*Object* | The parameters of the raw disk image
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`sourceType`<br/>*string* | The type of the image used to create this disk. The default and only value is RAW
+`licenses`<br/>*Array[URI]* | Any applicable license URI.
+`rawDisk`<br/>*Object* | The parameters of the raw disk image.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`sourceType`<br/>*string* | The type of the image used to create this disk. The default and only value is RAW.
 `status`<br/>*string* | The status of the image. An image can be used to create other resources, such as instances, only after the image has been successfully created and the status is set to READY. Possible values are FAILED, PENDING, or READY.
-`vendorFamily`<br/>*string* | Image family's vendor name
-`shortName`<br/>*string* | A short version of the OS image's name
-`iconUrl`<br/>*string* | Icon representing the OS image
-`id`<br/>*UUID* | The image's id
-`name`<br/>*string* | The image's name
+`vendorFamily`<br/>*string* | Image family's vendor name.
+`shortName`<br/>*string* | A short version of the OS image's name.
+`iconUrl`<br/>*string* | Icon representing the OS image.
+`id`<br/>*UUID* | The image's id.
+`name`<br/>*string* | The image's name.

--- a/source/includes/gcp/_instance_groups.md
+++ b/source/includes/gcp/_instance_groups.md
@@ -50,20 +50,20 @@ Retrieve a list of all instance groups in a given [environment](#administration-
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`description`<br/>*string* | An optional description of this resource
-`fingerprint`<br/>*string* | A short sequence of bytes used to identify the named ports
-`id`<br/>*UUID* | The id of the instance group
-`kind`<br/>*string* | Type of the resource
-`name`<br/>*string* | The display name of the instance group
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`description`<br/>*string* | An optional description of this resource.
+`fingerprint`<br/>*string* | A short sequence of bytes used to identify the named ports.
+`id`<br/>*UUID* | The id of the instance group.
+`kind`<br/>*string* | Type of the resource.
+`name`<br/>*string* | The display name of the instance group.
 `namedPorts`<br/>*object* | Assigns a name to a port number. This allows the system to reference ports by the assigned name instead of a port number. Named ports apply to all instances in this instance group.
-`network`<br/>*string* | The network to which the instance group is connected to
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`shortRegion`<br/>*string* | A short version of the region name
-`shortZone`<br/>*string* | A short version of the zone name
-`size`<br/>*integer* | The number of instances in the group
-`subnetwork`<br/>*string* | The sub-network within the network the instance group is connected to
-`zone`<br/>*string* | URL of the zone where the instance group resides
+`network`<br/>*string* | The network to which the instance group is connected to.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`shortRegion`<br/>*string* | A short version of the region name.
+`shortZone`<br/>*string* | A short version of the zone name.
+`size`<br/>*integer* | The number of instances in the group.
+`subnetwork`<br/>*string* | The sub-network within the network the instance group is connected to.
+`zone`<br/>*string* | URL of the zone where the instance group resides.
 
 <!-------------------- RETRIEVE AN INSTANCE GROUP -------------------->
 
@@ -108,20 +108,20 @@ Retrieve an instance group in a given [environment](#administration-environments
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`description`<br/>*string* | An optional description of this resource
-`fingerprint`<br/>*string* | A short sequence of bytes used to identify the named ports
-`id`<br/>*UUID* | The id of the instance group
-`kind`<br/>*string* | Type of the resource
-`name`<br/>*string* | The display name of the instance group
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`description`<br/>*string* | An optional description of this resource.
+`fingerprint`<br/>*string* | A short sequence of bytes used to identify the named ports.
+`id`<br/>*UUID* | The id of the instance group.
+`kind`<br/>*string* | Type of the resource.
+`name`<br/>*string* | The display name of the instance group.
 `namedPorts`<br/>*object* | Assigns a name to a port number. This allows the system to reference ports by the assigned name instead of a port number. Named ports apply to all instances in this instance group.
-`network`<br/>*string* | The network to which the instance group is connected to
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`shortRegion`<br/>*string* | A short version of the region name
-`shortZone`<br/>*string* | A short version of the zone name
-`size`<br/>*integer* | The number of instances in the group
-`subnetwork`<br/>*string* | The sub-network within the network the instance group is connected to
-`zone`<br/>*string* | URL of the zone where the instance group resides
+`network`<br/>*string* | The network to which the instance group is connected to.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`shortRegion`<br/>*string* | A short version of the region name.
+`shortZone`<br/>*string* | A short version of the zone name.
+`size`<br/>*integer* | The number of instances in the group.
+`subnetwork`<br/>*string* | The sub-network within the network the instance group is connected to.
+`zone`<br/>*string* | URL of the zone where the instance group resides.
 
 <!-------------------- CREATE AN INSTANCE GROUP -------------------->
 
@@ -153,15 +153,15 @@ Create a new instance group.
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the instance group
-`shortZone`<br/>*string* | A short version of the zone name
+`name`<br/>*string* | The display name of the instance group.
+`shortZone`<br/>*string* | A short version of the zone name.
 
 Optional | &nbsp;
 ------- | -----------
-`shortInstances`<br/>*array[string]* | Array of instance names to add to the instance group upon creation
-`shortNetwork`<br/>*string* | The network to which the instance group is connected to
-`shortRegion`<br/>*string* | A short version of the region name
-`shortSubnetwork`<br/>*string* | The sub-network within the network the instance group is connected to
+`shortInstances`<br/>*array[string]* | Array of instance names to add to the instance group upon creation.
+`shortNetwork`<br/>*string* | The network to which the instance group is connected to.
+`shortRegion`<br/>*string* | A short version of the region name.
+`shortSubnetwork`<br/>*string* | The sub-network within the network the instance group is connected to.
 
 <!-------------------- DELETE AN INSTANCE GROUP -------------------->
 
@@ -201,7 +201,7 @@ curl -X POST \
 Manage instance members in an existing instance group.
 
 <aside class="notice">
-An instance can only belong to one load balanced instance group. But you can add an instance to multiple non-load balanced instance groups
+An instance can only belong to one load balanced instance group. But you can add an instance to multiple non-load balanced instance groups.
 </aside>
 
 Required | &nbsp;

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -110,37 +110,37 @@ Retrieve a list of all instances in a given [environment](#administration-enviro
 
 Attributes | &nbsp;
 ------- | -----------
-`status`<br/>*string* | The status of the instance. One of the following values: PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, and TERMINATED
-`zone`<br/>*string* | URL of the zone where the instance resides
-`machineType`<br/>*string* | URL of the machine type resource used by this instance
-`cpuPlatform`<br/>*string* | The CPU platform used by this instance
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`deletionProtection`<br/>*string* | Whether the resource should be protected against deletion
-`disks`<br/>*Array[Disk]* | Array of disks associated with this instance
-`kind`<br/>*string* | Type of the resource
-`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
-`metadata`<br/>*object* | The metadata key/value pairs assigned to this instance
-`networkInterfaces`<br/>*Array[object]* | An array of network configurations for this instance
-`scheduling`<br/>*object* | Sets the scheduling options for this instance
-`selfLink`<br/>*string* | Server-defined URL for this resource
+`status`<br/>*string* | The status of the instance. One of the following values: PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, and TERMINATED.
+`zone`<br/>*string* | URL of the zone where the instance resides.
+`machineType`<br/>*string* | URL of the machine type resource used by this instance.
+`cpuPlatform`<br/>*string* | The CPU platform used by this instance.
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`deletionProtection`<br/>*string* | Whether the resource should be protected against deletion.
+`disks`<br/>*Array[Disk]* | Array of disks associated with this instance.
+`kind`<br/>*string* | Type of the resource.
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking.
+`metadata`<br/>*object* | The metadata key/value pairs assigned to this instance.
+`networkInterfaces`<br/>*Array[object]* | An array of network configurations for this instance.
+`scheduling`<br/>*object* | Sets the scheduling options for this instance.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
 `startRestricted`<br/>*boolean* | Whether a VM has been restricted for start because Compute Engine has detected suspicious activity.
-`tags`<br/>*object* | Tags to apply to this instance. Tags are used to identify valid sources or targets for network firewalls and are specified by the client during instance creation
-`shortMachineType`<br/>*string* | A short version of the machineType name
-`project`<br/>*string* | The project where the instance resides
-`internalIp`<br/>*string* | The instance's internal IP
-`networkName`<br/>*string* | The network to which the instance is connected to
-`subnetworkName`<br/>*string* | The sub-network within the network the instance is connected to
-`iconUrl`<br/>*string* | Icon representing the OS installed on the instance's boot disk
-`osImageName`<br/>*string* | The name of the OS image installed on the instance's boot disk
-`osImageSelfLink`<br/>*string* | The full URL to the OS image
-`osImageSizeInGb`<br/>*string* | The size of the OS image
-`bootDiskSizeInGb`<br/>*string* | The size of the instance's boot disk
-`cpuCount`<br/>*string* | The number of vCPUs for the machine type
-`memoryInGB`<br/>*string* | The memory size for the machine name
-`id`<br/>*UUID* | The id of the instance
-`name`<br/>*string* | The display name of the instance
-`shortZone`<br/>*string* | A short version of the zone name
-`shortRegion`<br/>*string* | A short version of the region name
+`tags`<br/>*object* | Tags to apply to this instance. Tags are used to identify valid sources or targets for network firewalls and are specified by the client during instance creation.
+`shortMachineType`<br/>*string* | A short version of the machineType name.
+`project`<br/>*string* | The project where the instance resides.
+`internalIp`<br/>*string* | The instance's internal IP.
+`networkName`<br/>*string* | The network to which the instance is connected to.
+`subnetworkName`<br/>*string* | The sub-network within the network the instance is connected to.
+`iconUrl`<br/>*string* | Icon representing the OS installed on the instance's boot disk.
+`osImageName`<br/>*string* | The name of the OS image installed on the instance's boot disk.
+`osImageSelfLink`<br/>*string* | The full URL to the OS image.
+`osImageSizeInGb`<br/>*string* | The size of the OS image.
+`bootDiskSizeInGb`<br/>*string* | The size of the instance's boot disk.
+`cpuCount`<br/>*string* | The number of vCPUs for the machine type.
+`memoryInGB`<br/>*string* | The memory size for the machine name.
+`id`<br/>*UUID* | The id of the instance.
+`name`<br/>*string* | The display name of the instance.
+`shortZone`<br/>*string* | A short version of the zone name.
+`shortRegion`<br/>*string* | A short version of the region name.
 
 <!-------------------- RETRIEVE AN INSTANCE -------------------->
 
@@ -245,37 +245,37 @@ Retrieve an instance in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
-`status`<br/>*string* | The status of the instance. One of the following values: PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, and TERMINATED
-`zone`<br/>*string* | URL of the zone where the instance resides
-`machineType`<br/>*string* | URL of the machine type resource used by this instance
-`cpuPlatform`<br/>*string* | The CPU platform used by this instance
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`deletionProtection`<br/>*string* | Whether the resource should be protected against deletion
-`disks`<br/>*Array[Disk]* | Array of disks associated with this instance
-`kind`<br/>*string* | Type of the resource
-`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
-`metadata`<br/>*object* | The metadata key/value pairs assigned to this instance
-`networkInterfaces`<br/>*Array[object]* | An array of network configurations for this instance
-`scheduling`<br/>*object* | Sets the scheduling options for this instance
-`selfLink`<br/>*string* | Server-defined URL for this resource
+`status`<br/>*string* | The status of the instance. One of the following values: PROVISIONING, STAGING, RUNNING, STOPPING, STOPPED, SUSPENDING, SUSPENDED, and TERMINATED.
+`zone`<br/>*string* | URL of the zone where the instance resides.
+`machineType`<br/>*string* | URL of the machine type resource used by this instance.
+`cpuPlatform`<br/>*string* | The CPU platform used by this instance.
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`deletionProtection`<br/>*string* | Whether the resource should be protected against deletion.
+`disks`<br/>*Array[Disk]* | Array of disks associated with this instance.
+`kind`<br/>*string* | Type of the resource.
+`labelFingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking.
+`metadata`<br/>*object* | The metadata key/value pairs assigned to this instance.
+`networkInterfaces`<br/>*Array[object]* | An array of network configurations for this instance.
+`scheduling`<br/>*object* | Sets the scheduling options for this instance.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
 `startRestricted`<br/>*boolean* | Whether a VM has been restricted for start because Compute Engine has detected suspicious activity.
-`tags`<br/>*object* | Tags to apply to this instance. Tags are used to identify valid sources or targets for network firewalls and are specified by the client during instance creation
-`shortMachineType`<br/>*string* | A short version of the machineType name
-`project`<br/>*string* | The project where the instance resides
-`internalIp`<br/>*string* | The instance's internal IP
-`networkName`<br/>*string* | The network to which the instance is connected to
-`subnetworkName`<br/>*string* | The sub-network within the network the instance is connected to
-`iconUrl`<br/>*string* | Icon representing the OS installed on the instance's boot disk
-`osImageName`<br/>*string* | The name of the OS image installed on the instance's boot disk
-`osImageSelfLink`<br/>*string* | The full URL to the OS image
-`osImageSizeInGb`<br/>*string* | The size of the OS image
-`bootDiskSizeInGb`<br/>*string* | The size of the instance's boot disk
-`cpuCount`<br/>*string* | The number of vCPUs for the machine type
-`memoryInGB`<br/>*string* | The memory size for the machine name
-`id`<br/>*UUID* | The id of the instance
-`name`<br/>*string* | The display name of the instance
-`shortZone`<br/>*string* | A short version of the zone name
-`shortRegion`<br/>*string* | A short version of the region name
+`tags`<br/>*object* | Tags to apply to this instance. Tags are used to identify valid sources or targets for network firewalls and are specified by the client during instance creation.
+`shortMachineType`<br/>*string* | A short version of the machineType name.
+`project`<br/>*string* | The project where the instance resides.
+`internalIp`<br/>*string* | The instance's internal IP.
+`networkName`<br/>*string* | The network to which the instance is connected to.
+`subnetworkName`<br/>*string* | The sub-network within the network the instance is connected to.
+`iconUrl`<br/>*string* | Icon representing the OS installed on the instance's boot disk.
+`osImageName`<br/>*string* | The name of the OS image installed on the instance's boot disk.
+`osImageSelfLink`<br/>*string* | The full URL to the OS image.
+`osImageSizeInGb`<br/>*string* | The size of the OS image.
+`bootDiskSizeInGb`<br/>*string* | The size of the instance's boot disk.
+`cpuCount`<br/>*string* | The number of vCPUs for the machine type.
+`memoryInGB`<br/>*string* | The memory size for the machine name.
+`id`<br/>*UUID* | The id of the instance.
+`name`<br/>*string* | The display name of the instance.
+`shortZone`<br/>*string* | A short version of the zone name.
+`shortRegion`<br/>*string* | A short version of the region name.
 
 <!-------------------- CREATE AN INSTANCE -------------------->
 
@@ -336,14 +336,14 @@ Create a new instance.
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the instance
-`shortRegion`<br/>*string* | A short version of the region name
-`shortZone`<br/>*string* | A short version of the zone name
-`bootDiskType`<br/>*string* | The boot disk type. Choices are 'pd-standard' or 'pd-ssd'
-`bootDiskSizeInGb` <br/>*string* | The size of the boot disk in GB. Acceptable values are 1 to 2000, inclusive
-`cpuCount`<br/>*string* | Updated number of vCPUs of instance
-`memoryInGB`<br/>*string* | Updated memory of instance
-`osImageSelfLink`<br/>*string* | The full URL to the OS image
+`name`<br/>*string* | The display name of the instance.
+`shortRegion`<br/>*string* | A short version of the region name.
+`shortZone`<br/>*string* | A short version of the zone name.
+`bootDiskType`<br/>*string* | The boot disk type. Choices are 'pd-standard' or 'pd-ssd'.
+`bootDiskSizeInGb` <br/>*string* | The size of the boot disk in GB. Acceptable values are 1 to 2000, inclusive.
+`cpuCount`<br/>*string* | Updated number of vCPUs of instance.
+`memoryInGB`<br/>*string* | Updated memory of instance.
+`osImageSelfLink`<br/>*string* | The full URL to the OS image.
 
 Optional | &nbsp;
 ------- | -----------
@@ -406,8 +406,8 @@ The total memory for a machine type must be a multiple of 512 MB. For example, 6
 
 Optional | &nbsp;
 ------ | -----------
-`cpuCount`<br/>*string* | Updated number of vCPUs of instance
-`memoryInGB`<br/>*string* | Updated memory of instance
+`cpuCount`<br/>*string* | Updated number of vCPUs of instance.
+`memoryInGB`<br/>*string* | Updated memory of instance.
 
 <!-------------------- CHANGE EXTERNAL IP -------------------->
 
@@ -499,7 +499,7 @@ Set and retrieve a generated password to a given user on a running Windows insta
 
 Required | &nbsp;
 ------ | -----------
-`username`<br/>*string* | The username
+`username`<br/>*string* | The username.
 
 <!-------------------- MANAGE GROUP MEMBERSHIP -------------------->
 

--- a/source/includes/gcp/_k8_charts.md
+++ b/source/includes/gcp/_k8_charts.md
@@ -88,26 +88,26 @@ Required | &nbsp;
 Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id for the chart.  
-`type` <br/>*string* | The type of chart
-`attributes` <br/>*object* | The annotations of the pod
-`attributes.name` <br/>*string* | The name of the chart
-`attributes.repo` <br/>*map* | The repository information where this chart was fetched (name,url)
-`attributes.repoUrl` <br/>*string* | The url of the source of the chart
-`attributes.description` <br/>*string* | The chart description
-`attributes.home` <br/>*string* | The home url for the chart
-`attributes.keywords` <br/>*string* | The keywords linked to the chart
-`attributes.maintainers` <br/>*object* | The maintainers of the charts and their information
-`attributes.sources` <br/>*list* | The sources for the chart
-`attributes.icon` <br/>*string* | The icon for the chart
-`relationships` <br/>*objection* | The relationship information for the chart
-`relationships.latestChartVersion` <br/>*object* | The lastest version chart information
-`relationships.latestChartVersion.data.version` <br/>*string* | The digest validating the chart
-`relationships.latestChartVersion.data.digest` <br/>*string* | The name of the chart
-`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download
-`relationships.latestChartVersion.data.readme` <br/>*string* | The readme file location
-`relationships.latestChartVersion.data.values` <br/>*string* | The values file location
-`version`<br/>*string* | The revision of the release
-`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection
+`type` <br/>*string* | The type of chart.
+`attributes` <br/>*object* | The annotations of the pod.
+`attributes.name` <br/>*string* | The name of the chart.
+`attributes.repo` <br/>*map* | The repository information where this chart was fetched (name,url).
+`attributes.repoUrl` <br/>*string* | The url of the source of the chart.
+`attributes.description` <br/>*string* | The chart description.
+`attributes.home` <br/>*string* | The home url for the chart.
+`attributes.keywords` <br/>*string* | The keywords linked to the chart.
+`attributes.maintainers` <br/>*object* | The maintainers of the charts and their information.
+`attributes.sources` <br/>*list* | The sources for the chart.
+`attributes.icon` <br/>*string* | The icon for the chart.
+`relationships` <br/>*objection* | The relationship information for the chart.
+`relationships.latestChartVersion` <br/>*object* | The lastest version chart information.
+`relationships.latestChartVersion.data.version` <br/>*string* | The digest validating the chart.
+`relationships.latestChartVersion.data.digest` <br/>*string* | The name of the chart.
+`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download.
+`relationships.latestChartVersion.data.readme` <br/>*string* | The readme file location.
+`relationships.latestChartVersion.data.values` <br/>*string* | The values file location.
+`version`<br/>*string* | The revision of the release.
+`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection.
 
 
 
@@ -193,26 +193,26 @@ Required | &nbsp;
 Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id for the chart.  
-`type` <br/>*string* | The type of chart
-`attributes` <br/>*object* | The annotations of the pod
-`attributes.name` <br/>*string* | The name of the chart
-`attributes.repo` <br/>*map* | The repository information where this chart was fetched (name,url)
-`attributes.repoUrl` <br/>*string* | The url of the source of the chart
-`attributes.description` <br/>*string* | The chart description
-`attributes.home` <br/>*string* | The home url for the chart
-`attributes.keywords` <br/>*string* | The keywords linked to the chart
-`attributes.maintainers` <br/>*object* | The maintainers of the charts and their information
-`attributes.sources` <br/>*list* | The sources for the chart
-`attributes.icon` <br/>*string* | The icon for the chart
-`relationships` <br/>*objection* | The relationship information for the chart
-`relationships.latestChartVersion` <br/>*object* | The lastest version chart information
-`relationships.latestChartVersion.data.version` <br/>*string* | The digest validating the chart
-`relationships.latestChartVersion.data.digest` <br/>*string* | The name of the chart
-`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download
-`relationships.latestChartVersion.data.readme` <br/>*string* | The readme file location
-`relationships.latestChartVersion.data.values` <br/>*string* | The values file location
-`version`<br/>*string* | The revision of the release
-`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection
+`type` <br/>*string* | The type of chart.
+`attributes` <br/>*object* | The annotations of the pod.
+`attributes.name` <br/>*string* | The name of the chart.
+`attributes.repo` <br/>*map* | The repository information where this chart was fetched (name,url).
+`attributes.repoUrl` <br/>*string* | The url of the source of the chart.
+`attributes.description` <br/>*string* | The chart description.
+`attributes.home` <br/>*string* | The home url for the chart.
+`attributes.keywords` <br/>*string* | The keywords linked to the chart.
+`attributes.maintainers` <br/>*object* | The maintainers of the charts and their information.
+`attributes.sources` <br/>*list* | The sources for the chart.
+`attributes.icon` <br/>*string* | The icon for the chart.
+`relationships` <br/>*objection* | The relationship information for the chart.
+`relationships.latestChartVersion` <br/>*object* | The lastest version chart information.
+`relationships.latestChartVersion.data.version` <br/>*string* | The digest validating the chart.
+`relationships.latestChartVersion.data.digest` <br/>*string* | The name of the chart.
+`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download.
+`relationships.latestChartVersion.data.readme` <br/>*string* | The readme file location.
+`relationships.latestChartVersion.data.values` <br/>*string* | The values file location.
+`version`<br/>*string* | The revision of the release.
+`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection.
 
 
 
@@ -258,10 +258,10 @@ Required | &nbsp;
 
 Attributes | &nbsp;
 ------- | -----------
-`relationships` <br/>*objection* | The relationship information for the chart
-`relationships.latestChartVersion` <br/>*object* | The lastest version chart information
-`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download
-`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection
-`passedValues` <br/>*string* | The values to use to install the chart. It must be a valid Yaml format
-`namespace` <br/>*map* | The namespace in which the chart will be installed
+`relationships` <br/>*objection* | The relationship information for the chart.
+`relationships.latestChartVersion` <br/>*object* | The lastest version chart information.
+`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download.
+`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection.
+`passedValues` <br/>*string* | The values to use to install the chart. It must be a valid Yaml format.
+`namespace` <br/>*map* | The namespace in which the chart will be installed.
 `releaseName` <br/>*string* | The name under which the chart will be known.

--- a/source/includes/gcp/_k8_pods.md
+++ b/source/includes/gcp/_k8_pods.md
@@ -217,17 +217,17 @@ Required | &nbsp;
 Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id of the pod.  
-`metadata` <br/>*object* | The metadata of the the pod
-`metadata.annotations` <br/>*map* | The annotations of the pod
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string
-`metadata.labels` <br/>*map* | The labels associated to the pod and there associated values
-`metadata.name` <br/>*string* | The name of the pod
-`metadata.namespace` <br/>*string* | The namespace in which the pod is created
-`metadata.uid` <br/>*object* | The UUID of the pod
-`spec`<br/>*object* | The specification used to create and run the pod
-`spec.container`<br/>*string* | The name of the container running
-`status`<br/>*object* | The status information of the the pod
-`status.phase`<br/>*string* | The status of the the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed
+`metadata` <br/>*object* | The metadata of the the pod.
+`metadata.annotations` <br/>*map* | The annotations of the pod.
+`metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string.
+`metadata.labels` <br/>*map* | The labels associated to the pod and there associated values.
+`metadata.name` <br/>*string* | The name of the pod.
+`metadata.namespace` <br/>*string* | The namespace in which the pod is created.
+`metadata.uid` <br/>*object* | The UUID of the pod.
+`spec`<br/>*object* | The specification used to create and run the pod.
+`spec.container`<br/>*string* | The name of the container running.
+`status`<br/>*object* | The status information of the the pod.
+`status.phase`<br/>*string* | The status of the the pod. Possible statuses are Running, Pending, Succeeded, Unknown, and Failed.
 
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
@@ -451,17 +451,17 @@ Required | &nbsp;
 Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id of the pod.  
-`metadata` <br/>*object* | The metadata of the the pod
-`metadata.annotations` <br/>*map* | The annotations of the pod
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string
-`metadata.labels` <br/>*map* | The labels associated to the pod and there associated values
-`metadata.name` <br/>*string* | The name of the pod
-`metadata.namespace` <br/>*string* | The namespace in which the pod is created
-`metadata.uid` <br/>*object* | The UUID of the pod
-`spec`<br/>*object* | The specification used to create and run the pod
-`spec.container`<br/>*string* | The name of the container running
-`status`<br/>*object* | The status information of the the pod
-`status.phase`<br/>*string* | The status of the the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed
+`metadata` <br/>*object* | The metadata of the the pod.
+`metadata.annotations` <br/>*map* | The annotations of the pod.
+`metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string.
+`metadata.labels` <br/>*map* | The labels associated to the pod and there associated values.
+`metadata.name` <br/>*string* | The name of the pod.
+`metadata.namespace` <br/>*string* | The namespace in which the pod is created.
+`metadata.uid` <br/>*object* | The UUID of the pod.
+`spec`<br/>*object* | The specification used to create and run the pod.
+`spec.container`<br/>*string* | The name of the container running.
+`status`<br/>*object* | The status information of the the pod.
+`status.phase`<br/>*string* | The status of the the pod. Possible statuses are Running, Pending, Succeeded, Unknown, and Failed.
 
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
@@ -500,4 +500,4 @@ Required | &nbsp;
 Attributes | &nbsp;
 ------- | -----------
 `taskId` <br/>*string* | The task id related to the delete pod.  
-`taskStatus` <br/>*string* | The status of the operation
+`taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/gcp/_k8_releases.md
+++ b/source/includes/gcp/_k8_releases.md
@@ -117,29 +117,29 @@ Optional | &nbsp;
 Attributes | &nbsp;
 ------- | -----------
 `name` <br/>*string* | The name of the release.  
-`info` <br/>*object* | The information about the release
-`info.first_deployed` <br/>*string* | The annotations of the pod
-`info.last_deployed` <br/>*string* | The date of creation of the pod as a string
-`info.deleted` <br/>*string* | The labels associated to the pod and there associated values
-`info.description` <br/>*string* | The name of the pod
-`info.status` <br/>*string* | The status of the release. Possible values are unknown, installed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade, pending-rollback
-`info.notes` <br/>*string* | The notes linked to the release
-`chart`<br/>*object* | The information related to the chart of used in the release
-`chart.version` <br/>*string* | The version of the chart
-`chart.metadata` <br/>*object* | The metadata associated to the chart
-`chart.metadata.name` <br/>*string* | The name of the chart
-`chart.metadata.home` <br/>*string* | The home URL for the chart
-`chart.metadata.sources` <br/>*list* | The list of source of the charts
-`chart.metadata.version` <br/>*string* | The version of the chart
-`chart.metadata.description` <br/>*string* | The description of the chart
-`chart.metadata.keywords` <br/>*list* | The list of keywords linked to the chart
-`chart.metadata.maintainers` <br/>*list* | The list of the maintainer contact information
-`chart.metadata.icon` <br/>*string* | The icon URL for the chart
-`chart.metadata.appVersion` <br/>*string* | The version of the application
-`chart.metadata.deprecate` <br/>*bool* | If the chart is deprecated or not of the application
-`values` <br/>*object* | All values that were used to install the release
-`version`<br/>*string* | The revision of the release
-`namespace`<br/>*string* | The namespace to which the release is installed
+`info` <br/>*object* | The information about the release.
+`info.first_deployed` <br/>*string* | The annotations of the pod.
+`info.last_deployed` <br/>*string* | The date of creation of the pod as a string.
+`info.deleted` <br/>*string* | The labels associated to the pod and there associated values.
+`info.description` <br/>*string* | The name of the pod.
+`info.status` <br/>*string* | The status of the release. Possible values are unknown, installed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade, and pending-rollback.
+`info.notes` <br/>*string* | The notes linked to the release.
+`chart`<br/>*object* | The information related to the chart of used in the release.
+`chart.version` <br/>*string* | The version of the chart.
+`chart.metadata` <br/>*object* | The metadata associated to the chart.
+`chart.metadata.name` <br/>*string* | The name of the chart.
+`chart.metadata.home` <br/>*string* | The home URL for the chart.
+`chart.metadata.sources` <br/>*list* | The list of sources of the charts.
+`chart.metadata.version` <br/>*string* | The version of the chart.
+`chart.metadata.description` <br/>*string* | The description of the chart.
+`chart.metadata.keywords` <br/>*list* | The list of keywords linked to the chart.
+`chart.metadata.maintainers` <br/>*list* | The list of the maintainer contact information.
+`chart.metadata.icon` <br/>*string* | The icon URL for the chart.
+`chart.metadata.appVersion` <br/>*string* | The version of the application.
+`chart.metadata.deprecate` <br/>*bool* | If the chart is deprecated or not of the application.
+`values` <br/>*object* | All values that were used to install the release.
+`version`<br/>*string* | The revision of the release.
+`namespace`<br/>*string* | The namespace to which the release is installed.
 
 The information is not totally returned in the list. We filter out the manifest portion. We also filter out the files and the templates of the chart details. This information will be present in the GET request for an individual release.
 
@@ -288,26 +288,26 @@ Required | &nbsp;
 Attributes | &nbsp;
 ------- | -----------
 `name` <br/>*string* | The name of the release.  
-`info` <br/>*object* | The information about the release
-`info.first_deployed` <br/>*string* | The annotations of the pod
-`info.last_deployed` <br/>*string* | The date of creation of the pod as a string
-`info.deleted` <br/>*string* | The labels associated to the pod and there associated values
-`info.description` <br/>*string* | The name of the pod
-`info.status` <br/>*string* | The status of the release. Possible values are unknown, installed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade, pending-rollback
-`info.notes` <br/>*string* | The notes linked to the release
-`chart`<br/>*object* | The information related to the chart of used in the release
-`chart.version` <br/>*string* | The version of the chart
-`chart.metadata` <br/>*object* | The metadata associated to the chart
-`chart.metadata.name` <br/>*string* | The name of the chart
-`chart.metadata.home` <br/>*string* | The home URL for the chart
-`chart.metadata.sources` <br/>*list* | The list of source of the charts
-`chart.metadata.version` <br/>*string* | The version of the chart
-`chart.metadata.description` <br/>*string* | The description of the chart
-`chart.metadata.keywords` <br/>*list* | The list of keywords linked to the chart
-`chart.metadata.maintainers` <br/>*list* | The list of the maintainer contact information
-`chart.metadata.icon` <br/>*string* | The icon URL for the chart
-`chart.metadata.appVersion` <br/>*string* | The version of the application
-`chart.metadata.deprecate` <br/>*bool* | If the chart is deprecated or not of the application
+`info` <br/>*object* | The information about the release.
+`info.first_deployed` <br/>*string* | The annotations of the pod.
+`info.last_deployed` <br/>*string* | The date of creation of the pod as a string.
+`info.deleted` <br/>*string* | The labels associated to the pod and there associated values.
+`info.description` <br/>*string* | The name of the pod.
+`info.status` <br/>*string* | The status of the release. Possible values are unknown, installed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade, and pending-rollback.
+`info.notes` <br/>*string* | The notes linked to the release.
+`chart`<br/>*object* | The information related to the chart of used in the release.
+`chart.version` <br/>*string* | The version of the chart.
+`chart.metadata` <br/>*object* | The metadata associated to the chart.
+`chart.metadata.name` <br/>*string* | The name of the chart.
+`chart.metadata.home` <br/>*string* | The home URL for the chart.
+`chart.metadata.sources` <br/>*list* | The list of source of the charts.
+`chart.metadata.version` <br/>*string* | The version of the chart.
+`chart.metadata.description` <br/>*string* | The description of the chart.
+`chart.metadata.keywords` <br/>*list* | The list of keywords linked to the chart.
+`chart.metadata.maintainers` <br/>*list* | The list of the maintainer contact information.
+`chart.metadata.icon` <br/>*string* | The icon URL for the chart.
+`chart.metadata.appVersion` <br/>*string* | The version of the application.
+`chart.metadata.deprecate` <br/>*bool* | If the chart is deprecated or not of the application.
 `chart.templates` <br/> *list* | The list of templates contained inside the chart.
 `chart.templates.name` <br/> *string* | The path name of the template inside the chart.
 `chart.templates.data` <br/> *string* | The contents of the template. This is a base64 encode string.
@@ -315,9 +315,9 @@ Attributes | &nbsp;
 `chart.files.name` <br/> *string* | The path name of the file inside the chart.
 `chart.files.data` <br/> *string* | The contents of the file. This is a base64 encode string.
 `manifest` <br/> *string* | The YAML Kubernetes resources created by the Helm templating.
-`values` <br/>*object* | All values that were used to install the release
-`version`<br/>*string* | The revision of the release
-`namespace`<br/>*string* | The namespace to which the release is installed
+`values` <br/>*object* | All values that were used to install the release.
+`version`<br/>*string* | The revision of the release.
+`namespace`<br/>*string* | The namespace to which the release is installed.
 
 <!-- ROLLBACK RELEASE -->
 #### Rollback release to previous revision

--- a/source/includes/gcp/_load_balancer.md
+++ b/source/includes/gcp/_load_balancer.md
@@ -45,12 +45,12 @@ Retrieve a list of all load balancers in a given [environment](#administration-e
 
 Attributes | &nbsp;
 ------- | -----------
-`backendServices`<br/>*List<String>* | The list of backends for this resource
-`forwardingRules`<br/>*List<String>* | The list of forwarding rules for this resource
-`id`<br/>*String* | The id of this resource, which should be the same id as corresponding Url Map
-`name`<br/>*String* | The name of this resource
-`targetProxies`<br/>*List<String>* | The list of target proxies for this resource
-`urlMap`<br/>*String* | Server-defined URL for corresponding url map
+`backendServices`<br/>*List<String>* | The list of backends for this resource.
+`forwardingRules`<br/>*List<String>* | The list of forwarding rules for this resource.
+`id`<br/>*String* | The id of this resource, which should be the same id as corresponding Url Map.
+`name`<br/>*String* | The name of this resource.
+`targetProxies`<br/>*List<String>* | The list of target proxies for this resource.
+`urlMap`<br/>*String* | Server-defined URL for corresponding url map.
 
 <!-------------------- RETRIEVE A LOAD BALANCER -------------------->
 
@@ -90,12 +90,12 @@ Retrieve a load balancer in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
-`backendServices`<br/>*List<String>* | The list of backends for this resource
-`forwardingRules`<br/>*List<String>* | The list of forwarding rules for this resource
-`id`<br/>*String* | The id of this resource, which should be the same id as corresponding Url Map
-`name`<br/>*String* | The name of this resource
-`targetProxies`<br/>*List<String>* | The list of target proxies for this resource
-`urlMap`<br/>*String* | Server-defined URL for corresponding url map
+`backendServices`<br/>*List<String>* | The list of backends for this resource.
+`forwardingRules`<br/>*List<String>* | The list of forwarding rules for this resource.
+`id`<br/>*String* | The id of this resource, which should be the same id as corresponding Url Map.
+`name`<br/>*String* | The name of this resource.
+`targetProxies`<br/>*List<String>* | The list of target proxies for this resource.
+`urlMap`<br/>*String* | Server-defined URL for corresponding url map.
 
 <!-------------------- CREATE A LOADBALANCER -------------------->
 ##### Create a load balancer
@@ -150,7 +150,7 @@ Create a new load balancer.
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the load balancer
+`name`<br/>*string* | The display name of the load balancer.
 `shortBackend`<br/>*string* | The existing backend serivce that will be attached to this load balancer.
 `shortProtocol`<br/>*string* | The protocol of this resource.
 `shortPort`<br/>*string* | The port number of this resource.
@@ -198,6 +198,6 @@ Any specified optional resources to be removed will be deleted if they can be de
 
 Optional | &nbsp;
 ------ | -----------
-`shortBackendsToDelete`<br/>*List<String>* | A list of backend services to delete
-`shortHealthChecksToDelete`<br/>*List<String>* | A list of health checks to delete
-`shortSslCertificatesToDelete`<br/>*List<String>* | A list of SSL certificates to delete
+`shortBackendsToDelete`<br/>*List<String>* | A list of backend services to delete.
+`shortHealthChecksToDelete`<br/>*List<String>* | A list of health checks to delete.
+`shortSslCertificatesToDelete`<br/>*List<String>* | A list of SSL certificates to delete.

--- a/source/includes/gcp/_networks.md
+++ b/source/includes/gcp/_networks.md
@@ -50,14 +50,14 @@ Retrieve a list of all networks in an [environment](#administration-environments
 Attributes | &nbsp;
 ---------- | -----
 `autoCreateSubnetworks`<br/>*boolean* | When set to true, the VPC network is created in "auto" mode. When set to false, the VPC network is created in "custom" mode.
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`description`<br/>*string* | An optional description of this resource
-`id`<br/>*string* | The network's id
-`name`<br/>*string* | The network's name
-`kind`<br/>*string* | Type of the resource
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`description`<br/>*string* | An optional description of this resource.
+`id`<br/>*string* | The network's id.
+`name`<br/>*string* | The network's name.
+`kind`<br/>*string* | Type of the resource.
 `routingConfig`<br/>*object* | The network-level routing configuration for this network. Used by Cloud Router to determine what type of network-wide routing behavior to enforce. RoutingMode is either REGIONAL or GLOBAL.
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`subnetworks`<br/>*Array[URL]* | Server-defined fully-qualified URLs for all subnetworks in this VPC network
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`subnetworks`<br/>*Array[URL]* | Server-defined fully-qualified URLs for all subnetworks in this VPC network.
 
 <!-------------------- RETRIEVE A NETWORK -------------------->
 
@@ -101,11 +101,11 @@ Retrieve information about a network.
 Attributes | &nbsp;
 ---------- | -----
 `autoCreateSubnetworks`<br/>*boolean* | When set to true, the VPC network is created in "auto" mode. When set to false, the VPC network is created in "custom" mode.
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`description`<br/>*string* | An optional description of this resource
-`id`<br/>*string* | The network's id
-`name`<br/>*string* | The network's name
-`kind`<br/>*string* | Type of the resource
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`description`<br/>*string* | An optional description of this resource.
+`id`<br/>*string* | The network's id.
+`name`<br/>*string* | The network's name.
+`kind`<br/>*string* | Type of the resource.
 `routingConfig`<br/>*object* | The network-level routing configuration for this network. Used by Cloud Router to determine what type of network-wide routing behavior to enforce. RoutingMode is either REGIONAL or GLOBAL.
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`subnetworks`<br/>*Array[URL]* | Server-defined fully-qualified URLs for all subnetworks in this VPC network
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`subnetworks`<br/>*Array[URL]* | Server-defined fully-qualified URLs for all subnetworks in this VPC network.

--- a/source/includes/gcp/_regions.md
+++ b/source/includes/gcp/_regions.md
@@ -54,15 +54,15 @@ Retrieve a list of available regions, filtered by the [service connection](#admi
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`description`<br/>*string* | An optional description of this resource
-`id`<br/>*UUID* | The region's id
-`kind`<br/>*string* | Type of the resource
-`name`<br/>*string* | The region's name
-`quotas`<br/>*Array[object]* | Quotas assigned to this region
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`status`<br/>*string* | tatus of the region, either UP or DOWN
-`zones`<br/>*Array[URL]* | A list of zones available in this region, in the form of resource URLs
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`description`<br/>*string* | An optional description of this resource.
+`id`<br/>*UUID* | The region's id.
+`kind`<br/>*string* | Type of the resource.
+`name`<br/>*string* | The region's name.
+`quotas`<br/>*Array[object]* | Quotas assigned to this region.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`status`<br/>*string* | tatus of the region, either UP or DOWN.
+`zones`<br/>*Array[URL]* | A list of zones available in this region, in the form of resource URLs.
 
 <!-------------------- RETRIEVE A REGION -------------------->
 
@@ -111,12 +111,12 @@ Retrieve information about a region.
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`description`<br/>*string* | An optional description of this resource
-`id`<br/>*UUID* | The region's id
-`kind`<br/>*string* | Type of the resource
-`name`<br/>*string* | The region's name
-`quotas`<br/>*Array[object]* | Quotas assigned to this region
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`status`<br/>*string* | tatus of the region, either UP or DOWN
-`zones`<br/>*Array[URL]* | A list of zones available in this region, in the form of resource URLs
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`description`<br/>*string* | An optional description of this resource.
+`id`<br/>*UUID* | The region's id.
+`kind`<br/>*string* | Type of the resource.
+`name`<br/>*string* | The region's name.
+`quotas`<br/>*Array[object]* | Quotas assigned to this region.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`status`<br/>*string* | tatus of the region, either UP or DOWN.
+`zones`<br/>*Array[URL]* | A list of zones available in this region, in the form of resource URLs.

--- a/source/includes/gcp/_ssh_keys.md
+++ b/source/includes/gcp/_ssh_keys.md
@@ -34,8 +34,8 @@ Retrieve a list of all SSH keys in an [environment](#administration-environments
 
 Attributes | &nbsp;
 ---------- | -----
-`id`<br/>*string* | The SSH key's id
-`name`<br/>*string* | The name of the SSH key
+`id`<br/>*string* | The SSH key's id.
+`name`<br/>*string* | The name of the SSH key.
 `publicKey`<br/>*string* | A string representing the protocol, public key and username. [GCP SSH keys documentation](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#sshkeyformat)
 
 <!-------------------- RETRIEVE AN SSH KEY -------------------->
@@ -65,8 +65,8 @@ Retrieve information about an SSH key of an [environment](#administration-enviro
 
 Attributes | &nbsp;
 ---------- | -----
-`id`<br/>*string* | The SSH key's id
-`name`<br/>*string* | The name of the SSH key
+`id`<br/>*string* | The SSH key's id.
+`name`<br/>*string* | The name of the SSH key.
 `publicKey`<br/>*string* | A string representing the protocol, public key and username. [GCP SSH keys documentation](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#sshkeyformat)
 
 <!-------------------- ADD AN SSH KEY -------------------->
@@ -94,7 +94,7 @@ Add an SSH key to the [environment](#administration-environments).
 
 Attributes | &nbsp;
 ---------- | -----
-`name`<br/>*string* | The name of the SSH key
+`name`<br/>*string* | The name of the SSH key.
 `publicKey`<br/>*string* | A string representing the protocol, public key and username. [GCP SSH keys documentation](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#sshkeyformat)
 
 <!-------------------- DELETE AN SSH KEY -------------------->

--- a/source/includes/gcp/_ssl_certificates.md
+++ b/source/includes/gcp/_ssl_certificates.md
@@ -159,10 +159,10 @@ Create a new ssl certificate.
 
 | Required | &nbsp;|
 | --- | --- |
-| `certificate`<br/>*string* | Public key certificate in PEM format |
+| `certificate`<br/>*string* | Public key certificate in PEM format. |
 | `chainCertificate`<br/>*string* | Chain certificates in PEM format, if there are any. Also total number of certificates, including main certificate cannot be more than 5. |
 | `description`<br/>*string* | A short description of this certificate. |
-| `name`<br/>*string* | The display name of the ssl certificate |
+| `name`<br/>*string* | The display name of the ssl certificate. |
 | `privateKey`<br/>*string* | The privateKey associated to certificate in PEM format. |
 
 <!-------------------- DELETE A SSL CERTIFICATE -------------------->

--- a/source/includes/gcp/_vpn_gateways.md
+++ b/source/includes/gcp/_vpn_gateways.md
@@ -50,9 +50,9 @@ Retrieve a list of all VPN gateways in a given [environment](#administration-env
 Attributes | &nbsp;
 ------- | -----------
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
-`description`<br/>*string* | An optional description
+`description`<br/>*string* | An optional description.
 `externalIp`<br/>*Object* | The external IP attached to this VPN gateway.
-`forwardingRules`<br/>Array | List of the forwarding rules which are defined for this VPN gateway
+`forwardingRules`<br/>Array | List of the forwarding rules which are defined for this VPN gateway.
 `id`<br/>*UUID* | Unique identifier for this resource.
 `name`<br/>*string* | The display name of the VPN gateway.
 `network`<br/>*string* | URL of the network to which this VPN gateway is attached.
@@ -103,9 +103,9 @@ Retrieve a VPN gateway in a given [environment](#administration-environments).
 Attributes | &nbsp;
 ------- | -----------
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
-`description`<br/>*string* | An optional description
+`description`<br/>*string* | An optional description.
 `externalIp`<br/>*Object* | The external IP attached to this VPN gateway.
-`forwardingRules`<br/>Array | List of the forwarding rules which are defined for this VPN gateway
+`forwardingRules`<br/>Array | List of the forwarding rules which are defined for this VPN gateway.
 `id`<br/>*UUID* | Unique identifier for this resource.
 `name`<br/>*string* | The display name of the VPN gateway.
 `network`<br/>*string* | URL of the network to which this VPN gateway is attached.
@@ -150,13 +150,13 @@ Create a new Classic VPN gateway in a given [environment](#administration-enviro
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the VPN gateway
-`shortRegion`<br/>*string* | A short version of the region name
+`name`<br/>*string* | The display name of the VPN gateway.
+`shortRegion`<br/>*string* | A short version of the region name.
 
 Optional | &nbsp;
 ------- | -----------
-`description`<br/>*string* | An optional description
-`shortIP`<br/>*string* | The name of the external static IP to use for the VPN gateway
+`description`<br/>*string* | An optional description.
+`shortIP`<br/>*string* | The name of the external static IP to use for the VPN gateway.
 `reseveStaticIP`<br/>*string* | A flag to indicate if a new external static IP needs to be reserved for the VPN gateway. This option is mutually exclusive with `shortIP`.
 
 <!-------------------- DELETE VPN GATEWAY -------------------->

--- a/source/includes/gcp/_vpn_tunnels.md
+++ b/source/includes/gcp/_vpn_tunnels.md
@@ -59,19 +59,19 @@ Retrieve a list of all VPN tunnels in a given [environment](#administration-envi
 Attributes | &nbsp;
 ------- | -----------
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
-`description`<br/>*string* | An optional description
-`id`<br/>*UUID* | Unique identifier for this resource
-`gcpVpnGateway`<br/>*Object* | The VPN Gateway associated with this tunnel
-`ikeVersion`<br/>*integer* | IKE protocol version to use when establishing the VPN tunnel with the peer VPN gateway. Acceptable IKE versions are 1 or 2. The default version is 2
+`description`<br/>*string* | An optional description.
+`id`<br/>*UUID* | Unique identifier for this resource.
+`gcpVpnGateway`<br/>*Object* | The VPN Gateway associated with this tunnel.
+`ikeVersion`<br/>*integer* | IKE protocol version to use when establishing the VPN tunnel with the peer VPN gateway. Acceptable IKE versions are 1 or 2. The default version is 2.
 `localTrafficSelector`<br/>*string* | Local traffic selector to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string. Only IPv4 is supported. By default it's the CIDR associated with the region in which the VPN gateway resides.
-`name`<br/>*string* | The display name of the address
-`peerIp`<br/>*string* | IP address of the peer VPN gateway in another VPC
-`region`<br/>*string* | The URL of the region where the VPN tunnel is
+`name`<br/>*string* | The display name of the address.
+`peerIp`<br/>*string* | IP address of the peer VPN gateway in another VPC.
+`region`<br/>*string* | The URL of the region where the VPN tunnel is.
 `remoteTrafficSelector`<br/>*string* | Remote traffic selectors to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string. Only IPv4 is supported. The CIDR associated with the `peerIp`.
 `sharedSecret`<br/>*string* | Shared secret used to set the secure session between the Cloud VPN gateway and the peer VPN gateway.
-`status`<br/>*string* | The status of the VPN tunnel
-`selfLink`<br/>*string* | Server-defined URL for the resource
-`targetVpnGateway`<br/>*string* | The URL of the Target VPN gateway with which this VPN tunnel is associated
+`status`<br/>*string* | The status of the VPN tunnel.
+`selfLink`<br/>*string* | Server-defined URL for the resource.
+`targetVpnGateway`<br/>*string* | The URL of the Target VPN gateway with which this VPN tunnel is associated.
 `type`<br/>*string* | The type of this VPN Tunnel. Only CLASSIC is supported.
 
 <!-------------------- RETRIEVE A VPN TUNNEL -------------------->
@@ -126,19 +126,19 @@ Retrieve a VPN tunnel in a given [environment](#administration-environments).
 Attributes | &nbsp;
 ------- | -----------
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
-`description`<br/>*string* | An optional description
-`id`<br/>*UUID* | Unique identifier for this resource
-`gcpVpnGateway`<br/>*Object* | The VPN Gateway associated with this tunnel
-`ikeVersion`<br/>*integer* | IKE protocol version to use when establishing the VPN tunnel with the peer VPN gateway. Acceptable IKE versions are 1 or 2. The default version is 2
+`description`<br/>*string* | An optional description.
+`id`<br/>*UUID* | Unique identifier for this resource.
+`gcpVpnGateway`<br/>*Object* | The VPN Gateway associated with this tunnel.
+`ikeVersion`<br/>*integer* | IKE protocol version to use when establishing the VPN tunnel with the peer VPN gateway. Acceptable IKE versions are 1 or 2. The default version is 2.
 `localTrafficSelector`<br/>*string* | Local traffic selector to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string. Only IPv4 is supported. By default it's the CIDR associated with the region in which the VPN gateway resides.
-`name`<br/>*string* | The display name of the address
-`peerIp`<br/>*string* | IP address of the peer VPN gateway in another VPC
-`region`<br/>*string* | The URL of the region where the VPN tunnel is
+`name`<br/>*string* | The display name of the address.
+`peerIp`<br/>*string* | IP address of the peer VPN gateway in another VPC.
+`region`<br/>*string* | The URL of the region where the VPN tunnel is.
 `remoteTrafficSelector`<br/>*string* | Remote traffic selectors to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string. Only IPv4 is supported. The CIDR associated with the `peerIp`.
 `sharedSecret`<br/>*string* | Shared secret used to set the secure session between the Cloud VPN gateway and the peer VPN gateway.
-`status`<br/>*string* | The status of the VPN tunnel
-`selfLink`<br/>*string* | Server-defined URL for the resource
-`targetVpnGateway`<br/>*string* | The URL of the Target VPN gateway with which this VPN tunnel is associated
+`status`<br/>*string* | The status of the VPN tunnel.
+`selfLink`<br/>*string* | Server-defined URL for the resource.
+`targetVpnGateway`<br/>*string* | The URL of the Target VPN gateway with which this VPN tunnel is associated.
 `type`<br/>*string* | The type of this VPN Tunnel. Only CLASSIC is supported.
 
 <!-------------------- CREATE A VPN TUNNEL -------------------->
@@ -173,17 +173,17 @@ Create a new Classic VPN tunnel in a given [environment](#administration-environ
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the VPN tunnel
-`ikeVersion`<br/>*string* | KE protocol version to use when establishing the VPN tunnel with the peer VPN gateway. Acceptable IKE versions are 1 or 2. The default version is 2
-`peerIP`<br/>*string* | The IP address of the Virtual Private Cloud (VPC) the tunnel will connect to
-`remoteTrafficSelector`<br/>*string* | Remote traffic selectors to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string
+`name`<br/>*string* | The display name of the VPN tunnel.
+`ikeVersion`<br/>*string* | KE protocol version to use when establishing the VPN tunnel with the peer VPN gateway. Acceptable IKE versions are 1 or 2. The default version is 2.
+`peerIP`<br/>*string* | The IP address of the Virtual Private Cloud (VPC) the tunnel will connect to.
+`remoteTrafficSelector`<br/>*string* | Remote traffic selectors to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string.
 `sharedSecret`<br/>*string* | TShared secret used to set the secure session between the Cloud VPN gateway and the peer VPN gateway.
-`targetVpnGateway`<br/>*string* | URL of the Target VPN gateway with which this VPN tunnel is associated
+`targetVpnGateway`<br/>*string* | URL of the Target VPN gateway with which this VPN tunnel is associated.
 
 Optional | &nbsp;
 ------- | -----------
-`description`<br/>*string* | An optional description
-`localTrafficSelector`<br/>*string* | Local traffic selector to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string
+`description`<br/>*string* | An optional description.
+`localTrafficSelector`<br/>*string* | Local traffic selector to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string.
 
 <!-------------------- DELETE VPN GATEWAY -------------------->
 
@@ -211,5 +211,5 @@ Delete a Classic VPN tunnel in a given [environment](#administration-environment
 
 Optional | &nbsp;
 ------- | -----------
-`vpnGatewayToDelete`<br/>*string* | The ID of the VPN gateway to delete after deleting the VPN tunnel
+`vpnGatewayToDelete`<br/>*string* | The ID of the VPN gateway to delete after deleting the VPN tunnel.
 `gcpVpnGateway.externalIpToRelease`<br/>*Array* | A list with only one element specifying the IP address to release.

--- a/source/includes/masterportal/_applications.md
+++ b/source/includes/masterportal/_applications.md
@@ -21,14 +21,14 @@ curl -X POST \
   "taskStatus": "SUCCESS"
 }
 ```
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/apps/:id</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/apps/:id?operation=addCredentials</code>
 
 Add credentials to your own user for the given application.
 
 Required | &nbsp;
 ---------- | -----
-`username`<br/>*string* | The username for the application
-`password`<br/>*string* | The password for the application
+`username`<br/>*string* | The username for the application.
+`password`<br/>*string* | The password for the application.
 
 #### Add Credentials for Another User
 
@@ -55,17 +55,17 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/appUser/:id</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/appUser/:id?operation=addUserCredentials</code>
 
 Add credentials to another user for the given application. Note the appUser's id
 is their [CloudMC user](#administration-users) id and [application](#masterportal-applications) id concatenated like `<cloudMcUserId>:<appId>`.
 
 Required | &nbsp;
 ---------- | -----
-`cloudMcUserId`<br/>*UUID* | The id for the *cloudmc* user to which the credentials should be added
-`app > id`<br/>*UUID* | The id of the [application](#masterportal-applications) to which the credentials should be added
-`app > username`<br/>*string* | The username for the application
-`app > password`<br/>*string* | The password for the application
+`cloudMcUserId`<br/>*UUID* | The id for the *cloudmc* user to which the credentials should be added.
+`app > id`<br/>*UUID* | The id of the [application](#masterportal-applications) to which the credentials should be added.
+`app > username`<br/>*string* | The username for the application.
+`app > password`<br/>*string* | The password for the application.
 
 #### Login to An Application
 

--- a/source/includes/openstack/_routerInterfaces.md
+++ b/source/includes/openstack/_routerInterfaces.md
@@ -101,7 +101,7 @@ curl -X POST \
 
 Create a router interface.
 
-Required attributes          | Description                          
+Required          | Description                          
 --------------------------   | ------------------------------------
 `networkId`<br/>*UUID*        | The ID of the network that is being connected. 
 `routerId`<br/>*UUID*         | The ID of the router.

--- a/source/includes/openstack/_securityGroupRules.md
+++ b/source/includes/openstack/_securityGroupRules.md
@@ -122,11 +122,11 @@ curl -X POST \
 
 Create a security group rule for a security group.
 
- Required attributes          | Description                          
+ Required          | Description                          
  --------------------------   | ------------------------------------
  `securityGroupId`<br/>*UUID* | The ID of the parent security group.
 
- Optional attributes          | Description                          
+ Optional          | Description                          
  --------------------------   | ------------------------------------
  `ingress`<br/>*boolean*      | Direction in which the rule is applied, false implies egress. Defaults to ingress.            
  `protocol`<br/>*string*      | The IP protocol, either ICMP, TCP or UDP. Defaults to allow all protocols.

--- a/source/includes/openstack/_securityGroups.md
+++ b/source/includes/openstack/_securityGroups.md
@@ -89,7 +89,7 @@ curl -X POST \
 
 Create a security group in an environment.
 
-| Required attributes        | Description                          |
+| Required        | Description                          |
 | -------------------------- | ------------------------------------ |
 | `name`<br/>*string*        | The security group's name.            |
 | `description`<br/>*string* | A description of the group's purpose. |

--- a/source/includes/openstack/_sshKeys.md
+++ b/source/includes/openstack/_sshKeys.md
@@ -97,7 +97,7 @@ curl -X POST \
 
 Create a SSH key.
 
-Required attributes                | Description                         
+Required                | Description                         
 ---------------------------------- | -----------------------------------
 `name`<br/>*string*                | The SSH key's name.
 `publicKey`<br/>*string*           | A public SSH key in RSA format.

--- a/source/includes/openstack/_volumes.md
+++ b/source/includes/openstack/_volumes.md
@@ -101,7 +101,7 @@ curl -X POST \
 
 Create a volume.
 
-Required attributes                | Description                         
+Required                | Description                         
 ---------------------------------- | -----------------------------------
 `name`<br/>*string*                | The volume name.
 `description`<br/>*string*         | The volume description.
@@ -140,7 +140,7 @@ curl -X POST \
 
 Attach a volume to an instance.
 
-Required attributes                | Description                         
+Required                | Description                         
 ---------------------------------- | -----------------------------------
 `instanceId`<br/>*UUID*            | The instance id.
 
@@ -177,7 +177,7 @@ curl -X POST \
 
 Extend a volume size.
 
-Required attributes                | Description                         
+Required                | Description                         
 ---------------------------------- | -----------------------------------
 `sizeInGB`<br/>*integer*            | The new size of the volume. It must be greater than the existing size.
 

--- a/source/includes/swift/_containers.md
+++ b/source/includes/swift/_containers.md
@@ -136,7 +136,7 @@ curl -X POST \
 
 Create a new container.
 
-Required | &nbsp;∂===
+Required | &nbsp;
 ------- | -----------
 `name` <br/>*string* | The name of the container. It cannot exceed 256 characters and cannot contain '/'.
 


### PR DESCRIPTION
### Acceptance review fixes for [MC-10744](https://cloud-ops.atlassian.net/browse/MC-10744)

I can't leave a review since I opened the PR but I reviewed all the diffs, most of which are grammar fixes and adding periods.

#### Changes made
- Add missing query params to masterportal docs
- Change some table headers from *Required attributes* to *Required*, same for *Optional*
- Progress on adding periods to all tables and descriptions (thanks @lamminade)
- Still missing periods in `Cloudstack`, `Openstack`, `Kubernetes` and `Azure` docs but will create an issue for this

#### Related PRs
- #132 
- #133 
- #134 

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->