### PR TITLE
MC-11640: doc for retrieve and delete subnet

### DIFF
--- a/source/includes/gcp/_subnets.md
+++ b/source/includes/gcp/_subnets.md
@@ -1,7 +1,7 @@
 ### Subnets
 Create and manage your subnets. Subnets belongs to a network.
 
-<!-------------------- LIST SUBNETWORKS -------------------->
+<!-------------------- LIST SUBNETS -------------------->
 
 #### List subnets
 
@@ -38,7 +38,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks</code>
 
-Retrieve a list of all networks in a given [environment](#administration-environments).
+Retrieve a list of all subnets in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
@@ -62,7 +62,58 @@ Attributes | &nbsp;
 
 Retrieve a list of all networks in a given [environment](#administration-environments) and [VPC-network].
 
-<!-------------------- CREATE A SUBNETWORK -------------------->
+<!-------------------- RETRIEVE A SUBNET -------------------->
+
+#### Retrieve a subnet
+
+```shell
+curl -X GET \
+  -H "mc-api-key: your_api_key" \
+  "https://cloudmc_endpoint/v1/services/gcp/test-area/subnetworks/8841143494674098002"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "creationTimestamp": "2020-06-12T08:05:33.741-07:00",
+    "fingerprint": "resource_fingerprint",
+    "gatewayAddress": "10.128.0.1",
+    "ipCidrRange": "10.128.0.0/20",
+    "kind": "compute#subnetwork",
+    "network": "https://www.googleapis.com/compute/v1/projects/test-area-oox/global/networks/default",
+    "privateIpGoogleAccess": false,
+    "region": "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-central1",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/test-area-oox/regions/us-central1/subnetworks/default",
+    "shortNetwork": "default",
+    "id": "resource_id",
+    "name": "default",
+    "shortRegion": "us-central1"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks/:id</code>
+
+Retrieve information about a subnet.
+
+Attributes | &nbsp;
+---------- | -----
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
+`fingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
+`gatewayAddress`<br/>*string* | Second address in the primary IP range for the subnet
+`ipCidrRange`<br/>*string* | Primary IP address range for the following resources: VM instances, internal load balancers, and internal protocol forwarding
+`kind`<br/>*string* | Type of the resource
+`network`<br/>*string* | Server-defined URL for the VPC network that contains the subnet
+`privateIpGoogleAccess`<br/>*string* | Whether the Private Google Access is configured
+`region`<br/>*Array[Disk]* | Server-defined URL for the region name
+`selfLink`<br/>*string* | Server-defined URL for this resource
+`shortNetwork`<br/>*string* | Display name of the VPC network that contains the subnet
+`id`<br/>*UUID* | The id of the subnet
+`name`<br/>*string* | The display name of the subnet.
+`shortRegion`<br/>*string* | A short version of the region name
+
+<!-------------------- CREATE A SUBNET -------------------->
 
 #### Create a subnet
 
@@ -98,3 +149,11 @@ Required | &nbsp;
 Optional | &nbsp;
 ------- | -----------
 `description`<br/>*string* | Description of the subnet
+
+<!-------------------- DELETE A SUBNET -------------------->
+
+#### Delete a subnet
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks/:id</code>
+
+Delete an existing subnet

--- a/source/includes/gcp/_subnets.md
+++ b/source/includes/gcp/_subnets.md
@@ -42,19 +42,19 @@ Retrieve a list of all subnets in a given [environment](#administration-environm
 
 Attributes | &nbsp;
 ------- | -----------
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`fingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
-`gatewayAddress`<br/>*string* | Second address in the primary IP range for the subnet
-`ipCidrRange`<br/>*string* | Primary IP address range for the following resources: VM instances, internal load balancers, and internal protocol forwarding
-`kind`<br/>*string* | Type of the resource
-`network`<br/>*string* | Server-defined URL for the VPC network that contains the subnet
-`privateIpGoogleAccess`<br/>*string* | Whether the Private Google Access is configured
-`region`<br/>*Array[Disk]* | Server-defined URL for the region name
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`shortNetwork`<br/>*string* | Display name of the VPC network that contains the subnet
-`id`<br/>*UUID* | The id of the subnet
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`fingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking.
+`gatewayAddress`<br/>*string* | Second address in the primary IP range for the subnet.
+`ipCidrRange`<br/>*string* | Primary IP address range for the following resources: VM instances, internal load balancers, and internal protocol forwarding.
+`kind`<br/>*string* | Type of the resource.
+`network`<br/>*string* | Server-defined URL for the VPC network that contains the subnet.
+`privateIpGoogleAccess`<br/>*string* | Whether the Private Google Access is configured.
+`region`<br/>*Array[Disk]* | Server-defined URL for the region name.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`shortNetwork`<br/>*string* | Display name of the VPC network that contains the subnet.
+`id`<br/>*UUID* | The id of the subnet.
 `name`<br/>*string* | The display name of the subnet.
-`shortRegion`<br/>*string* | A short version of the region name
+`shortRegion`<br/>*string* | A short version of the region name.
 
 #### Filters
 
@@ -99,19 +99,19 @@ Retrieve information about a subnet.
 
 Attributes | &nbsp;
 ---------- | -----
-`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format
-`fingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking
-`gatewayAddress`<br/>*string* | Second address in the primary IP range for the subnet
-`ipCidrRange`<br/>*string* | Primary IP address range for the following resources: VM instances, internal load balancers, and internal protocol forwarding
-`kind`<br/>*string* | Type of the resource
-`network`<br/>*string* | Server-defined URL for the VPC network that contains the subnet
-`privateIpGoogleAccess`<br/>*string* | Whether the Private Google Access is configured
-`region`<br/>*Array[Disk]* | Server-defined URL for the region name
-`selfLink`<br/>*string* | Server-defined URL for this resource
-`shortNetwork`<br/>*string* | Display name of the VPC network that contains the subnet
-`id`<br/>*UUID* | The id of the subnet
+`creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
+`fingerprint`<br/>*string* | A base64-encoded string. A hash of the label's contents and used for optimistic locking.
+`gatewayAddress`<br/>*string* | Second address in the primary IP range for the subnet.
+`ipCidrRange`<br/>*string* | Primary IP address range for the following resources: VM instances, internal load balancers, and internal protocol forwarding.
+`kind`<br/>*string* | Type of the resource.
+`network`<br/>*string* | Server-defined URL for the VPC network that contains the subnet.
+`privateIpGoogleAccess`<br/>*string* | Whether the Private Google Access is configured.
+`region`<br/>*Array[Disk]* | Server-defined URL for the region name.
+`selfLink`<br/>*string* | Server-defined URL for this resource.
+`shortNetwork`<br/>*string* | Display name of the VPC network that contains the subnet.
+`id`<br/>*UUID* | The id of the subnet.
 `name`<br/>*string* | The display name of the subnet.
-`shortRegion`<br/>*string* | A short version of the region name
+`shortRegion`<br/>*string* | A short version of the region name.
 
 <!-------------------- CREATE A SUBNET -------------------->
 
@@ -141,18 +141,24 @@ Create a new subnet
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The display name of the subnet
-`shortRegion`<br/>*string* | A short version of the region name
-`network`<br/>*string* | The selflink of the network
-`ipCidrRange`<br/>*string* | The CIDR IP range of the subnet
+`name`<br/>*string* | The display name of the subnet.
+`shortRegion`<br/>*string* | A short version of the region name.
+`network`<br/>*string* | The selflink of the network.
+`ipCidrRange`<br/>*string* | The CIDR IP range of the subnet.
 
 Optional | &nbsp;
 ------- | -----------
-`description`<br/>*string* | Description of the subnet
+`description`<br/>*string* | Description of the subnet.
 
 <!-------------------- DELETE A SUBNET -------------------->
 
 #### Delete a subnet
+
+```shell
+curl -X DELETE \
+  -H "mc-api-key: your_api_key" \
+  "https://cloudmc_endpoint/v1/services/gcp/test-area/subnetworks/8841143494674098002"
+```
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/subnetworks/:id</code>
 


### PR DESCRIPTION
### Fixes [MC-11640](https://cloud-ops.atlassian.net/browse/MC-11640)

#### Changes made
<!-- Changes should match the template provided below -->
- ...

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->