### PR TITLE
Mc 10555 startup script

### DIFF
--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -46,10 +46,16 @@ curl -X GET \
       ],
       "kind": "compute#instance",
       "labelFingerprint": "42WmSpB8rSM=",
-      "metadata": {
-        "fingerprint": "WFshDDge4fM=",
-        "kind": "compute#metadata"
-      },
+    "metadata": {
+      "fingerprint": "RnfaWQ2UP4U=",
+      "items": [
+        {
+          "key": "startup-script",
+          "value": "#! /bin/bash\napt-get update\nEOF"
+        }
+      ],
+      "kind": "compute#metadata"
+    },
       "networkInterfaces": [
         {
           "accessConfigs": [
@@ -187,6 +193,12 @@ curl -X GET \
     "labelFingerprint": "42WmSpB8rSM=",
     "metadata": {
       "fingerprint": "WFshDDge4fM=",
+      "items": [
+        {
+          "key": "startup-script",
+          "value": "#! /bin/bash\napt-get update\nEOF"
+        }
+      ],
       "kind": "compute#metadata"
     },
     "networkInterfaces": [
@@ -301,7 +313,8 @@ curl -X POST \
   "cpuCount": "2",
   "memoryInGB": "4.5",
   "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
-  "shortIP": "my-ip-name"
+  "shortIP": "my-ip-name",
+  "startupScript": "#! /bin/bash\napt-get update\nEOF"
 }
 
 // Create an instance with a new static IP
@@ -349,6 +362,7 @@ Optional | &nbsp;
 ------- | -----------
 `reserveStaticIP`<br/>*boolean* | If the value is false and if no shortIP is provided, an ephemeral external IP address will be assigned. If the value is true, a new static IP would be reserved and provided to the resource.
 `shortIP`<br/>*string* | The name of an existing regional external IP address assigned to this instance in the same region. This argument is only valid in conjunction with reserveStaticIP being false.
+`startupScript`<br/>*string* | A startup script metadata item to run every time the instance boots up.
 
 <!-------------------- DELETE AN INSTANCE -------------------->
 


### PR DESCRIPTION
### Fixes [MC-10555](https://cloud-ops.atlassian.net/browse/MC-10555)

#### Changes made
- Added startup script to sample create instance POST body
- Added startup script optional attribute description
- Added startup script key/value pair to data returned in list instances and get instance

#### Related PRs
- [GCP](https://github.com/cloudops/cloudmc-gcp-plugin/pull/237

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->