### PR TITLE
Feature/mc 10292 create applied pricing

### DIFF
--- a/source/includes/administration/_applied_princings.md
+++ b/source/includes/administration/_applied_princings.md
@@ -76,7 +76,7 @@ Attributes | &nbsp;
 `scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
 `scopeOrganization.name`<br/>*string* | The name of the organization.
 `creationDate`<br/>*Object* | The date the applied pricing was created.
-`status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, WILL_BE_ACTIVE.
+`status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, FUTURE.
 
 
 <!-------------------- GET APPLIED PRICING -------------------->
@@ -151,7 +151,7 @@ Attributes | &nbsp;
 `scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
 `scopeOrganization.name`<br/>*string* | The name of the organization.
 `creationDate`<br/>*Object* | The date the applied pricing was created.
-`status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, WILL_BE_ACTIVE.
+`status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, FUTURE.
 
 <!-------------------- CREATE APPLIED PRICING -------------------->
 #### Create applied pricing
@@ -212,7 +212,7 @@ Required | &nbsp;
 ------- | -----------
 `organization.id` <br/>*UUID* | The UUID of the organization the applied pricing belongs to. 
 `pricingDefinition.id` <br/>*UUID* | the UUID of the pricing that will be used in the applied pricing.
-`scopeQualifier` <br/>*string* | The scope qualifier for the applied pricing. Possible values are : ORG_BASE, ORG_TREE, ORG_SUB, ORG_TOPLEVEL, TAG_ANYMATCH, GLOBAL.
+`scopeQualifier` <br/>*string* | The scope qualifier for the applied pricing. Possible values are : ORG_BASE, ORG_TREE, ORG_SUB, ORG_TOPLEVEL, GLOBAL.
 `currency` <br/>*String* | The currency used for the applied pricing. The value is a ISO 4217 currency code that is part of the pricing selected. 
 `startDate` <br/>*Date* | The start date for the applied pricing.
 `billingDay` <br/>*int*| The billing day that the applied pricing will be applied.

