### PR TITLE
Add documentation for delete

### DIFF
--- a/source/includes/administration/_authentication.md
+++ b/source/includes/administration/_authentication.md
@@ -150,14 +150,14 @@ Optional | &nbsp;
 
 <!-------------------- UPDATE IDPS -------------------->
 
-#### Update Identity Providr
+#### Update Identity Provider
 
 `POST /identity_providers/:id`
 
 Update an existing identity provider.
 
 ```shell
-# Creates a new identity provider
+# Updates an existing identity provider
 curl -X POST "https://cloudmc_endpoint/rest/identity_providers/c84cfe41-929b-47c9-bde4-b55a10bd2774" \
    -H "MC-Api-Key: your_api_key"
 ```
@@ -231,3 +231,30 @@ Required | &nbsp;
 Optional | &nbsp;
 ---------- | -----------
 `css`<br/>*string* | Custom css for the login button of the identity provider.
+
+<!-------------------- Delete IDPs -------------------->
+
+#### Delete Identity Provider
+
+`Delete /identity_providers/:id`
+
+Delete an existing identity provider.
+
+```shell
+# Deletes a specified identity provider
+curl -X DELETE "https://cloudmc_endpoint/rest/identity_providers/c84cfe41-929b-47c9-bde4-b55a10bd2774" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
+  "taskStatus": "SUCCESS"
+}
+```
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the identity provider deletion.
+`taskStatus` <br/>*string* | The status of the operation.


### PR DESCRIPTION
### Fixes **[MC-11523](https://cloud-ops.atlassian.net/browse/MC-11523)**

#### Changes made
<!-- Changes should match the template provided below -->
- Added delete idp documentation
#### Related PRs
- [UI changes](https://github.com/cloudops/cloudmc-ui/pull/849)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->