### PR TITLE
MC-11704 - API of list service providers

### DIFF
--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -118,3 +118,166 @@ Attributes | &nbsp;
 `config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response.
 `config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from. Possible values are : ORGANIZATION, USER.
 `config.responseAttributes.attributeValueField.fieldName`<br/>*string* | The field name to get the information from.
+
+
+<!-------------------- CREATE SERVICE PROVIDERS -------------------->
+
+#### Create service provider
+
+`POST /service_providers`
+
+```shell
+# Creates a new service provider
+curl -X POST "https://cloudmc_endpoint/rest/service_providers" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```js
+{
+	"name": "Slack",
+	"type": "SAML",
+	"config": {
+		"assertionConsumerUrl": "https://yourdomain.slack.com/sso/saml",
+		"serviceProviderIssuer": "https://slack.com",
+		"sign": "RESPONSE",
+		"responseAttributes": [
+			{
+				"attributeName": "first-name",
+				"attributeValueField": {
+					"sourceModel": "user",
+					"fieldName": "firstName"
+				}
+			}
+		]
+	}
+}
+```
+> The above command return JSON structured like this:
+
+```js
+{
+  "data": {
+    "name": "Slack",
+    "id": "dbf3df1c-d28e-4cb5-bcb9-ce85d1675b27",
+    "type": "SAML",
+    "config": {
+      "assertionConsumerUrl": "https://yourdomain.slack.com/sso/saml",
+      "nameIdFormat": "UNSPECIFIED",
+      "responseAttributes": [
+        {
+          "nameFormat": "UNSPECIFIED",
+          "attributeName": "first-name",
+          "attributeValueField": {
+            "fieldName": "firstName",
+            "sourceModel": "user"
+          }
+        }
+      ],
+      "name": "Slack",
+      "sign": "RESPONSE",
+      "serviceProviderIssuer": "https://slack.com"
+    }
+  }
+}
+```
+Required | &nbsp;
+---------- | -----------
+`name`<br/>*string* | The name of the service provider.
+`type`<br/>*string* | The type of service provider. Possible values are : SAML.
+`config`<br/>*Object* | The object containing the configuration of the service provider.
+`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
+`config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
+`config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE. Only required if `config.responseAttributes` is passed.
+`config.responseAttributes.attributeName`<br/>*string* | The attribute name. Only required if `config.responseAttributes` is passed.
+`config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response. Only required if `config.responseAttributes` is passed.
+`config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from. Possible values are : ORGANIZATION, USER. Only required if `config.responseAttributes` is passed.
+`config.responseAttributes.attributeValueField.fieldName`<br/>*string* | The field name to get the information from. Only required if `config.responseAttributes` is passed.
+
+Optional | &nbsp;
+---------- | -----------
+`config.nameIdFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, EMAIL_ADDRESS, X509_SUBJECT, WINDOWS_DQN, KERBEROS_PRINCIPAL, ENTITY, PERSISTENT and TRANSIENT. If not provided this defaults to UNSPECIFIED.
+`config.responseAttributes.nameFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, URI and BASIC. If not provided this defaults to UNSPECIFIED.
+`config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response.
+
+
+#### Update service provider
+
+`PUT /service_providers/:id`
+
+```shell
+# Updates an existing service provider
+curl -X POST "https://cloudmc_endpoint/rest/service_providers/:id" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```js
+{
+	"name": "Slack",
+  "id": "dbf3df1c-d28e-4cb5-bcb9-ce85d1675b27",
+	"type": "SAML",
+	"config": {
+		"assertionConsumerUrl": "https://yourdomain.slack.com/sso/saml",
+		"serviceProviderIssuer": "https://slack.com",
+		"sign": "RESPONSE",
+		"responseAttributes": [
+			{
+				"attributeName": "first-name",
+				"attributeValueField": {
+					"sourceModel": "user",
+					"fieldName": "firstName"
+				}
+			}
+		]
+	}
+}
+```
+> The above command return JSON structured like this:
+
+```js
+{
+  "data": {
+    "name": "Slack",
+    "id": "dbf3df1c-d28e-4cb5-bcb9-ce85d1675b27",
+    "type": "SAML",
+    "config": {
+      "assertionConsumerUrl": "https://yourdomain.slack.com/sso/saml",
+      "nameIdFormat": "UNSPECIFIED",
+      "responseAttributes": [
+        {
+          "nameFormat": "UNSPECIFIED",
+          "attributeName": "first-name",
+          "attributeValueField": {
+            "fieldName": "firstName",
+            "sourceModel": "user"
+          }
+        }
+      ],
+      "name": "Slack",
+      "sign": "RESPONSE",
+      "serviceProviderIssuer": "https://slack.com"
+    }
+  }
+}
+```
+Required | &nbsp;
+---------- | -----------
+`name`<br/>*string* | The name of the service provider.
+`type`<br/>*string* | The type of service provider. Possible values are : SAML.
+`config`<br/>*Object* | The object containing the configuration of the service provider.
+`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
+`config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
+`config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE. Only required if `config.responseAttributes` is passed.
+`config.responseAttributes.attributeName`<br/>*string* | The attribute name. Only required if `config.responseAttributes` is passed.
+`config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response. Only required if `config.responseAttributes` is passed.
+`config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from. Possible values are : ORGANIZATION, USER. Only required if `config.responseAttributes` is passed.
+`config.responseAttributes.attributeValueField.fieldName`<br/>*string* | The field name to get the information from. Only required if `config.responseAttributes` is passed.
+
+Optional | &nbsp;
+---------- | -----------
+`config.nameIdFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, EMAIL_ADDRESS, X509_SUBJECT, WINDOWS_DQN, KERBEROS_PRINCIPAL, ENTITY, PERSISTENT and TRANSIENT. If not provided this defaults to UNSPECIFIED.
+`config.responseAttributes.nameFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, URI and BASIC. If not provided this defaults to UNSPECIFIED.
+`config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response.