--- a/source/includes/administration/_applied_princings.md
+++ b/source/includes/administration/_applied_princings.md
@@ -1,0 +1,115 @@
+### Applied Pricings
+
+The applied pricing allows the assignment of pricing to organization with a determined scope.
+
+<!-------------------- LIST APPLIED PRICINGS -------------------->
+#### List applied pricings
+
+`GET /applied_pricings`
+
+Retrieves a list of applied pricings configured in the system.
+
+```shell
+# Retrieve applied pricing list
+curl "https://cloudmc_endpoint/rest/applied_pricings" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the pricing.
+`name`<br/>*Object* | The name object in each language for the pricing.
+`description`<br/>*string* | The description object in each language for the pricing.
+`supportedCurrencies`<br/>*Array[string]* | List of the currencies which are supported by this pricing.
+`productCatalogs`<br/>*Array[Object]* | List of product catalog objects which are attached to this pricing.
+`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the pricing.
+`pricingProducts`<br/>*Array[Object]* | The list of product pricings assigned to the pricing.
+`pricingProducts.id`<br/>*UUID* | UUID of the product pricing.
+`pricingProducts.unitPrice`<br/>*double* | The unit price of the product.
+`pricingProducts.product`<br/>*Object* | The product attached to this product pricing element.
+`pricingProducts.cogs`<br/>*double* | The Cost Of Goods Sold (COGS) of the product.
+`pricingProducts.currency`<br/>*string* | The currency of the pricing.
+
+
+<!-------------------- GET APPLIED PRICING -------------------->
+#### Retrieve an applied pricing
+
+`GET /applied_pricings/:id`
+
+Retrieve an applied pricing's details.
+
+```shell
+# Retrieve an applied pricing
+curl "https://cloudmc_endpoint/rest/applied_pricings/03bc22bd-adc4-46b8-988d-afddc24c0cb5" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the pricing.
+`name`<br/>*Object* | The name object in each language for the pricing.
+`description`<br/>*string* | The description object in each language for the pricing.
+`supportedCurrencies`<br/>*Array[string]* | List of the currencies which are supported by this pricing.
+`productCatalogs`<br/>*Array[Object]* | List of product catalog objects which are attached to this pricing.
+`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the pricing. It is more detailed.
+`pricingProducts`<br/>*Array[Object]* | The list of product pricings assigned to the pricing.
+`pricingProducts.id`<br/>*UUID* | UUID of the product pricing.
+`pricingProducts.unitPrice`<br/>*double* | The unit price of the product.
+`pricingProducts.product`<br/>*Object* | The product attached to this product pricing element.
+`pricingProducts.cogs`<br/>*double* | The Cost Of Goods Sold (COGS) of the product.
+`pricingProducts.currency`<br/>*string* | The currency of the pricing.
+
+<!-------------------- CREATE APPLIED PRICING -------------------->
+#### Create applied pricing
+
+`POST /applied_pricings`
+
+Create a new pricing.
+
+```shell
+# Creates a new pricing
+curl -X POST "https://cloudmc_endpoint/rest/applied_pricings" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```js
+{
+
+}
+```
+> The above command return JSON structured like this:
+
+```js
+{
+
+}
+```
+
+Required | &nbsp;
+------- | -----------
+`ownerOrganization.id` <br/>*UUID* | The UUID of the organization the applied pricing belongs to. 
+`pricingDefinition.id` <br/>*UUID* | the UUID of the pricing that will be used in the applied pricing.
+`scopeQualifier` <br/>*string* | The scope qualifier for the applied pricing. Possible values are : ORG_BASE, ORG_TREE, ORG_SUB, ORG_TOPLEVEL, TAG_ANYMATCH, GLOBAL.
+`currency` <br/>*String* | The currency used for the applied pricing. The value is a ISO 4217 currency code that is part of the pricing selected. 
+`startDate` <br/>*Date* | The start date for the applied pricing.
+`billingDay` <br/>*int*| The billing day of the month.
+
+Optional | &nbsp;
+------- | -----------
+`endDate` <br/>*Date* | The end date for the applied pricing. 
+`organization.id` <br/>*UUID* | The UUID of the organization that the scope is targeting. Only required for scopes : ORG_BASE, ORG_TREE, ORG_SUBS. 
+`tags` <br/>*Array[string]* | The list of tags to be scoped when the scope qualifier is TAGS_ANY_MATCH. 

--- a/source/includes/administration/_applied_princings.md
+++ b/source/includes/administration/_applied_princings.md
@@ -72,7 +72,7 @@ Attributes | &nbsp;
 `currency`<br/>*string* | The currency associated to the applied pricing.
 `billingDay`<br/>*int* | The billing day that the applied pricing will be applied.
 `scopeQualifier`<br/>*string* | Scope qualifier of the applied pricing. Possible values are : GLOBAL, ORG_TOPLEVEL, ORG_SUBS, ORG_BASE, ORG_TREE.
-`scopeOrganization`<br/>*Object* | The organisation to which the scope is applied to.
+`scopeOrganization`<br/>*Object* | The organization to which the scope is applied to.
 `scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
 `scopeOrganization.name`<br/>*string* | The name of the organization.
 `creationDate`<br/>*Object* | The date the applied pricing was created.
@@ -147,7 +147,7 @@ Attributes | &nbsp;
 `currency`<br/>*string* | The currency associated to the applied pricing.
 `billingDay`<br/>*int* | The billing day that the applied pricing will be applied.
 `scopeQualifier`<br/>*string* | Scope qualifier of the applied pricing. Possible values are : GLOBAL, ORG_TOPLEVEL, ORG_SUBS, ORG_BASE, ORG_TREE.
-`scopeOrganization`<br/>*Object* | The organisation to which the scope is applied to.
+`scopeOrganization`<br/>*Object* | The organization to which the scope is applied to.
 `scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
 `scopeOrganization.name`<br/>*string* | The name of the organization.
 `creationDate`<br/>*Object* | The date the applied pricing was created.
@@ -158,7 +158,7 @@ Attributes | &nbsp;
 
 `POST /applied_pricings`
 
-Create a new pricing.
+Create a new applied pricing.
 
 ```shell
 # Creates a new pricing

--- a/source/includes/administration/_applied_princings.md
+++ b/source/includes/administration/_applied_princings.md
@@ -95,7 +95,7 @@ curl -X POST "https://cloudmc_endpoint/rest/applied_pricings" \
 
 ```js
 {
-
+    
 }
 ```
 

