### PR TITLE
Feature/mc 10755 list namespaces

### DIFF
--- a/source/includes/kubernetes/_k8_namespaces.md
+++ b/source/includes/kubernetes/_k8_namespaces.md
@@ -1,0 +1,165 @@
+## Namespaces
+
+
+<!-------------------- LIST NAMESPACES -------------------->
+
+### List namespaces
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/namespaces"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "auth",
+      "metadata": {
+        "creationTimestamp": "2019-06-06T16:55:32.000-04:00",
+        "name": "auth",
+        "resourceVersion": "17516456",
+        "selfLink": "/api/v1/namespaces/auth",
+        "uid": "6cd793ae-889d-11e9-95db-02007a9a453g"
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "id": "cert-manager",
+      "metadata": {
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"cert-manager\"}}\n"
+        },
+        "creationTimestamp": "2020-04-24T15:06:10.000-04:00",
+        "name": "cert-manager",
+        "resourceVersion": "110011696",
+        "selfLink": "/api/v1/namespaces/cert-manager",
+        "uid": "ab4376c2-bb6d-44ae-a576-hdyr45839djs"
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "id": "lab",
+      "metadata": {
+        "creationTimestamp": "2019-07-10T16:51:13.000-04:00",
+        "name": "lab",
+        "resourceVersion": "25347372",
+        "selfLink": "/api/v1/namespaces/lab",
+        "uid": "74716eb1-a354-11e9-8c9b-1029384wedad"
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    }
+  ],
+  "metadata": {
+    "recordCount": 3
+  }
+}
+```
+
+
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/namespaces</code>
+
+Retrieve a list of all namespaces in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id` <br/>*string* | The id of the namespace.  
+`metadata` <br/>*object* | The metadata of the the namespace
+`metadata.annotations` <br/>*map* | The annotations of the namespace
+`metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string
+`metadata.name` <br/>*string* | The name of the namespace
+`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of namespace object
+`metadata.selfLink` <br/>*string* | A URL representing the namespace object
+`metadata.uid` <br/>*object* | The UUID of the namespace
+`spec`<br/>*object* | The specification describes the attributes on a namespace.
+`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove object from storage
+`status`<br/>*object* | The status information of the namespace
+`status.phase`<br/>*string* | The status of the namespace. Possible statuses are Active, Terminating and Unknown
+
+
+
+<!-------------------- GET A NAMESPACE -------------------->
+
+### Get a namespace
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/namespaces/cert-manager"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "cert-manager",
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"cert-manager\"}}\n"
+      },
+      "creationTimestamp": "2020-04-24T15:06:10.000-04:00",
+      "name": "cert-manager",
+      "resourceVersion": "110011696",
+      "selfLink": "/api/v1/namespaces/cert-manager",
+      "uid": "ab4376c2-bb6d-44ae-a576-f9b24f2ea624"
+    },
+    "spec": {
+      "finalizers": [
+        "kubernetes"
+      ]
+    },
+    "status": {
+      "phase": "Active"
+    }
+  }
+}
+```
+
+
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/namespaces/:id</code>
+
+Retrieve a namespace and all its info in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id` <br/>*string* | The id of the namespace.
+`apiVersion` <br/>*string* | APIVersion defines the versioned schema of this representation of a namespace object
+`kind` <br/>*string* | A string value representing the REST resource this object represents
+`metadata` <br/>*object* | The metadata of the the namespace
+`metadata.annotations` <br/>*map* | The annotations of the namespace
+`metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string
+`metadata.name` <br/>*string* | The name of the namespace
+`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of namespace object
+`metadata.selfLink` <br/>*string* | A URL representing the namespace object
+`metadata.uid` <br/>*object* | The UUID of the namespace
+`spec`<br/>*object* | The specification describes the attributes on a namespace.
+`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove object from storage
+`status`<br/>*object* | The status information of the namespace
+`status.phase`<br/>*string* | The status of the namespace. Possible statuses are Active, Terminating and Unknown

--- a/source/includes/kubernetes/_k8_namespaces.md
+++ b/source/includes/kubernetes/_k8_namespaces.md
@@ -8,7 +8,7 @@
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/namespaces"
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/namespaces"
 ```
 > The above command returns JSON structured like this:
 
@@ -88,17 +88,17 @@ Retrieve a list of all namespaces in a given [environment](#administration-envir
 Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id of the namespace.  
-`metadata` <br/>*object* | The metadata of the the namespace
+`metadata` <br/>*object* | The metadata of the namespace
 `metadata.annotations` <br/>*map* | The annotations of the namespace
 `metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string
 `metadata.name` <br/>*string* | The name of the namespace
