### PR TITLE
Feature/mc 11572 configmaps

### DIFF
--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -1,4 +1,4 @@
-## configmaps
+## ConfigMaps
 
 <!-------------------- LIST CONFIG MAPS -------------------->
 
@@ -53,7 +53,6 @@ Retrieve a list of all configmaps in a given [environment](#administration-envir
 | `metadata.selfLink` <br/>_object_          | A link uniquely identifying this config map             |
 | `metadata.resourceVersion` <br/>_object_   | The version returned of the configmap                   |
 
-
 <!-------------------- GET A configmap -------------------->
 
 ### Get a configmap
@@ -104,4 +103,3 @@ Retrieve a configmap and all its info in a given [environment](#administration-e
 | `metadata.uid` <br/>_object_               | The UUID of the configmap                                      |
 | `metadata.selfLink` <br/>_object_          | A link uniquely identifying this config map                    |
 | `metadata.resourceVersion` <br/>_object_   | The version returned of the configmap                          |
-

--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -51,7 +51,7 @@ Retrieve a list of all configmaps in a given [environment](#administration-envir
 | `metadata.namespace` <br/>_string_         | The namespace in which the configmap is created         |
 | `metadata.uid` <br/>_object_               | The UUID of the configmap                               |
 | `metadata.selfLink` <br/>_object_          | A link uniquely identifying this config map             |
-| `metadata.resourceVersion` <br/>_object_   | The version returned of the configmap                          |
+| `metadata.resourceVersion` <br/>_object_   | The version returned of the configmap                   |
 
 
 <!-------------------- GET A configmap -------------------->

--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -37,21 +37,21 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps</code>
 
-Retrieve a list of all configmaps in a given [environment](#administration-environments).
+Retrieve a list of all config maps in a given [environment](#administration-environments).
 
 | Attributes                                 | &nbsp;                                                  |
 | ------------------------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the configmap                                 |
-| `apiVersion` <br/>_string_                 | The API version used to retrieve this configmap         |
-| `kind` <br/>_string_                       | The type of the returned resource: ConfigMap            |
-| `metadata` <br/>_object_                   | The metadata of the configmap                           |
+| `id` <br/>_string_                         | The id of the config map                                |
+| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
+| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
+| `metadata` <br/>_object_                   | The metadata of the config map                          |
 | `metadata.creationTimestamp` <br/>_string_ | The date of creation of the configmap as a string       |
-| `metadata.annotations` <br/>_map_          | The annotations associated to the configmap             |
-| `metadata.name` <br/>_string_              | The name of the configmap                               |
-| `metadata.namespace` <br/>_string_         | The namespace in which the configmap is created         |
-| `metadata.uid` <br/>_object_               | The UUID of the configmap                               |
-| `metadata.selfLink` <br/>_object_          | A link uniquely identifying this config map             |
-| `metadata.resourceVersion` <br/>_object_   | The version returned of the configmap                   |
+| `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
+| `metadata.name` <br/>_string_              | The name of the config map                              |
+| `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
+| `metadata.uid` <br/>_object_               | The UUID of the config map                              |
+| `metadata.selfLink` <br/>_object_          | A link that uniquely identifies this config map         |
+| `metadata.resourceVersion` <br/>_object_   | The resource version of the config map                  |
 
 
 <!-------------------- GET A configmap -------------------->
@@ -91,17 +91,17 @@ curl -X GET \
 
 Retrieve a configmap and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the configmap                                        |
-| `apiVersion` <br/>_string_                 | The API version used to retrieve this configmap                |
-| `kind` <br/>_string_                       | The type of the returned resource: ConfigMap                   |
-| `metadata` <br/>_object_                   | The metadata of the configmap                                  |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the configmap as a string              |
-| `metadata.annotations` <br/>_map_          | The annotations associated to the configmag                    |
-| `metadata.name` <br/>_string_              | The name of the configmap                                      |
-| `metadata.namespace` <br/>_string_         | The namespace in which the configmap is created                |
-| `metadata.uid` <br/>_object_               | The UUID of the configmap                                      |
-| `metadata.selfLink` <br/>_object_          | A link uniquely identifying this config map                    |
-| `metadata.resourceVersion` <br/>_object_   | The version returned of the configmap                          |
+| Attributes                                 | &nbsp;                                                  |
+| ------------------------------------------ | ------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the config map                                |
+| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
+| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
+| `metadata` <br/>_object_                   | The metadata of the config map                          |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the configmap as a string       |
+| `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
+| `metadata.name` <br/>_string_              | The name of the config map                              |
+| `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
+| `metadata.uid` <br/>_object_               | The UUID of the config map                              |
+| `metadata.selfLink` <br/>_object_          | A link that uniquely identifies this config map         |
+| `metadata.resourceVersion` <br/>_object_   | The resource version of the config map                  |
 

--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -1,0 +1,107 @@
+## configmaps
+
+<!-------------------- LIST CONFIG MAPS -------------------->
+
+### List configmaps
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/configmaps"
+```
+
+> The above command returns a JSON structured like this:
+
+```js
+{
+  "data": [{
+      "id": "cert-manager-cainjector-leader-election/kube-system",
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "annotations": {
+          "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"cert-manager-cainjector-54c4796c5d-9txng_7d63d35e-a197-497b-9b5f-c9722aabc6cd\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-06-14T02:01:27Z\",\"renewTime\":\"2020-06-16T19:54:04Z\",\"leaderTransitions\":23}"
+        },
+        "creationTimestamp": "2020-03-20T15:48:41.000-04:00",
+        "name": "cert-manager-cainjector-leader-election",
+        "namespace": "kube-system",
+        "resourceVersion": "25190285",
+        "selfLink": "/api/v1/namespaces/kube-system/configmaps/cert-manager-cainjector-leader-election",
+        "uid": "255fdf58-4f53-4260-abb9-334445c187a2"
+      }
+    }, {
+      etc...
+    } 
+  ]
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps</code>
+
+Retrieve a list of all configmaps in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                  |
+| ------------------------------------------ | ------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the configmap                                 |
+| `apiVersion` <br/>_string_                 | The API version used to retrieve this configmap         |
+| `kind` <br/>_string_                       | The type of the returned resource: ConfigMap            |
+| `metadata` <br/>_object_                   | The metadata of the configmap                           |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the configmap as a string       |
+| `metadata.annotations` <br/>_map_          | The annotations associated to the configmap             |
+| `metadata.name` <br/>_string_              | The name of the configmap                               |
+| `metadata.namespace` <br/>_string_         | The namespace in which the configmap is created         |
+| `metadata.uid` <br/>_object_               | The UUID of the configmap                               |
+| `metadata.selfLink` <br/>_object_          | A link uniquely identifying this config map             |
+| `metadata.resourceVersion` <br/>_object_   | The version returned of the configmap                          |
+
+
+<!-------------------- GET A configmap -------------------->
+
+### Get a configmap
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/configmaps/cert-manager-cainjector-leader-election/kube-system"
+```
+
+> The above command returns a JSON structured like this:
+
+```js
+{
+    "data": {
+      "id": "cert-manager-cainjector-leader-election/kube-system",
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "annotations": {
+          "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"cert-manager-cainjector-54c4796c5d-9txng_7d63d35e-a197-497b-9b5f-c9722aabc6cd\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-06-14T02:01:27Z\",\"renewTime\":\"2020-06-16T19:54:04Z\",\"leaderTransitions\":23}"
+        },
+        "creationTimestamp": "2020-03-20T15:48:41.000-04:00",
+        "name": "cert-manager-cainjector-leader-election",
+        "namespace": "kube-system",
+        "resourceVersion": "25190285",
+        "selfLink": "/api/v1/namespaces/kube-system/configmaps/cert-manager-cainjector-leader-election",
+        "uid": "255fdf58-4f53-4260-abb9-334445c187a2"
+      }
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps/:id</code>
+
+Retrieve a configmap and all its info in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the configmap                                        |
+| `apiVersion` <br/>_string_                 | The API version used to retrieve this configmap                |
+| `kind` <br/>_string_                       | The type of the returned resource: ConfigMap                   |
+| `metadata` <br/>_object_                   | The metadata of the configmap                                  |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the configmap as a string              |
+| `metadata.annotations` <br/>_map_          | The annotations associated to the configmag                    |
+| `metadata.name` <br/>_string_              | The name of the configmap                                      |
+| `metadata.namespace` <br/>_string_         | The namespace in which the configmap is created                |
+| `metadata.uid` <br/>_object_               | The UUID of the configmap                                      |
+| `metadata.selfLink` <br/>_object_          | A link uniquely identifying this config map                    |
+| `metadata.resourceVersion` <br/>_object_   | The version returned of the configmap                          |
+

--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -45,7 +45,7 @@ Retrieve a list of all config maps in a given [environment](#administration-envi
 | `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
 | `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
 | `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the configmap as a string       |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string       |
 | `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
 | `metadata.name` <br/>_string_              | The name of the config map                              |
 | `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
@@ -96,7 +96,7 @@ Retrieve a configmap and all its info in a given [environment](#administration-e
 | `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
 | `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
 | `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the configmap as a string       |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string       |
 | `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
 | `metadata.name` <br/>_string_              | The name of the config map                              |
 | `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -102,6 +102,7 @@ includes:
   - kubernetes/k8_statefulsets
   - kubernetes/k8_daemonsets
   - kubernetes/k8_deployments
+  - kubernetes/k8_configmaps
   - kubernetes/k8_releases
   - kubernetes/k8_charts
   - kubernetes/k8_namespaces


### PR DESCRIPTION
### Fixes [MC-11572](https://cloud-ops.atlassian.net/browse/MC-11572)

#### Changes made
- Added doc for config maps for kubernetes plugin
#### Related PRs
- [Kubernetes SDK](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/68)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->