--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -110,7 +110,7 @@ Attributes | &nbsp;
 `config`<br/>*Object* | The object containing the configuration of the service provider.
 `config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what is contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
 `config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
-`config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
+`config.sign`<br/>*string* | How the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
 `config.nameIdFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, EMAIL_ADDRESS, X509_SUBJECT, WINDOWS_DQN, KERBEROS_PRINCIPAL, ENTITY, PERSISTENT and TRANSIENT.
 `config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response
 `config.responseAttributes.nameFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, URI and BASIC. 

--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -52,12 +52,12 @@ Attributes | &nbsp;
 `config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
 `config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
 `config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
-`config.nameIdFormat`<br/>*string* | The format for the name field
+`config.nameIdFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, EMAIL_ADDRESS, X509_SUBJECT, WINDOWS_DQN, KERBEROS_PRINCIPAL, ENTITY, PERSISTENT and TRANSIENT.
 `config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response
-`config.responseAttributes.nameFormat`<br/>*string* | The format for the name field
+`config.responseAttributes.nameFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, URI and BASIC. 
 `config.responseAttributes.attributeName`<br/>*string* | The attribute name
 `config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response.
-`config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from.
+`config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from. Possible values are : ORGANIZATION, USER.
 `config.responseAttributes.attributeValueField.fieldName`<br/>*string* | The field name to get the information from.
 
 
@@ -111,10 +111,10 @@ Attributes | &nbsp;
 `config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
 `config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
 `config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
-`config.nameIdFormat`<br/>*string* | The format for the name field
+`config.nameIdFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, EMAIL_ADDRESS, X509_SUBJECT, WINDOWS_DQN, KERBEROS_PRINCIPAL, ENTITY, PERSISTENT and TRANSIENT.
 `config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response
-`config.responseAttributes.nameFormat`<br/>*string* | The format for the name field
+`config.responseAttributes.nameFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, URI and BASIC. 
 `config.responseAttributes.attributeName`<br/>*string* | The attribute name
 `config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response.