-`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of namespace object
+`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of the namespace object
 `metadata.selfLink` <br/>*string* | A URL representing the namespace object
 `metadata.uid` <br/>*object* | The UUID of the namespace
 `spec`<br/>*object* | The specification describes the attributes on a namespace.
-`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove object from storage
+`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove the object from storage
 `status`<br/>*object* | The status information of the namespace
-`status.phase`<br/>*string* | The status of the namespace. Possible statuses are Active, Terminating and Unknown
+`status.phase`<br/>*string* | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`
 
 
 
@@ -109,7 +109,7 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/anenvironment/namespaces/cert-manager"
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/namespaces/cert-manager"
 ```
 > The above command returns JSON structured like this:
 
@@ -152,14 +152,14 @@ Attributes | &nbsp;
 `id` <br/>*string* | The id of the namespace.
 `apiVersion` <br/>*string* | APIVersion defines the versioned schema of this representation of a namespace object
 `kind` <br/>*string* | A string value representing the REST resource this object represents
-`metadata` <br/>*object* | The metadata of the the namespace
+`metadata` <br/>*object* | The metadata of the namespace
 `metadata.annotations` <br/>*map* | The annotations of the namespace
 `metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string
 `metadata.name` <br/>*string* | The name of the namespace
-`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of namespace object
+`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of the namespace object
 `metadata.selfLink` <br/>*string* | A URL representing the namespace object
 `metadata.uid` <br/>*object* | The UUID of the namespace
 `spec`<br/>*object* | The specification describes the attributes on a namespace.
-`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove object from storage
+`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove the object from storage
 `status`<br/>*object* | The status information of the namespace
-`status.phase`<br/>*string* | The status of the namespace. Possible statuses are Active, Terminating and Unknown
+`status.phase`<br/>*string* | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -213,7 +213,7 @@ Retrieve a list of all pods in a given [environment](#administration-environment
 Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id of the pod.  
-`metadata` <br/>*object* | The metadata of the the pod
+`metadata` <br/>*object* | The metadata of the pod
 `metadata.annotations` <br/>*map* | The annotations of the pod
 `metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string
 `metadata.labels` <br/>*map* | The labels associated to the pod and there associated values
@@ -222,8 +222,8 @@ Attributes | &nbsp;
 `metadata.uid` <br/>*object* | The UUID of the pod
 `spec`<br/>*object* | The specification used to create and run the pod
 `spec.container`<br/>*string* | The name of the container running
-`status`<br/>*object* | The status information of the the pod
-`status.phase`<br/>*string* | The status of the the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed
+`status`<br/>*object* | The status information of the pod
+`status.phase`<br/>*string* | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed
 
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
@@ -442,7 +442,7 @@ Retrieve a pod and all its info in a given [environment](#administration-environ
 Attributes | &nbsp;
 ------- | -----------
 `id` <br/>*string* | The id of the pod.  
-`metadata` <br/>*object* | The metadata of the the pod
+`metadata` <br/>*object* | The metadata of the pod
 `metadata.annotations` <br/>*map* | The annotations of the pod
 `metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string
 `metadata.labels` <br/>*map* | The labels associated to the pod and there associated values
@@ -451,8 +451,8 @@ Attributes | &nbsp;
 `metadata.uid` <br/>*object* | The UUID of the pod
 `spec`<br/>*object* | The specification used to create and run the pod
 `spec.container`<br/>*string* | The name of the container running
-`status`<br/>*object* | The status information of the the pod
-`status.phase`<br/>*string* | The status of the the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed
+`status`<br/>*object* | The status information of the pod
+`status.phase`<br/>*string* | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed
 
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -86,12 +86,14 @@ includes:
   - gcp/k8_pods
   - gcp/k8_releases
   - gcp/k8_charts
+  - gcp/k8_namespaces
   - gcp/images
   - gcp/regions
   - kubernetes
   - kubernetes/k8_pods
   - kubernetes/k8_releases
   - kubernetes/k8_charts
+  - kubernetes/k8_namespaces
   - azure
   - azure/compute
   - azure/instances


### PR DESCRIPTION
### Fixes [MC-10755](https://cloud-ops.atlassian.net/browse/MC-10755)

#### Changes made
<!-- Changes should match the template provided below -->
- Added docs for listing all namespace and getting details of a specific k8s namespace.

#### Related PRs
- https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/52
- https://github.com/cloudops/cloudmc-kubernetes-plugin/pull/24

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->