### PR TITLE
MC-11014: retrieve cluster api doc

### DIFF
--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -15,7 +15,7 @@ curl -X GET \
 ```
 > The above command returns a JSON structured like this:
 
-```json
+```js
 {
   "data": [
     {
@@ -68,7 +68,7 @@ curl -X GET \
 ```
 > The above command returns a JSON structured like this:
 
-```json
+```js
 {
   "data": {
       "id": "/subscriptions/9e548d49-7d56-452c-8fc8-e81a25d05ddf/resourcegroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.ContainerService/managedClusters/ssamadh-aks-mean",
@@ -89,11 +89,11 @@ Attributes        | &nbsp;
 -------           | -----------
 id                | The resource id
 name              | The name of the resource, unique within the environment
-provisioningState | The state of the cluster could be any of [Succeeded, Creating, Deleting, Updating, Cancelled, Failed],
+provisioningState | The state of the cluster could be any of [Succeeded, Creating, Deleting, Updating, Cancelled, Failed]
 dnsPrefix         | DNS prefix specified when creating the managed cluster
-nodePools         | Number of node container service agent pool.
+nodePools         | Number of node container service agent pool
 totalNodes        | The total number of nodes across all nodePools
 rbacEnabled       | Indicates of RBAC is enabled for this kubernetes cluster
 endpoint          | The fully qualified domain name (fqdn) for the master pool
 region            | The resource location
-version           | The version of kubernetes running in the cluster,
+version           | The version of kubernetes running in the cluster

--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -60,7 +60,8 @@ curl -X GET \
    "https://cloudmc_endpoint/v1/services/azure-conn/test_env/clusters/subscriptions/9e548d49-7d56-452c-8fc8-e81a25d05ddf/resourcegroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.ContainerService/managedClusters/ssamadh-aks-mean"
 ```
 
-Note: The cluster may also be retrieved by the cluster name: 
+Note: The above example uses the complete cluster id set by Azure. However, the cluster may also be retrieved by the cluster name as shown below:
+
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
@@ -90,8 +91,8 @@ Attributes        | &nbsp;
 id                | The resource id
 name              | The name of the resource, unique within the environment
 provisioningState | The state of the cluster could be any of [Succeeded, Creating, Deleting, Updating, Cancelled, Failed]
-dnsPrefix         | DNS prefix specified when creating the managed cluster
-nodePools         | Number of node container service agent pool
+dnsPrefix         | The DNS prefix specified when creating the managed cluster
+nodePools         | The number of node container service agent pool
 totalNodes        | The total number of nodes across all nodePools
 rbacEnabled       | Indicates of RBAC is enabled for this kubernetes cluster
 endpoint          | The fully qualified domain name (fqdn) for the master pool

--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -49,3 +49,51 @@ Attributes | &nbsp;
 ------- | -----------
 `data`<br/>*array* | A list of Azure Kubenetes Service (AKS) Clusters. _(See ["Retrieve an AKS cluster"](#azure-retrieve-an-aks-cluster) API for the strucutre of each AKS cluster object)_
 `metadata`<br/>*object* | Consists of the meta information related to the returned cluster list. The attribute `recordCount` contains the number of clusters returned.
+
+<!-------------------- Retrieve  AKS Cluster -------------------->
+
+#### Retrieve an AKS clusters
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/azure-conn/test_env/clusters/subscriptions/9e548d49-7d56-452c-8fc8-e81a25d05ddf/resourcegroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.ContainerService/managedClusters/ssamadh-aks-mean"
+```
+
+Note: The cluster may also be retrieved by the cluster name: 
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/azure-conn/test_env/clusters/ssamadh-aks-mean"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+      "id": "/subscriptions/9e548d49-7d56-452c-8fc8-e81a25d05ddf/resourcegroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.ContainerService/managedClusters/ssamadh-aks-mean",
+      "name": "ssamadh-basic",
+      "version": "premium_lrs",
+      "region": "southeastasia",
+      "nodePools": "4",
+      "totalNodes": "7",
+    },
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters/:cluster_name</code>
+
+Retrieve a specific AKS cluster in a given [environment](#administration-environments).
+
+Attributes        | &nbsp;
+-------           | -----------
+id                | The resource id
+name              | The name of the resource, unique within the environment
+provisioningState | The state of the cluster could be any of [Succeeded, Creating, Deleting, Updating, Cancelled, Failed],
+dnsPrefix         | DNS prefix specified when creating the managed cluster
+nodePools         | Number of node container service agent pool.
+totalNodes        | The total number of nodes across all nodePools
+rbacEnabled       | Indicates of RBAC is enabled for this kubernetes cluster
+endpoint          | The fully qualified domain name (fqdn) for the master pool
+region            | The resource location
+version           | The version of kubernetes running in the cluster,


### PR DESCRIPTION
### Fixes [MC-11014](https://cloud-ops.atlassian.net/browse/MC-11014)

#### Changes made
<!-- Changes should match the template provided below -->
- Added retrieve cluster doc

#### Related PRs
- [Cluster details](https://github.com/cloudops/cloudmc-azure-plugin/pull/198)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->