-`config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from.
+`config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from. Possible values are : ORGANIZATION, USER.
 `config.responseAttributes.attributeValueField.fieldName`<br/>*string* | The field name to get the information from.

--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -49,9 +49,9 @@ Attributes | &nbsp;
 `name`<br/>*string* | The name of the service provider.
 `type`<br/>*string* | The type of service provider. Possible values are : SAML.
 `config`<br/>*Object* | The object containing the configuration of the service provider.
-`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
+`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what is contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
 `config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
-`config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
+`config.sign`<br/>*string* | How the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
 `config.nameIdFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, EMAIL_ADDRESS, X509_SUBJECT, WINDOWS_DQN, KERBEROS_PRINCIPAL, ENTITY, PERSISTENT and TRANSIENT.
 `config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response
 `config.responseAttributes.nameFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, URI and BASIC. 
@@ -108,7 +108,7 @@ Attributes | &nbsp;
 `name`<br/>*string* | The name of the service provider.
 `type`<br/>*string* | The type of service provider. Possible values are : SAML.
 `config`<br/>*Object* | The object containing the configuration of the service provider.
-`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
+`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what is contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
 `config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
 `config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
 `config.nameIdFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, EMAIL_ADDRESS, X509_SUBJECT, WINDOWS_DQN, KERBEROS_PRINCIPAL, ENTITY, PERSISTENT and TRANSIENT.

--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -201,6 +201,7 @@ Optional | &nbsp;
 `config.responseAttributes.nameFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, URI and BASIC. If not provided this defaults to UNSPECIFIED.
 `config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response.
 
+<!-------------------- UPDATE SERVICE PROVIDERS -------------------->
 
 #### Update service provider
 

--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -1,0 +1,120 @@
+## Service Providers
+Configure the service providers that can use CloudMC as their authentication source.
+
+<!-------------------- LIST SERVICE PROVIDERS -------------------->
+
+### List service providers
+
+`GET /service_providers`
+
+```shell
+# Retrieve service providers
+curl "https://cloudmc_endpoint/v1/service_providers" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "name": "Slack",
+      "id": "04b77783-516f-4064-a6df-e7f9cae222c1",
+      "type": "SAML",
+      "config": {
+        "assertionConsumerUrl": "issuer.com",
+        "nameIdFormat": "UNSPECIFIED",
+        "responseAttributes": [
+          {
+            "nameFormat": "UNSPECIFIED",
+            "attributeName": "username",
+            "attributeValueField": {
+              "fieldName": "firstName",
+              "sourceModel": "user"
+            }
+          }
+        ],
+        "sign": "RESPONSE",
+        "serviceProviderIssuer": "slack"
+      }
+    }
+  ]
+}
+```
+List the service providers configured on the system.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the service provider.
+`name`<br/>*string* | The name of the service provider.
+`type`<br/>*string* | The type of service provider. Possible values are : SAML.
+`config`<br/>*Object* | The object containing the configuration of the service provider.
+`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
+`config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
+`config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
+`config.nameIdFormat`<br/>*string* | The format for the name field
+`config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response
+`config.responseAttributes.nameFormat`<br/>*string* | The format for the name field
+`config.responseAttributes.attributeName`<br/>*string* | The attribute name
+`config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response.
+`config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from.
+`config.responseAttributes.attributeValueField.fieldName`<br/>*string* | The field name to get the information from.
+
+
+
+<!-------------------- GET SERVICE PROVIDERS -------------------->
+
+### Retrieve service provider
+
+`GET /service_provider/:id`
+
+```shell
+# Retrieve service providers
+curl "https://cloudmc_endpoint/v1/service_providers/04b77783-516f-4064-a6df-e7f9cae222c1" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "name": "Slack",
+    "id": "04b77783-516f-4064-a6df-e7f9cae222c1",
+    "type": "SAML",
+    "config": {
+      "assertionConsumerUrl": "issuer.com",
+      "nameIdFormat": "UNSPECIFIED",
+      "responseAttributes": [
+        {
+          "nameFormat": "UNSPECIFIED",
+          "attributeName": "username",
+          "attributeValueField": {
+            "fieldName": "firstName",
+            "sourceModel": "user"
+          }
+        }
+      ],
+      "sign": "RESPONSE",
+      "serviceProviderIssuer": "slack"
+    }
+  }
+}
+```
+Return the service provider configured associated to the id on the system.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the service provider.
+`name`<br/>*string* | The name of the service provider.
+`type`<br/>*string* | The type of service provider. Possible values are : SAML.
+`config`<br/>*Object* | The object containing the configuration of the service provider.
+`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
+`config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
+`config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE.
+`config.nameIdFormat`<br/>*string* | The format for the name field
+`config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response
+`config.responseAttributes.nameFormat`<br/>*string* | The format for the name field
+`config.responseAttributes.attributeName`<br/>*string* | The attribute name
+`config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response.
+`config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from.
+`config.responseAttributes.attributeValueField.fieldName`<br/>*string* | The field name to get the information from.

