### PR TITLE
Add authentication documentation

### DIFF
--- a/source/includes/administration/_authentication.md
+++ b/source/includes/administration/_authentication.md
@@ -2,7 +2,7 @@
 
 
 
-<!-------------------- LIST ENVIRONMENTS -------------------->
+<!-------------------- LIST IDPS -------------------->
 
 ### List identity providers
 

--- a/source/includes/administration/_authentication.md
+++ b/source/includes/administration/_authentication.md
@@ -1,0 +1,66 @@
+## Authentication
+
+
+
+<!-------------------- LIST ENVIRONMENTS -------------------->
+
+### List identity providers
+
+`GET /identity_providers`
+
+```shell
+# Retrieve identity providers
+curl "https://cloudmc_endpoint/v1/identity_providers" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [{
+      "provider": "GOOGLE",
+      "displayName": "Google",
+      "logo": "aHR0cHM6Ly9kZXZlbG9wZXJzLmdvb2dsZS5jb20vaWR23nRpdHkvaW1hZ2VzL2ctbG9nby5wbmc=",
+      "identityProviderUsers": [
+        {
+          "user": {
+            "id": "0c4hc34e-ff76-48de-8976-7cb2fc89aa96"
+          },
+          "subjectId": "totallyFakeSubjectID"
+        }
+      ],
+      "id": "02b3cbd5-9286-4cd7-b47e-22b2fb9ceae5",
+      "connectionName": "Google",
+      "type": "OIDC",
+      "parameters": [
+        {
+          "parameter": "issuerURL",
+          "id": "02b3cbd5-9286-4cd7-b47e-22b2fb9ceab1",
+          "value": "https://accounts.google.com"
+        },
+        {
+          "parameter": "clientSecret",
+          "id": "02b3cbd5-9286-4cd7-b47e-22b2fb9ceab3",
+          "value": "sssshhhhhhhhh"
+        },
+        {
+          "parameter": "clientID",
+          "id": "02b3cbd5-9286-4cd7-b47e-22b2fb9ceab4",
+          "value": "shhhID"
+        }
+      ]
+    }]
+}
+```
+List the identity providers configured on the system.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the identity provider.
+`provider`<br/>*string* | The name of the provider. Possible values include the default providers (e.g GOOGLE), or CUSTOM for a custom user-defined provider.
+`displayName`<br/>*string* | The display name of the identity provider that will appear on the login screen.
+`logo`<br/>*string* | A base64 encoded data url for the logo to display on the login screen.
+`identityProviderUsers`<br/>*Array* | A list of objects containing the ids of users associated with the identity provider, and their subject ids.
+`connectionName`<br/>*string* | The connection name of the identity provider.
+`type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
+`parameters`<br/>*Array* | A list of parameters associated with the identity provider.

--- a/source/includes/administration/_authentication.md
+++ b/source/includes/administration/_authentication.md
@@ -1,5 +1,5 @@
 ## Authentication
-
+Configure methods of authentication for your organizations.
 
 
 <!-------------------- LIST IDPS -------------------->

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -5,7 +5,7 @@ The product catalogs determine the product configured for a service type and opt
 <!-------------------- LIST PRODUCT CATALOGS -------------------->
 #### List product catalogs
 
-`GET /product_catalogs
+`GET /product_catalogs`
 
 Retrieves a list of product catalogs configured in the system.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -18,6 +18,7 @@ includes:
   - administration/monetization
   - administration/products
   - administration/pricings
+  - administration/authentication
   - cloudstack
   - cloudstack/compute # Compute section
   - cloudstack/instances


### PR DESCRIPTION
### Fixes [MC-11029](https://cloud-ops.atlassian.net/browse/MC-)

#### Changes made
<!-- Changes should match the template provided below -->
- Added authentication section under administration
- Added documentation on list identity providers

#### Related PRs
- [core](https://github.com/cloudops/cloudmc-core/pull/799)
- [ui](https://github.com/cloudops/cloudmc-ui/pull/838)
<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->