--- a/source/includes/administration/_applied_princings.md
+++ b/source/includes/administration/_applied_princings.md
@@ -18,23 +18,65 @@ curl "https://cloudmc_endpoint/rest/applied_pricings" \
 
 ```json
 {
+  "data": [
+    {
+      "pricingDefinition": {
+        "supportedCurrencies": [
+          "CAD",
+          "USD"
+        ],
+        "organization": {
+          "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+        },
+        "name": {
+          "en": "Simple pricing",
+          "fr": "Facturaction simple"
+        },
+        "changes": [],
+        "description": {},
+        "id": "f786b9c5-177b-4cbc-9011-331282485d05",
+        "effectiveDate": "2020-06-04T17:55:17Z"
+      },
+      "endDate": "2021-06-05T23:59:59.999Z",
+      "organization": {
+        "name": "System",
+        "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+      },
+      "billingDay": 5,
+      "currency": "USD",
+      "id": "47c4993a-a131-4365-a427-02de95bad85b",
+      "creationDate": "2020-06-04T18:30:21.000Z",
+      "scopeQualifier": "GLOBAL",
+      "startDate": "2020-06-05T00:00:00Z",
+      "status": "ACTIVE"
+    }
+  ]
 }
 ```
 
 Attributes | &nbsp;
 ---- | -----------
