### PR TITLE
MC-11707 : Added delete service provider documentation

### DIFF
--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -41,6 +41,8 @@ curl "https://cloudmc_endpoint/v1/service_providers" \
   ]
 }
 ```
+<code>GET /service_providers</code>
+
 List the service providers configured on the system.
 
 Attributes | &nbsp;
@@ -66,7 +68,7 @@ Attributes | &nbsp;
 
 ### Retrieve service provider
 
-`GET /service_provider/:id`
+`GET /service_providers/:id`
 
 ```shell
 # Retrieve service providers
@@ -100,6 +102,8 @@ curl "https://cloudmc_endpoint/v1/service_providers/04b77783-516f-4064-a6df-e7f9
   }
 }
 ```
+<code>GET /service_providers/:id</code>
+
 Return the service provider configured associated to the id on the system.
 
 Attributes | &nbsp;
@@ -182,6 +186,11 @@ curl -X POST "https://cloudmc_endpoint/rest/service_providers" \
   }
 }
 ```
+
+<code>POST /service_providers</code>
+
+Create a new service provider
+
 Required | &nbsp;
 ---------- | -----------
 `name`<br/>*string* | The name of the service provider.
@@ -264,6 +273,11 @@ curl -X POST "https://cloudmc_endpoint/rest/service_providers/:id" \
   }
 }
 ```
+
+<code>POST /service_providers/:id</code>
+
+Updates a specific service provider
+
 Required | &nbsp;
 ---------- | -----------
 `name`<br/>*string* | The name of the service provider.
@@ -296,4 +310,7 @@ curl "https://cloudmc_endpoint/rest/service_providers/f9dea588-d7ab-4f42-b6e6-4b
    -X DELETE -H "MC-Api-Key: your_api_key"
 
 ```
+
+<code>DELETE /service_providers/:id</code>
+
 Delete a specific service provider. 

--- a/source/includes/administration/_service_providers.md
+++ b/source/includes/administration/_service_providers.md
@@ -282,3 +282,18 @@ Optional | &nbsp;
 `config.nameIdFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, EMAIL_ADDRESS, X509_SUBJECT, WINDOWS_DQN, KERBEROS_PRINCIPAL, ENTITY, PERSISTENT and TRANSIENT. If not provided this defaults to UNSPECIFIED.
 `config.responseAttributes.nameFormat`<br/>*string* | The format for the name field. Possible values are : UNSPECIFIED, URI and BASIC. If not provided this defaults to UNSPECIFIED.
 `config.responseAttributes`<br/>*Array[Object]* | The list of attributes part of the response.
+
+<!-------------------- DELETE SERVICE PROVIDER -------------------->
+
+
+### Delete service provider
+
+`DELETE /service_providers/:id`
+
+```shell
+# Delete a service provider
+curl "https://cloudmc_endpoint/rest/service_providers/f9dea588-d7ab-4f42-b6e6-4b85f273f3db" \
+   -X DELETE -H "MC-Api-Key: your_api_key"
+
+```
+Delete a specific service provider. 


### PR DESCRIPTION
### Fixes [MC-11707](https://cloud-ops.atlassian.net/browse/MC-11707)

#### Code walkthrough : @lamminade 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
There was no possibility to delete a service provider

#### Solution
Implemented the delete of the service provider

#### Test cases
- Manual Test
- Unit test

#### UI changes
![image](https://user-images.githubusercontent.com/56133634/84706137-7e428f80-af2a-11ea-91fa-b8ea5829ec85.png)
![image](https://user-images.githubusercontent.com/56133634/84706172-8a2e5180-af2a-11ea-9200-d858c625a74d.png)


#### Related PRs
- PR # https://github.com/cloudops/cloudmc-ui/pull/889
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/168

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->