### PR TITLE
MC-10750: Added create cluster docs.

### DIFF
--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -141,10 +141,10 @@ Required | &nbsp;
 `primaryPoolNodeType`<br/>*string* | The size type of each virtual machine in the agent pool.
 `rbacEnabled`<br/>*boolean* | A boolean to indicate whether RBAC should be enabled on this cluster or not.
 `region`<br/>*string* | The name of the region for the cluster.
-`rootUsername`<br/>*string* | The user name to create a root user on cluster.
-
-Optional | &nbsp;
-------- | -----------
 `sshkey`<br/>*string* | The ssh key public portion that will be used to access cluster.
 `version` <br/>*string* | The version for the Kubernetes cluster.
 `vmScaleSetsEnabled`<br/>*boolean* | The boolean to indicate whether to use virtual machine scale sets or availability set for agent pool.
+
+Optional | &nbsp;
+------- | -----------
+`rootUsername`<br/>*string* | The user name to create a root user on cluster.

--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -15,7 +15,7 @@ curl -X GET \
 ```
 > The above command returns a JSON structured like this:
 
-```js
+```json
 {
   "data": [
     {
@@ -50,7 +50,55 @@ Attributes | &nbsp;
 `data`<br/>*array* | A list of Azure Kubenetes Service (AKS) Clusters. _(See ["Retrieve an AKS cluster"](#azure-retrieve-an-aks-cluster) API for the strucutre of each AKS cluster object)_
 `metadata`<br/>*object* | Consists of the meta information related to the returned cluster list. The attribute `recordCount` contains the number of clusters returned.
 
-<<<<<<< HEAD
+<!-------------------- Retrieve  AKS Cluster -------------------->
+
+#### Retrieve an AKS clusters
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/azure-conn/test_env/clusters/subscriptions/9e548d49-7d56-452c-8fc8-e81a25d05ddf/resourcegroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.ContainerService/managedClusters/ssamadh-aks-mean"
+```
+
+Note: The above example uses the complete cluster id set by Azure. However, the cluster may also be retrieved by the cluster name as shown below:
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/azure-conn/test_env/clusters/ssamadh-aks-mean"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+      "id": "/subscriptions/9e548d49-7d56-452c-8fc8-e81a25d05ddf/resourcegroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.ContainerService/managedClusters/ssamadh-aks-mean",
+      "name": "ssamadh-basic",
+      "version": "premium_lrs",
+      "region": "southeastasia",
+      "nodePools": "4",
+      "totalNodes": "7",
+    },
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters/:cluster_name</code>
+
+Retrieve a specific AKS cluster in a given [environment](#administration-environments).
+
+Attributes        | &nbsp;
+-------           | -----------
+`id` <br/>*string* | The resource id
+`name` <br/>*string* | The name of the resource, unique within the environment
+`provisioningState` <br/>*string*  | The state of the cluster could be any of [Succeeded, Creating, Deleting, Updating, Cancelled, Failed]
+`dnsPrefix`<br/>*string* | The DNS prefix specified when creating the managed cluster
+`nodePools`<br/>*int* | The number of node container service agent pool
+`totalNodes`<br/>*int* | The total number of nodes across all nodePools
+`rbacEnabled`<br/>*boolean* | Indicates of RBAC is enabled for this kubernetes cluster
+`endpoint`<br/>*string* | The fully qualified domain name (fqdn) for the master pool
+`region`<br/>*string* | The resource location
+`version` <br/>*string* | The version of kubernetes running in the cluster
+
 
 
 <!-------------------- CREATE AKS CLUSTER -------------------->
@@ -66,7 +114,7 @@ curl -X POST \
 ```
 > Request body examples:
 
-```js
+```json
 {
 	"version": "1.18.2",
 	"dnsPrefix": "kub-root-nik-dns",
@@ -99,54 +147,4 @@ Optional | &nbsp;
 ------- | -----------
 `sshkey`<br/>*string* | The ssh key public portion that will be used to access cluster.
 `version` <br/>*string* | The version for the Kubernetes cluster.
-`vmScaleSetsEnabled`<br/>*boolean* | The boolean to indicate whether to use virtual machine scale sets or availability set for agent pool. 
-=======
-<!-------------------- Retrieve  AKS Cluster -------------------->
-
-#### Retrieve an AKS clusters
-
-```shell
-curl -X GET \
-   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/azure-conn/test_env/clusters/subscriptions/9e548d49-7d56-452c-8fc8-e81a25d05ddf/resourcegroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.ContainerService/managedClusters/ssamadh-aks-mean"
-```
-
-Note: The above example uses the complete cluster id set by Azure. However, the cluster may also be retrieved by the cluster name as shown below:
-
-```shell
-curl -X GET \
-   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/azure-conn/test_env/clusters/ssamadh-aks-mean"
-```
-> The above command returns a JSON structured like this:
-
-```js
-{
-  "data": {
-      "id": "/subscriptions/9e548d49-7d56-452c-8fc8-e81a25d05ddf/resourcegroups/azure-connect-system-ssamadh-mean-env/providers/Microsoft.ContainerService/managedClusters/ssamadh-aks-mean",
-      "name": "ssamadh-basic",
-      "version": "premium_lrs",
-      "region": "southeastasia",
-      "nodePools": "4",
-      "totalNodes": "7",
-    },
-}
-```
-
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters/:cluster_name</code>
-
-Retrieve a specific AKS cluster in a given [environment](#administration-environments).
-
-Attributes        | &nbsp;
--------           | -----------
-id                | The resource id
-name              | The name of the resource, unique within the environment
-provisioningState | The state of the cluster could be any of [Succeeded, Creating, Deleting, Updating, Cancelled, Failed]
-dnsPrefix         | The DNS prefix specified when creating the managed cluster
-nodePools         | The number of node container service agent pool
-totalNodes        | The total number of nodes across all nodePools
-rbacEnabled       | Indicates of RBAC is enabled for this kubernetes cluster
-endpoint          | The fully qualified domain name (fqdn) for the master pool
-region            | The resource location
-version           | The version of kubernetes running in the cluster
->>>>>>> bcfd45fd21902eace4690eba92a6ab304a072f9b
+`vmScaleSetsEnabled`<br/>*boolean* | The boolean to indicate whether to use virtual machine scale sets or availability set for agent pool.

--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -49,3 +49,53 @@ Attributes | &nbsp;
 ------- | -----------
 `data`<br/>*array* | A list of Azure Kubenetes Service (AKS) Clusters. _(See ["Retrieve an AKS cluster"](#azure-retrieve-an-aks-cluster) API for the strucutre of each AKS cluster object)_
 `metadata`<br/>*object* | Consists of the meta information related to the returned cluster list. The attribute `recordCount` contains the number of clusters returned.
+
+
+
+<!-------------------- CREATE AKS CLUSTER -------------------->
+
+#### Create a cluster
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "http://cloudmc_endpoint/v1/services/azure/example/clusters"
+```
+> Request body examples:
+
+```js
+{
+	"version": "1.18.2",
+	"dnsPrefix": "kub-root-nik-dns",
+	"rootUsername": "root_nzk",
+	"primaryPoolNodeType": "Standard_B2ms",
+	"primaryPoolNodeCount": 1,
+	"vmScaleSetsEnabled": false,
+	"rbacEnabled": false,
+	"region": "canadacentral",
+	"name": "kub_root_nzk",
+	"sshkey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCguvgDRuUF/wijOJCNmYlQHujCmUHl/i0Ubos4nHy5uCBdn1LGF+PG3TpJqO1LUWqpHaPl4yN7bpsdXyq6a9nxe0C1bQ4FK6P5qm0X320uvqv34jwTPsIbnhw9I317df+xJyXXsL/P5vS4ULPMC5UZjWm4BYe7did4zmXXhA/zmLY6cUg19sZp5r5SUQcf5xHAqO3cQVZwzBhBMwroflZZ59zNpxy+xXPBqC3IdusF2yTDW7bwCQHESUOsd9XhwrzCB+1wETKjLpk0wkWj8G2j1pkKGRpv60QcG85lbZvQAg54v3HYD7fVJCaz9gJJoiyRBnqQ6XVxam5bZgiMKa0J johndoe@machine.local"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters</code>
+
+Create a new cluster.
+
+Required | &nbsp;
+------- | -----------
+`dnsPrefix`<br/>*string* | The DNS prefix to be used to create the FQDN for the master pool.
+`name`<br/>*string* | . The name of the cluster.
+`primaryPoolNodeCount`<br/>*string* | The number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive).
+`primaryPoolNodeType`<br/>*string* | The size type of each virtual machine in the agent pool.
+`rbacEnabled`<br/>*boolean* | A boolean to indicate whether RBAC should be enabled on this cluster or not.
+`region`<br/>*string* | The name of the region for the cluster.
+`rootUsername`<br/>*string* | The user name to create a root user on cluster.
+
+Optional | &nbsp;
+------- | -----------
+`sshkey`<br/>*string* | The ssh key public portion that will be used to access cluster.
+`version` <br/>*string* | The version for the Kubernetes cluster.
+`vmScaleSetsEnabled`<br/>*boolean* | The boolean to indicate whether to use virtual machine scale sets or availability set for agent pool. 


### PR DESCRIPTION
### Fixes [MC-10750](https://cloud-ops.atlassian.net/browse/MC-10750)

#### Changes made
<!-- Changes should match the template provided below -->
- Updated Azure Kubernetes documentation by adding create cluster related details.

#### Related PRs
- https://github.com/cloudops/cloudmc-azure-plugin/pull/195

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->