### PR TITLE
Feature/mc 11639 create subnet

### DIFF
--- a/source/includes/gcp/_subnets.md
+++ b/source/includes/gcp/_subnets.md
@@ -40,12 +40,6 @@ curl -X GET \
 
 Retrieve a list of all networks in a given [environment](#administration-environments).
 
-#### Filters:
-
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks?network=<a href="#VPC-network-selflink">:VPC-network-selflink</a></code>
-
-Retrieve a list of all networks in a given [environment](#administration-environments) and [VPC-network].
-
 Attributes | &nbsp;
 ------- | -----------
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
@@ -62,6 +56,12 @@ Attributes | &nbsp;
 `name`<br/>*string* | The display name of the subnet.
 `shortRegion`<br/>*string* | A short version of the region name
 
+#### Filters
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks?network=<a href="#VPC-network-selflink">:VPC-network-selflink</a></code>
+
+Retrieve a list of all networks in a given [environment](#administration-environments) and [VPC-network].
+
 <!-------------------- CREATE A SUBNETWORK -------------------->
 
 #### Create a subnet
@@ -72,7 +72,6 @@ curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/subnetworks"
-}'
 ```
 > Request body example:
 

--- a/source/includes/gcp/_subnetworks.md
+++ b/source/includes/gcp/_subnetworks.md
@@ -1,6 +1,67 @@
 ### Subnetworks
 Create and manage your subnetworks. Subnetworks belongs to a network.
 
+<!-------------------- LIST INSTANCES -------------------->
+
+#### List subnetworks
+
+```shell
+curl -X GET \
+  -H "mc-api-key: MSzI0RPkdvMgU9Y68oGRsw==" \
+  "https://cloudmc_endpoint/v1/services/gcp/test-area/subnetworks"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "creationTimestamp": "2020-05-28T07:20:17.315-07:00",
+      "fingerprint": "6S1Xfr1s97Y=",
+      "gatewayAddress": "10.128.0.1",
+      "ipCidrRange": "10.128.0.0/20",
+      "kind": "compute#subnetwork",
+      "network": "https://www.googleapis.com/compute/v1/projects/cmc-ankhang-gcp-env-ggb/global/networks/default",
+      "privateIpGoogleAccess": false,
+      "region": "https://www.googleapis.com/compute/v1/projects/cmc-ankhang-gcp-env-ggb/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/cmc-ankhang-gcp-env-ggb/regions/us-central1/subnetworks/default",
+      "shortNetwork": "default",
+      "id": "5575250766523954766",
+      "name": "default",
+      "shortRegion": "us-central1"
+    }],
+  "metadata": {
+    "recordCount": 1
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks</code>
+
+Retrieve a list of all networks in a given [environment](#administration-environments).
+
+#### Filters:
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks?network=<a href="#VPC-network-selflink">:VPC-network-selflink</a></code>
+
+Retrieve a list of all networks in a given [environment](#administration-environments) and [VPC-network].
+
+Attributes | &nbsp;
+------- | -----------
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`fingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
+`gatewayAddress`<br/>*string* | Second address in the primary IP range for the subnet
+`ipCidrRange`<br/>*string* | Primary IP address range for the following resources: VM instances, internal load balancers, and internal protocol forwarding
+`kind`<br/>*string* | Type of the resource
+`network`<br/>*string* | Server-defined URL for the VPC network that contains the subnet
+`privateIpGoogleAccess`<br/>*string* | Whether the Private Google Access is configured
+`region`<br/>*Array[Disk]* | Server-defined URL for the region name
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`shortNetwork`<br/>*string* | Display name of the VPC network that contains the subnet
+`id`<br/>*UUID* | The id of the instance
+`name`<br/>*string* | The display name of the subnetwork.
+`shortRegion`<br/>*string* | A short version of the region name
+
 <!-------------------- CREATE A SUBNETWORK -------------------->
 
 #### Create a subnet
@@ -18,9 +79,9 @@ curl -X POST \
 ```json
 {
   "name": "my-subnet",
-	"shortRegion": "northamerica-northeast1",
-	"ipCidrRange": "10.0.0.0/9",
-	"network": "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-network"
+  "shortRegion": "northamerica-northeast1",
+  "ipCidrRange": "10.0.0.0/9",
+  "network": "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-network"
 }
 ```
 

--- a/source/includes/gcp/_subnetworks.md
+++ b/source/includes/gcp/_subnetworks.md
@@ -1,0 +1,40 @@
+### Subnetworks
+Create and manage your subnetworks. Subnetworks belongs to a network.
+
+<!-------------------- CREATE A SUBNETWORK -------------------->
+
+#### Create a subnet
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/subnetworks"
+}'
+```
+> Request body example:
+
+```json
+{
+  "name": "my-subnet",
+	"shortRegion": "northamerica-northeast1",
+	"ipCidrRange": "10.0.0.0/9",
+	"network": "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-network"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks</code>
+
+Create a new subnetwork
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*string* | The display name of the instance
+`shortRegion`<br/>*string* | A short version of the region name
+`network`<br/>*string* | The selflink of the network
+`ipCidrRange`<br/>*string* | The CIDR IP range of the subnetwork
+
+Optional | &nbsp;
+------- | -----------
+`description`<br/>*string* | Description of the subnet

--- a/source/includes/gcp/_subnetworks.md
+++ b/source/includes/gcp/_subnetworks.md
@@ -1,13 +1,13 @@
-### Subnetworks
-Create and manage your subnetworks. Subnetworks belongs to a network.
+### Subnets
+Create and manage your subnets. Subnets belongs to a network.
 
 <!-------------------- LIST SUBNETWORKS -------------------->
 
-#### List subnetworks
+#### List subnets
 
 ```shell
 curl -X GET \
-  -H "mc-api-key: MSzI0RPkdvMgU9Y68oGRsw==" \
+  -H "mc-api-key: your_api_key" \
   "https://cloudmc_endpoint/v1/services/gcp/test-area/subnetworks"
 ```
 > The above command returns a JSON structured like this:
@@ -17,16 +17,16 @@ curl -X GET \
   "data": [
     {
       "creationTimestamp": "2020-05-28T07:20:17.315-07:00",
-      "fingerprint": "6S1Xfr1s97Y=",
+      "fingerprint": "resource_fingerprint",
       "gatewayAddress": "10.128.0.1",
       "ipCidrRange": "10.128.0.0/20",
       "kind": "compute#subnetwork",
-      "network": "https://www.googleapis.com/compute/v1/projects/cmc-ankhang-gcp-env-ggb/global/networks/default",
+      "network": "https://www.googleapis.com/compute/v1/projects/test-area-oox/global/networks/default",
       "privateIpGoogleAccess": false,
-      "region": "https://www.googleapis.com/compute/v1/projects/cmc-ankhang-gcp-env-ggb/regions/us-central1",
-      "selfLink": "https://www.googleapis.com/compute/v1/projects/cmc-ankhang-gcp-env-ggb/regions/us-central1/subnetworks/default",
+      "region": "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-central1/subnetworks/default",
       "shortNetwork": "default",
-      "id": "5575250766523954766",
+      "id": "resource_id",
       "name": "default",
       "shortRegion": "us-central1"
     }],
@@ -58,13 +58,13 @@ Attributes | &nbsp;
 `region`<br/>*Array[Disk]* | Server-defined URL for the region name
 `selfLink`<br/>*string* | Server-defined URL for this resource
 `shortNetwork`<br/>*string* | Display name of the VPC network that contains the subnet
-`id`<br/>*UUID* | The id of the instance
-`name`<br/>*string* | The display name of the subnetwork.
+`id`<br/>*UUID* | The id of the subnet
+`name`<br/>*string* | The display name of the subnet.
 `shortRegion`<br/>*string* | A short version of the region name
 
 <!-------------------- CREATE A SUBNETWORK -------------------->
 
-#### Create a subnetwork
+#### Create a subnet
 
 ```shell
 curl -X POST \
@@ -87,14 +87,14 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks</code>
 
-Create a new subnetwork
+Create a new subnet
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the instance
+`name`<br/>*string* | The display name of the subnet
 `shortRegion`<br/>*string* | A short version of the region name
 `network`<br/>*string* | The selflink of the network
-`ipCidrRange`<br/>*string* | The CIDR IP range of the subnetwork
+`ipCidrRange`<br/>*string* | The CIDR IP range of the subnet
 
 Optional | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_subnetworks.md
+++ b/source/includes/gcp/_subnetworks.md
@@ -1,7 +1,7 @@
 ### Subnetworks
 Create and manage your subnetworks. Subnetworks belongs to a network.
 
-<!-------------------- LIST INSTANCES -------------------->
+<!-------------------- LIST SUBNETWORKS -------------------->
 
 #### List subnetworks
 
@@ -64,7 +64,7 @@ Attributes | &nbsp;
 
 <!-------------------- CREATE A SUBNETWORK -------------------->
 
-#### Create a subnet
+#### Create a subnetwork
 
 ```shell
 curl -X POST \

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -77,7 +77,7 @@ includes:
   - gcp/routers
   - gcp/vpn_gateways
   - gcp/vpn_tunnels
-  - gcp/subnetworks
+  - gcp/subnets
   - gcp/load_balancing # Load balancing subsection
   - gcp/load_balancer
   - gcp/forwarding_rules

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -77,6 +77,7 @@ includes:
   - gcp/routers
   - gcp/vpn_gateways
   - gcp/vpn_tunnels
+  - gcp/subnetworks
   - gcp/load_balancing # Load balancing subsection
   - gcp/load_balancer
   - gcp/forwarding_rules


### PR DESCRIPTION
### Fixes [MC-11639 and MC-11641](https://cloud-ops.atlassian.net/browse/MC-11639 and https://cloud-ops.atlassian.net/browse/MC-11641)

#### Changes made
Added documentation for list and create subnetwork.

#### Related PRs
- [MC-11639] (https://cloud-ops.atlassian.net/browse/MC-11639)
- [MC-11641] (https://cloud-ops.atlassian.net/browse/MC-11641)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->

[MC-11639]: https://cloudops.atlassian.net/browse/MC-11639
[MC-11641]: https://cloudops.atlassian.net/browse/MC-11641