-`id`<br/>*UUID* | The UUID of the pricing.
-`name`<br/>*Object* | The name object in each language for the pricing.
-`description`<br/>*string* | The description object in each language for the pricing.
-`supportedCurrencies`<br/>*Array[string]* | List of the currencies which are supported by this pricing.
-`productCatalogs`<br/>*Array[Object]* | List of product catalog objects which are attached to this pricing.
-`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the pricing.
-`pricingProducts`<br/>*Array[Object]* | The list of product pricings assigned to the pricing.
-`pricingProducts.id`<br/>*UUID* | UUID of the product pricing.
-`pricingProducts.unitPrice`<br/>*double* | The unit price of the product.
-`pricingProducts.product`<br/>*Object* | The product attached to this product pricing element.
-`pricingProducts.cogs`<br/>*double* | The Cost Of Goods Sold (COGS) of the product.
-`pricingProducts.currency`<br/>*string* | The currency of the pricing.
+`id`<br/>*UUID* | The UUID of the applied pricing.
+`pricingDefinition`<br/>*Object* | The pricing definition associated with the applied pricing.
+`pricingDefinition.id`<br/>*UUID* | The UUID of the pricing.
+`pricingDefinition.supportedCurrencies`<br/>*Array[string]* | The list of currencies associated to the pricing.
+`pricingDefinition.organization.id`<br/>*UUID* | The UUID of the organization owning of the pricing definition.
+`pricingDefinition.name`<br/>*Object* | Mapped object containing the pricing name in different languages.
+`pricingDefinition.description`<br/>*Object* | Mapped object containing the pricing description in different languages.
+`pricingDefinition.effectiveDate`<br/>*date* | The date to which the pricing will be applicable from.
+`organization`<br/>*Object* | The object representing the organization owning the applied pricing.
+`organization.id`<br/>*UUID* | The UUID of the organization.
+`organization.name`<br/>*string* | The name of the organization.
+`startDate`<br/>*date* | The start date of the applied pricing.
+`endDate`<br/>*date* | The end date of the applied pricing. If it is not present, there is no end date defined.
+`currency`<br/>*string* | The currency associated to the applied pricing.
+`billingDay`<br/>*int* | The billing day that the applied pricing will be applied.
+`scopeQualifier`<br/>*string* | Scope qualifier of the applied pricing. Possible values are : GLOBAL, ORG_TOPLEVEL, ORG_SUBS, ORG_BASE, ORG_TREE.
+`scopeOrganization`<br/>*Object* | The organisation to which the scope is applied to.
+`scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
+`scopeOrganization.name`<br/>*string* | The name of the organization.
+`creationDate`<br/>*Object* | The date the applied pricing was created.
+`status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, WILL_BE_ACTIVE.
 
 
 <!-------------------- GET APPLIED PRICING -------------------->
@@ -53,23 +95,63 @@ curl "https://cloudmc_endpoint/rest/applied_pricings/03bc22bd-adc4-46b8-988d-afd
 
 ```json
 {
+  "data": {
+    "pricingDefinition": {
+      "supportedCurrencies": [
+        "CAD",
+        "USD"
+      ],
+      "organization": {
+        "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+      },
+      "name": {
+        "en": "Simple pricing",
+        "fr": "Facturaction simple"
+      },
+      "changes": [],
+      "description": {},
+      "id": "f786b9c5-177b-4cbc-9011-331282485d05",
+      "effectiveDate": "2020-06-04T17:55:17Z"
+    },
+    "endDate": "2021-06-05T23:59:59.999Z",
+    "organization": {
+      "name": "System",
+      "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+    },
+    "billingDay": 5,
+    "currency": "USD",
+    "id": "47c4993a-a131-4365-a427-02de95bad85b",
+    "creationDate": "2020-06-04T18:30:21.000Z",
+    "scopeQualifier": "GLOBAL",
+    "startDate": "2020-06-05T00:00:00Z",
+    "status": "ACTIVE"
+  }
 }
 ```
 
 Attributes | &nbsp;
 ---- | -----------
-`id`<br/>*UUID* | The UUID of the pricing.
-`name`<br/>*Object* | The name object in each language for the pricing.
-`description`<br/>*string* | The description object in each language for the pricing.
-`supportedCurrencies`<br/>*Array[string]* | List of the currencies which are supported by this pricing.
-`productCatalogs`<br/>*Array[Object]* | List of product catalog objects which are attached to this pricing.
-`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the pricing. It is more detailed.
-`pricingProducts`<br/>*Array[Object]* | The list of product pricings assigned to the pricing.
-`pricingProducts.id`<br/>*UUID* | UUID of the product pricing.
-`pricingProducts.unitPrice`<br/>*double* | The unit price of the product.
-`pricingProducts.product`<br/>*Object* | The product attached to this product pricing element.
-`pricingProducts.cogs`<br/>*double* | The Cost Of Goods Sold (COGS) of the product.
-`pricingProducts.currency`<br/>*string* | The currency of the pricing.
+`id`<br/>*UUID* | The UUID of the applied pricing.
+`pricingDefinition`<br/>*Object* | The pricing definition associated with the applied pricing.
+`pricingDefinition.id`<br/>*UUID* | The UUID of the pricing.
+`pricingDefinition.supportedCurrencies`<br/>*Array[string]* | The list of currencies associated to the pricing.
+`pricingDefinition.organization.id`<br/>*UUID* | The UUID of the organization owning of the pricing definition.
+`pricingDefinition.name`<br/>*Object* | Mapped object containing the pricing name in different languages.
+`pricingDefinition.description`<br/>*Object* | Mapped object containing the pricing description in different languages.
+`pricingDefinition.effectiveDate`<br/>*date* | The date to which the pricing will be applicable from.
+`organization`<br/>*Object* | The object representing the organization owning the applied pricing.
+`organization.id`<br/>*UUID* | The UUID of the organization.
+`organization.name`<br/>*string* | The name of the organization.
+`startDate`<br/>*date* | The start date of the applied pricing.
+`endDate`<br/>*date* | The end date of the applied pricing. If it is not present, there is no end date defined.
+`currency`<br/>*string* | The currency associated to the applied pricing.
+`billingDay`<br/>*int* | The billing day that the applied pricing will be applied.
+`scopeQualifier`<br/>*string* | Scope qualifier of the applied pricing. Possible values are : GLOBAL, ORG_TOPLEVEL, ORG_SUBS, ORG_BASE, ORG_TREE.
+`scopeOrganization`<br/>*Object* | The organisation to which the scope is applied to.
+`scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
+`scopeOrganization.name`<br/>*string* | The name of the organization.
+`creationDate`<br/>*Object* | The date the applied pricing was created.
+`status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, WILL_BE_ACTIVE.
 
 <!-------------------- CREATE APPLIED PRICING -------------------->
 #### Create applied pricing
@@ -88,28 +170,54 @@ curl -X POST "https://cloudmc_endpoint/rest/applied_pricings" \
 
 ```js
 {
-
+  "pricingDefinition": {
+    "id": "f786b9c5-177b-4cbc-9011-331282485d05"
+  },
+  "organization": {
+    "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+  },
+  "billingDay": 5,
+  "currency": "USD",
+  "scopeQualifier": "GLOBAL",
+  "startDate": "2020-06-05T00:00:00Z",
+  "endDate": "2021-06-05T23:59:59.999Z"
 }
 ```
 > The above command return JSON structured like this:
 
 ```js
 {
-    
+  "data": {
+    "pricingDefinition": {
+      "name": {},
+      "changes": [],
+      "description": {},
+      "id": "f786b9c5-177b-4cbc-9011-331282485d05"
+    },
+    "endDate": "2021-06-05T23:59:59.999Z",
+    "organization": {
+      "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+    },
+    "billingDay": 5,
+    "currency": "USD",
+    "id": "8bb5e457-41c3-410b-aced-b9c694ff141a",
+    "creationDate": "2020-06-04T19:31:31.178Z",
+    "scopeQualifier": "GLOBAL",
+    "startDate": "2020-06-05T00:00:00Z"
+  }
 }
 ```
 
 Required | &nbsp;
 ------- | -----------
-`ownerOrganization.id` <br/>*UUID* | The UUID of the organization the applied pricing belongs to. 
+`organization.id` <br/>*UUID* | The UUID of the organization the applied pricing belongs to. 
 `pricingDefinition.id` <br/>*UUID* | the UUID of the pricing that will be used in the applied pricing.
 `scopeQualifier` <br/>*string* | The scope qualifier for the applied pricing. Possible values are : ORG_BASE, ORG_TREE, ORG_SUB, ORG_TOPLEVEL, TAG_ANYMATCH, GLOBAL.
 `currency` <br/>*String* | The currency used for the applied pricing. The value is a ISO 4217 currency code that is part of the pricing selected. 
 `startDate` <br/>*Date* | The start date for the applied pricing.
-`billingDay` <br/>*int*| The billing day of the month.
+`billingDay` <br/>*int*| The billing day that the applied pricing will be applied.
 
 Optional | &nbsp;
 ------- | -----------
 `endDate` <br/>*Date* | The end date for the applied pricing. 
-`organization.id` <br/>*UUID* | The UUID of the organization that the scope is targeting. Only required for scopes : ORG_BASE, ORG_TREE, ORG_SUBS. 
-`tags` <br/>*Array[string]* | The list of tags to be scoped when the scope qualifier is TAGS_ANY_MATCH. 
+`scopeOrganization.id` <br/>*UUID* | The UUID of the organization that the scope is targeting. Only required for scopes : ORG_BASE, ORG_TREE, ORG_SUBS. 

--- a/source/includes/administration/_pricings.md
+++ b/source/includes/administration/_pricings.md
@@ -110,7 +110,7 @@ Attributes | &nbsp;
 Retrieve a pricing's details.
 
 ```shell
-# Retrieve an organization
+# Retrieve a pricing's details
 curl "https://cloudmc_endpoint/rest/pricings/03bc22bd-adc4-46b8-988d-afddc24c0cb5" \
    -H "MC-Api-Key: your_api_key"
 ```

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -113,7 +113,7 @@ Attributes | &nbsp;
 Retrieve a product catalog's details.
 
 ```shell
-# Retrieve an organization
+# Retrieve a product catalog's details
 curl "https://cloudmc_endpoint/rest/product_catalogs/03bc22bd-adc4-46b8-988d-afddc24c0cb5" \
    -H "MC-Api-Key: your_api_key"
 ```

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -18,6 +18,7 @@ includes:
   - administration/monetization
   - administration/products
   - administration/pricings
+  - administration/applied_pricings
   - administration/authentication
   - cloudstack
   - cloudstack/compute # Compute section


### PR DESCRIPTION
### Fixes [MC-10292](https://cloud-ops.atlassian.net/browse/MC-10292)

#### Changes made
<!-- Changes should match the template provided below -->
- Added Applied Pricing list
- Added Applied Pricing Get
- Added Applied Pricing Create

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-core/pull/802
- PR # https://github.com/cloudops/cloudmc-ui/pull/841
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/158

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->