--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -187,9 +187,9 @@ Required | &nbsp;
 `name`<br/>*string* | The name of the service provider.
 `type`<br/>*string* | The type of service provider. Possible values are : SAML.
 `config`<br/>*Object* | The object containing the configuration of the service provider.
-`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
+`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what is contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
 `config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
-`config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE. Only required if `config.responseAttributes` is passed.
+`config.sign`<br/>*string* | How the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE. Only required if `config.responseAttributes` is passed.
 `config.responseAttributes.attributeName`<br/>*string* | The attribute name. Only required if `config.responseAttributes` is passed.
 `config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response. Only required if `config.responseAttributes` is passed.
 `config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from. Possible values are : ORGANIZATION, USER. Only required if `config.responseAttributes` is passed.
@@ -269,9 +269,9 @@ Required | &nbsp;
 `name`<br/>*string* | The name of the service provider.
 `type`<br/>*string* | The type of service provider. Possible values are : SAML.
 `config`<br/>*Object* | The object containing the configuration of the service provider.
-`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
+`config.serviceProviderIssuer`<br/>*string* | The issuer for the service provider. This is what is contained in the SAML request issuer tag. This is also referred to as the EntityID or EntityURL.
 `config.assertionConsumerUrl`<br/>*string* | The URL where the response is sent.
-`config.sign`<br/>*string* | How is the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE. Only required if `config.responseAttributes` is passed.
+`config.sign`<br/>*string* | How the returned XML is signed. Possible values are : ASSERTION, RESPONSE, ASSERTION_AND_RESPONSE. Only required if `config.responseAttributes` is passed.
 `config.responseAttributes.attributeName`<br/>*string* | The attribute name. Only required if `config.responseAttributes` is passed.
 `config.responseAttributes.attributeValueField`<br/>*Object* | The object containing the source for the value in the response. Only required if `config.responseAttributes` is passed.
 `config.responseAttributes.attributeValueField.sourceModel`<br/>*string* | The model object to get the value from. Possible values are : ORGANIZATION, USER. Only required if `config.responseAttributes` is passed.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -20,6 +20,7 @@ includes:
   - administration/pricings
   - administration/applied_pricings
   - administration/authentication
+  - administration/service_providers
   - cloudstack
   - cloudstack/compute # Compute section
   - cloudstack/instances


### PR DESCRIPTION
### Fixes [MC-11704](https://cloud-ops.atlassian.net/browse/MC-11704)

#### Code walkthrough : @evanluc 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
Lacking Service provider management.

#### Solution
Adding the first portion of the management, the list.

#### Test cases
- Unit test
- Manuel UI test

#### UI changes
System Menu and Service Provider List
![image](https://user-images.githubusercontent.com/56133634/84687582-fb124100-af0b-11ea-83b3-214cd069c01c.png)

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/165
- PR # https://github.com/cloudops/cloudmc-ui/pull/887

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->