### PR TITLE
Feature/mc 10753 add deployments

### DIFF
--- a/source/includes/gcp/_k8_daemonsets.md
+++ b/source/includes/gcp/_k8_daemonsets.md
@@ -79,7 +79,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/statefulsets/test-aerospike/auth"
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/daemon sets/test-aerospike/auth"
 ```
 
 > The above command returns a JSON structured like this:
@@ -120,7 +120,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemon sets/:id</code>
 
 Retrieve a daemon set and all its info in a given [environment](#administration-environments).
 

--- a/source/includes/gcp/_k8_daemonsets.md
+++ b/source/includes/gcp/_k8_daemonsets.md
@@ -79,7 +79,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/daemon sets/test-aerospike/auth"
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/daemonsets/test-aerospike/auth"
 ```
 
 > The above command returns a JSON structured like this:
@@ -120,7 +120,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemon sets/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
 
 Retrieve a daemon set and all its info in a given [environment](#administration-environments).
 

--- a/source/includes/gcp/_k8_deployments.md
+++ b/source/includes/gcp/_k8_deployments.md
@@ -1,0 +1,157 @@
+### Deployments
+
+<!-------------------- LIST DEPLOYMENTS -------------------->
+
+#### List deployments
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/deployments"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "apm-server-1585600296-apm-server/monitoring",
+      "deploymentStatus": "Available",
+      "readyRatio": "1/1",
+      "metadata": {
+        "annotations": {
+          "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2020-03-30T16:31:43.000-04:00",
+        "generation": 1,
+        "labels": {
+          "app": "apm-server",
+          "release": "apm-server-1585600296"
+        },
+        "name": "apm-server-1585600296-apm-server",
+        "namespace": "monitoring",
+        "resourceVersion": "117204237",
+        "selfLink": "/apis/apps/v1/namespaces/monitoring/deployments/apm-server-1585600296-apm-server",
+        "uid": "783030e4-72c5-11ea-a953-02007a9a001f"
+      },
+      "spec": {
+        /*...*/
+      },
+      "status": {
+        "availableReplicas": 1,
+        "conditions": [
+          {
+            "lastTransitionTime": "2020-04-24T15:06:15.000-04:00",
+            "lastUpdateTime": "2020-04-24T15:08:43.000-04:00",
+            "message": "ReplicaSet \"cert-manager-webhook-6ff9487489\" has successfully progressed.",
+            "reason": "NewReplicaSetAvailable",
+            "status": "True",
+            "type": "Progressing"
+          }
+        ],
+        "observedGeneration": 1,
+        "readyReplicas": 1,
+        "replicas": 1,
+        "updatedReplicas": 1
+      }
+    }
+  ],
+  // ...
+  "metadata": {
+    "recordCount": 9
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments</code>
+
+Retrieve a list of all deployments in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the deployment                                        |
+| `metadata` <br/>_object_                   | The metadata of the deployment                                  |
+| `metadata.name` <br/>_string_              | The name of the deployment                                      |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                |
+| `metadata.uid` <br/>_object_               | The UUID of the deployment                                      |
+| `images` <br/>_object_                     | The container images within a deployment                        |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment         |
+| `status`<br/>_object_                      | The status information of the deployment                        |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET A DEPLOYMENT -------------------->
+
+#### Get a deployment
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/deployments/test-aerospike/auth"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "data": {
+      "id": "apm-server-1585600296-apm-server/monitoring",
+      "deploymentStatus": "Available",
+      "readyRatio": "1/1",
+      "metadata": {
+        "annotations": {
+          "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2020-03-30T16:31:43.000-04:00",
+        "generation": 1,
+        "labels": {
+          "app": "apm-server",
+          "release": "apm-server-1585600296"
+        },
+        "name": "apm-server-1585600296-apm-server",
+        "namespace": "monitoring",
+        "resourceVersion": "117204237",
+        "selfLink": "/apis/apps/v1/namespaces/monitoring/deployments/apm-server-1585600296-apm-server",
+        "uid": "783030e4-72c5-11ea-a953-02007a9a001f"
+      },
+      "spec": {
+        /*...*/
+      },
+      "status": {
+        "availableReplicas": 1,
+        "conditions": [
+          {
+            "lastTransitionTime": "2020-04-24T15:06:15.000-04:00",
+            "lastUpdateTime": "2020-04-24T15:08:43.000-04:00",
+            "message": "ReplicaSet \"cert-manager-webhook-6ff9487489\" has successfully progressed.",
+            "reason": "NewReplicaSetAvailable",
+            "status": "True",
+            "type": "Progressing"
+          }
+        ],
+        "observedGeneration": 1,
+        "readyReplicas": 1,
+        "replicas": 1,
+        "updatedReplicas": 1
+      }
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id</code>
+
+Retrieve a deployment and all its info in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the deployment                                        |
+| `metadata` <br/>_object_                   | The metadata of the deployment                                  |
+| `metadata.name` <br/>_string_              | The name of the deployment                                      |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                |
+| `metadata.uid` <br/>_object_               | The UUID of the deployment                                      |
+| `images` <br/>_object_                     | The container images within a deployment                        |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment         |
+| `status`<br/>_object_                      | The status information of the deployment                        |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -79,7 +79,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/statefulsets/test-aerospike/auth"
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/daemonsets/test-aerospike/auth"
 ```
 
 > The above command returns a JSON structured like this:
@@ -120,7 +120,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemon sets/:id</code>
 
 Retrieve a daemon set and all its info in a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -120,7 +120,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemon sets/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
 
 Retrieve a daemon set and all its info in a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -1,4 +1,4 @@
-### Deployments
+## Deployments
 
 <!-------------------- LIST DEPLOYMENTS -------------------->
 

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -1,0 +1,157 @@
+### Deployments
+
+<!-------------------- LIST DEPLOYMENTS -------------------->
+
+#### List deployments
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/deployments"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "apm-server-1585600296-apm-server/monitoring",
+      "deploymentStatus": "Available",
+      "readyRatio": "1/1",
+      "metadata": {
+        "annotations": {
+          "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2020-03-30T16:31:43.000-04:00",
+        "generation": 1,
+        "labels": {
+          "app": "apm-server",
+          "release": "apm-server-1585600296"
+        },
+        "name": "apm-server-1585600296-apm-server",
+        "namespace": "monitoring",
+        "resourceVersion": "117204237",
+        "selfLink": "/apis/apps/v1/namespaces/monitoring/deployments/apm-server-1585600296-apm-server",
+        "uid": "783030e4-72c5-11ea-a953-02007a9a001f"
+      },
+      "spec": {
+        /*...*/
+      },
+      "status": {
+        "availableReplicas": 1,
+        "conditions": [
+          {
+            "lastTransitionTime": "2020-04-24T15:06:15.000-04:00",
+            "lastUpdateTime": "2020-04-24T15:08:43.000-04:00",
+            "message": "ReplicaSet \"cert-manager-webhook-6ff9487489\" has successfully progressed.",
+            "reason": "NewReplicaSetAvailable",
+            "status": "True",
+            "type": "Progressing"
+          }
+        ],
+        "observedGeneration": 1,
+        "readyReplicas": 1,
+        "replicas": 1,
+        "updatedReplicas": 1
+      }
+    }
+  ],
+  // ...
+  "metadata": {
+    "recordCount": 9
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments</code>
+
+Retrieve a list of all deployments in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the deployment                                        |
+| `metadata` <br/>_object_                   | The metadata of the deployment                                  |
+| `metadata.name` <br/>_string_              | The name of the deployment                                      |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                |
+| `metadata.uid` <br/>_object_               | The UUID of the deployment                                      |
+| `images` <br/>_object_                     | The container images within a deployment                        |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment         |
+| `status`<br/>_object_                      | The status information of the deployment                        |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET A DEPLOYMENT -------------------->
+
+#### Get a deployment
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/deployments/test-aerospike/auth"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "data": {
+      "id": "apm-server-1585600296-apm-server/monitoring",
+      "deploymentStatus": "Available",
+      "readyRatio": "1/1",
+      "metadata": {
+        "annotations": {
+          "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2020-03-30T16:31:43.000-04:00",
+        "generation": 1,
+        "labels": {
+          "app": "apm-server",
+          "release": "apm-server-1585600296"
+        },
+        "name": "apm-server-1585600296-apm-server",
+        "namespace": "monitoring",
+        "resourceVersion": "117204237",
+        "selfLink": "/apis/apps/v1/namespaces/monitoring/deployments/apm-server-1585600296-apm-server",
+        "uid": "783030e4-72c5-11ea-a953-02007a9a001f"
+      },
+      "spec": {
+        /*...*/
+      },
+      "status": {
+        "availableReplicas": 1,
+        "conditions": [
+          {
+            "lastTransitionTime": "2020-04-24T15:06:15.000-04:00",
+            "lastUpdateTime": "2020-04-24T15:08:43.000-04:00",
+            "message": "ReplicaSet \"cert-manager-webhook-6ff9487489\" has successfully progressed.",
+            "reason": "NewReplicaSetAvailable",
+            "status": "True",
+            "type": "Progressing"
+          }
+        ],
+        "observedGeneration": 1,
+        "readyReplicas": 1,
+        "replicas": 1,
+        "updatedReplicas": 1
+      }
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id</code>
+
+Retrieve a deployment and all its info in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the deployment                                        |
+| `metadata` <br/>_object_                   | The metadata of the deployment                                  |
+| `metadata.name` <br/>_string_              | The name of the deployment                                      |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                |
+| `metadata.uid` <br/>_object_               | The UUID of the deployment                                      |
+| `images` <br/>_object_                     | The container images within a deployment                        |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment         |
+| `status`<br/>_object_                      | The status information of the deployment                        |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -88,6 +88,7 @@ includes:
   - gcp/k8_pods
   - gcp/k8_statefulsets
   - gcp/k8_daemonsets
+  - gcp/k8_deployments
   - gcp/k8_releases
   - gcp/k8_charts
   - gcp/k8_namespaces
@@ -97,6 +98,7 @@ includes:
   - kubernetes/k8_pods
   - kubernetes/k8_statefulsets
   - kubernetes/k8_daemonsets
+  - kubernetes/k8_deployments
   - kubernetes/k8_releases
   - kubernetes/k8_charts
   - kubernetes/k8_namespaces


### PR DESCRIPTION
### Fixes [MC-10753](https://cloud-ops.atlassian.net/browse/MC-10753)

#### Changes made
<!-- Changes should match the template provided below -->
- I added a "Deployments" page to both kubernetes and GCP Kubernetes

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->