### PR TITLE
Bug/mc 11900 hypercloud mandatory cluster

### DIFF
--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -12,36 +12,20 @@ curl -X GET \
 
 > The above command returns a JSON structured like this:
 
-```js
+```json
 {
-    "data": [
-        {
-            "id": "coredns/kube-system",
-            "data": {
-                "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
-            },
-            "metadata": {
-                "annotations": {
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"Corefile\":\".:53 {\\n    errors\\n    health\\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\\n      pods insecure\\n      upstream\\n      fallthrough in-addr.arpa ip6.arpa\\n    }\\n    prometheus :9153\\n    forward . /etc/resolv.conf\\n    cache 30\\n    loop\\n    reload\\n    loadbalance\\n    import custom/*.override\\n}\\nimport custom/*.server\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"}}\n"
-                },
-                "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
-                "labels": {
-                    "addonmanager.kubernetes.io/mode": "Reconcile",
-                    "k8s-app": "kube-dns",
-                    "kubernetes.io/cluster-service": "true"
-                },
-                "name": "coredns",
-                "namespace": "kube-system",
-                "resourceVersion": "92",
-                "selfLink": "/api/v1/namespaces/kube-system/configmaps/coredns",
-                "uid": "d77702d6-9f40-40ee-bf2f-b80ff313083f"
-            }
-        },
-        ...
-    ],
-    "metadata": {
-        "recordCount": 4
+  "data": [
+    {
+      "id": "coredns/kube-system",
+      "data": {
+        "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
+      },
+      "metadata": {}
     }
+  ],
+  "metadata": {
+    "recordCount": 4
+  }
 }
 ```
 
@@ -55,13 +39,6 @@ Retrieve a list of all config maps in a given [environment](#administration-envi
 | `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
 | `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
 | `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string      |
-| `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
-| `metadata.name` <br/>_string_              | The name of the config map                              |
-| `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
-| `metadata.uid` <br/>_object_               | The UUID of the config map                              |
-| `metadata.selfLink` <br/>_object_          | A link that uniquely identifies this config map         |
-| `metadata.resourceVersion` <br/>_object_   | The resource version of the config map                  |
 
 <!-------------------- GET A configmap -------------------->
 
@@ -75,23 +52,13 @@ curl -X GET \
 
 > The above command returns a JSON structured like this:
 
-```js
+```json
 {
-    "data": {
-      "id": "cert-manager-cainjector-leader-election/kube-system",
-      "apiVersion": "v1",
-      "kind": "ConfigMap",
-      "metadata": {
-        "annotations": {
-          "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"cert-manager-cainjector-54c4796c5d-9txng_7d63d35e-a197-497b-9b5f-c9722aabc6cd\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-06-14T02:01:27Z\",\"renewTime\":\"2020-06-16T19:54:04Z\",\"leaderTransitions\":23}"
-        },
-        "creationTimestamp": "2020-03-20T15:48:41.000-04:00",
-        "name": "cert-manager-cainjector-leader-election",
-        "namespace": "kube-system",
-        "resourceVersion": "25190285",
-        "selfLink": "/api/v1/namespaces/kube-system/configmaps/cert-manager-cainjector-leader-election",
-        "uid": "255fdf58-4f53-4260-abb9-334445c187a2"
-      }
+  "data": {
+    "id": "cert-manager-cainjector-leader-election/kube-system",
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {}
   }
 }
 ```
@@ -106,10 +73,3 @@ Retrieve a configmap and all its info in a given [environment](#administration-e
 | `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
 | `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
 | `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string      |
-| `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
-| `metadata.name` <br/>_string_              | The name of the config map                              |
-| `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
-| `metadata.uid` <br/>_object_               | The UUID of the config map                              |
-| `metadata.selfLink` <br/>_object_          | A link that uniquely identifies this config map         |
-| `metadata.resourceVersion` <br/>_object_   | The resource version of the config map                  |

--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -14,25 +14,35 @@ curl -X GET \
 
 ```js
 {
-  "data": [{
-      "id": "cert-manager-cainjector-leader-election/kube-system",
-      "apiVersion": "v1",
-      "kind": "ConfigMap",
-      "metadata": {
-        "annotations": {
-          "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"cert-manager-cainjector-54c4796c5d-9txng_7d63d35e-a197-497b-9b5f-c9722aabc6cd\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-06-14T02:01:27Z\",\"renewTime\":\"2020-06-16T19:54:04Z\",\"leaderTransitions\":23}"
+    "data": [
+        {
+            "id": "coredns/kube-system",
+            "data": {
+                "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
+            },
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"Corefile\":\".:53 {\\n    errors\\n    health\\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\\n      pods insecure\\n      upstream\\n      fallthrough in-addr.arpa ip6.arpa\\n    }\\n    prometheus :9153\\n    forward . /etc/resolv.conf\\n    cache 30\\n    loop\\n    reload\\n    loadbalance\\n    import custom/*.override\\n}\\nimport custom/*.server\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"}}\n"
+                },
+                "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
+                "labels": {
+                    "addonmanager.kubernetes.io/mode": "Reconcile",
+                    "k8s-app": "kube-dns",
+                    "kubernetes.io/cluster-service": "true"
+                },
+                "name": "coredns",
+                "namespace": "kube-system",
+                "resourceVersion": "92",
+                "selfLink": "/api/v1/namespaces/kube-system/configmaps/coredns",
+                "uid": "d77702d6-9f40-40ee-bf2f-b80ff313083f"
+            }
         },
-        "creationTimestamp": "2020-03-20T15:48:41.000-04:00",
-        "name": "cert-manager-cainjector-leader-election",
-        "namespace": "kube-system",
-        "resourceVersion": "25190285",
-        "selfLink": "/api/v1/namespaces/kube-system/configmaps/cert-manager-cainjector-leader-election",
-        "uid": "255fdf58-4f53-4260-abb9-334445c187a2"
-      }
-    }, {
-      etc...
-    } 
-  ]
+        ...
+    ],
+    "metadata": {
+        "recordCount": 4
+    }
+}
 ```
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps</code>
@@ -45,7 +55,7 @@ Retrieve a list of all config maps in a given [environment](#administration-envi
 | `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
 | `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
 | `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string       |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string      |
 | `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
 | `metadata.name` <br/>_string_              | The name of the config map                              |
 | `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
@@ -96,11 +106,10 @@ Retrieve a configmap and all its info in a given [environment](#administration-e
 | `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
 | `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
 | `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string       |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string      |
 | `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
 | `metadata.name` <br/>_string_              | The name of the config map                              |
 | `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
 | `metadata.uid` <br/>_object_               | The UUID of the config map                              |
 | `metadata.selfLink` <br/>_object_          | A link that uniquely identifies this config map         |
 | `metadata.resourceVersion` <br/>_object_   | The resource version of the config map                  |
-

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -17,37 +17,11 @@ curl -X GET \
   "data": [
     {
       "id": "canal/kube-system",
-      "metadata": {
-        "annotations": {
-          "deprecated.daemonset.template.generation": "8",
-          "kubectl.kubernetes.io/last-applied-configuration": "{...}"
-        },
-        "creationTimestamp": "2019-03-12T14:22:52.000-04:00",
-        "generation": 8,
-        "labels": {
-          "k8s-app": "canal"
-        },
-        "name": "canal",
-        "namespace": "kube-system",
-        "resourceVersion": "117221602",
-        "selfLink": "/apis/apps/v1/namespaces/kube-system/daemonsets/canal",
-        "uid": "d946db1b-44f3-11e9-960d-02007a9a001f"
-      },
-      "spec": {
-        /*...*/
-      },
-      "status": {
-        "currentNumberScheduled": 10,
-        "desiredNumberScheduled": 10,
-        "numberAvailable": 10,
-        "numberMisscheduled": 0,
-        "numberReady": 10,
-        "observedGeneration": 8,
-        "updatedNumberScheduled": 10
-      }
+      "metadata": {},
+      "spec": {},
+      "status": {}
     }
   ],
-  // ...
   "metadata": {
     "recordCount": 9
   }
@@ -62,11 +36,6 @@ Retrieve a list of all daemon sets in a given [environment](#administration-envi
 | ------------------------------------------ | ------------------------------------------------------- |
 | `id` <br/>_string_                         | The id of the daemon set                                |
 | `metadata` <br/>_object_                   | The metadata of the daemon set                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the daemon set as a string      |
-| `metadata.labels` <br/>_map_               | The labels associated to the daemon set                 |
-| `metadata.name` <br/>_string_              | The name of the daemon set                              |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created        |
-| `metadata.uid` <br/>_object_               | The UUID of the daemon set                              |
 | `spec`<br/>_object_                        | The specification used to create and run the daemon set |
 | `status`<br/>_object_                      | The status information of the daemon set                |
 
@@ -88,34 +57,9 @@ curl -X GET \
 {
     "data": {
         "id": "canal/kube-system",
-        "metadata": {
-            "annotations": {
-                "deprecated.daemonset.template.generation": "8",
-                "kubectl.kubernetes.io/last-applied-configuration": "{...}"
-            },
-            "creationTimestamp": "2019-03-12T14:22:52.000-04:00",
-            "generation": 8,
-            "labels": {
-                "k8s-app": "canal"
-            },
-            "name": "canal",
-            "namespace": "kube-system",
-            "resourceVersion": "117221602",
-            "selfLink": "/apis/apps/v1/namespaces/kube-system/daemonsets/canal",
-            "uid": "d946db1b-44f3-11e9-960d-02007a9a001f"
-        },
-        "spec": {
-          // ...
-        },
-        "status": {
-            "currentNumberScheduled": 10,
-            "desiredNumberScheduled": 10,
-            "numberAvailable": 10,
-            "numberMisscheduled": 0,
-            "numberReady": 10,
-            "observedGeneration": 8,
-            "updatedNumberScheduled": 10
-        }
+        "metadata": {},
+        "spec": {},
+        "status": {}
     }
 }
 ```
@@ -128,11 +72,6 @@ Retrieve a daemon set and all its info in a given [environment](#administration-
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `id` <br/>_string_                         | The id of the daemon set                                        |
 | `metadata` <br/>_object_                   | The metadata of the daemon set                                  |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the daemon set as a string              |
-| `metadata.labels` <br/>_map_               | The labels associated to the daemon                             |
-| `metadata.name` <br/>_string_              | The name of the daemon set                                      |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                |
-| `metadata.uid` <br/>_object_               | The UUID of the daemon set                                      |
 | `spec`<br/>_object_                        | The specification used to create and run the daemon set         |
 | `status`<br/>_object_                      | The status information of the daemon set                        |
 

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -19,45 +19,11 @@ curl -X GET \
       "id": "apm-server-1585600296-apm-server/monitoring",
       "deploymentStatus": "Available",
       "readyRatio": "1/1",
-      "metadata": {
-        "annotations": {
-          "deployment.kubernetes.io/revision": "1"
-        },
-        "creationTimestamp": "2020-03-30T16:31:43.000-04:00",
-        "generation": 1,
-        "labels": {
-          "app": "apm-server",
-          "release": "apm-server-1585600296"
-        },
-        "name": "apm-server-1585600296-apm-server",
-        "namespace": "monitoring",
-        "resourceVersion": "117204237",
-        "selfLink": "/apis/apps/v1/namespaces/monitoring/deployments/apm-server-1585600296-apm-server",
-        "uid": "783030e4-72c5-11ea-a953-02007a9a001f"
-      },
-      "spec": {
-        /*...*/
-      },
-      "status": {
-        "availableReplicas": 1,
-        "conditions": [
-          {
-            "lastTransitionTime": "2020-04-24T15:06:15.000-04:00",
-            "lastUpdateTime": "2020-04-24T15:08:43.000-04:00",
-            "message": "ReplicaSet \"cert-manager-webhook-6ff9487489\" has successfully progressed.",
-            "reason": "NewReplicaSetAvailable",
-            "status": "True",
-            "type": "Progressing"
-          }
-        ],
-        "observedGeneration": 1,
-        "readyReplicas": 1,
-        "replicas": 1,
-        "updatedReplicas": 1
-      }
+      "metadata": {},
+      "spec": {},
+      "status": {}
     }
-  ],
-  // ...
+  ],  
   "metadata": {
     "recordCount": 9
   }
@@ -99,42 +65,9 @@ curl -X GET \
       "id": "apm-server-1585600296-apm-server/monitoring",
       "deploymentStatus": "Available",
       "readyRatio": "1/1",
-      "metadata": {
-        "annotations": {
-          "deployment.kubernetes.io/revision": "1"
-        },
-        "creationTimestamp": "2020-03-30T16:31:43.000-04:00",
-        "generation": 1,
-        "labels": {
-          "app": "apm-server",
-          "release": "apm-server-1585600296"
-        },
-        "name": "apm-server-1585600296-apm-server",
-        "namespace": "monitoring",
-        "resourceVersion": "117204237",
-        "selfLink": "/apis/apps/v1/namespaces/monitoring/deployments/apm-server-1585600296-apm-server",
-        "uid": "783030e4-72c5-11ea-a953-02007a9a001f"
-      },
-      "spec": {
-        /*...*/
-      },
-      "status": {
-        "availableReplicas": 1,
-        "conditions": [
-          {
-            "lastTransitionTime": "2020-04-24T15:06:15.000-04:00",
-            "lastUpdateTime": "2020-04-24T15:08:43.000-04:00",
-            "message": "ReplicaSet \"cert-manager-webhook-6ff9487489\" has successfully progressed.",
-            "reason": "NewReplicaSetAvailable",
-            "status": "True",
-            "type": "Progressing"
-          }
-        ],
-        "observedGeneration": 1,
-        "readyReplicas": 1,
-        "replicas": 1,
-        "updatedReplicas": 1
-      }
+      "metadata": {},
+      "spec": {},
+      "status": {}
     }
 }
 ```
@@ -147,9 +80,6 @@ Retrieve a deployment and all its info in a given [environment](#administration-
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `id` <br/>_string_                         | The id of the deployment                                        |
 | `metadata` <br/>_object_                   | The metadata of the deployment                                  |
-| `metadata.name` <br/>_string_              | The name of the deployment                                      |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                |
-| `metadata.uid` <br/>_object_               | The UUID of the deployment                                      |
 | `images` <br/>_object_                     | The container images within a deployment                        |
 | `spec`<br/>_object_                        | The specification used to create and run the deployment         |
 | `status`<br/>_object_                      | The status information of the deployment                        |

--- a/source/includes/kubernetes/_k8_namespaces.md
+++ b/source/includes/kubernetes/_k8_namespaces.md
@@ -1,6 +1,5 @@
 ## Namespaces
 
-
 <!-------------------- LIST NAMESPACES -------------------->
 
 ### List namespaces
@@ -10,6 +9,7 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/an_environment/namespaces"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -17,60 +17,9 @@ curl -X GET \
   "data": [
     {
       "id": "auth",
-      "metadata": {
-        "creationTimestamp": "2019-06-06T16:55:32.000-04:00",
-        "name": "auth",
-        "resourceVersion": "17516456",
-        "selfLink": "/api/v1/namespaces/auth",
-        "uid": "6cd793ae-889d-11e9-95db-02007a9a453g"
-      },
-      "spec": {
-        "finalizers": [
-          "kubernetes"
-        ]
-      },
-      "status": {
-        "phase": "Active"
-      }
-    },
-    {
-      "id": "cert-manager",
-      "metadata": {
-        "annotations": {
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"cert-manager\"}}\n"
-        },
-        "creationTimestamp": "2020-04-24T15:06:10.000-04:00",
-        "name": "cert-manager",
-        "resourceVersion": "110011696",
-        "selfLink": "/api/v1/namespaces/cert-manager",
-        "uid": "ab4376c2-bb6d-44ae-a576-hdyr45839djs"
-      },
-      "spec": {
-        "finalizers": [
-          "kubernetes"
-        ]
-      },
-      "status": {
-        "phase": "Active"
-      }
-    },
-    {
-      "id": "lab",
-      "metadata": {
-        "creationTimestamp": "2019-07-10T16:51:13.000-04:00",
-        "name": "lab",
-        "resourceVersion": "25347372",
-        "selfLink": "/api/v1/namespaces/lab",
-        "uid": "74716eb1-a354-11e9-8c9b-1029384wedad"
-      },
-      "spec": {
-        "finalizers": [
-          "kubernetes"
-        ]
-      },
-      "status": {
-        "phase": "Active"
-      }
+      "metadata": {},
+      "spec": {},
+      "status": {}
     }
   ],
   "metadata": {
@@ -79,28 +28,16 @@ curl -X GET \
 }
 ```
 
-
-
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/namespaces</code>
 
 Retrieve a list of all namespaces in a given [environment](#administration-environments).
 
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id of the namespace.  
-`metadata` <br/>*object* | The metadata of the namespace
-`metadata.annotations` <br/>*map* | The annotations of the namespace
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string
-`metadata.name` <br/>*string* | The name of the namespace
-`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of the namespace object
-`metadata.selfLink` <br/>*string* | A URL representing the namespace object
-`metadata.uid` <br/>*object* | The UUID of the namespace
-`spec`<br/>*object* | The specification describes the attributes on a namespace.
-`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove the object from storage
-`status`<br/>*object* | The status information of the namespace
-`status.phase`<br/>*string* | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`
-
-
+| Attributes                     | &nbsp;                                                                                    |
+| ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `id` <br/>_string_             | The id of the namespace.                                                                  |
+| `metadata` <br/>_object_       | The metadata of the namespace                                                             |
+| `spec`<br/>_object_            | The specification describes the attributes on a namespace.                                |
+| `status`<br/>_object_          | The status information of the namespace                                                   |
 
 <!-------------------- GET A NAMESPACE -------------------->
 
@@ -111,6 +48,7 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/k8s/an_environment/namespaces/cert-manager"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -119,47 +57,22 @@ curl -X GET \
     "id": "cert-manager",
     "apiVersion": "v1",
     "kind": "Namespace",
-    "metadata": {
-      "annotations": {
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"cert-manager\"}}\n"
-      },
-      "creationTimestamp": "2020-04-24T15:06:10.000-04:00",
-      "name": "cert-manager",
-      "resourceVersion": "110011696",
-      "selfLink": "/api/v1/namespaces/cert-manager",
-      "uid": "ab4376c2-bb6d-44ae-a576-f9b24f2ea624"
-    },
-    "spec": {
-      "finalizers": [
-        "kubernetes"
-      ]
-    },
-    "status": {
-      "phase": "Active"
-    }
+    "metadata": {},
+    "spec": {},
+    "status": {}
   }
 }
 ```
-
-
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/namespaces/:id</code>
 
 Retrieve a namespace and all its info in a given [environment](#administration-environments).
 
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id of the namespace.
-`apiVersion` <br/>*string* | APIVersion defines the versioned schema of this representation of a namespace object
-`kind` <br/>*string* | A string value representing the REST resource this object represents
-`metadata` <br/>*object* | The metadata of the namespace
-`metadata.annotations` <br/>*map* | The annotations of the namespace
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string
-`metadata.name` <br/>*string* | The name of the namespace
-`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of the namespace object
-`metadata.selfLink` <br/>*string* | A URL representing the namespace object
-`metadata.uid` <br/>*object* | The UUID of the namespace
-`spec`<br/>*object* | The specification describes the attributes on a namespace.
-`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove the object from storage
-`status`<br/>*object* | The status information of the namespace
-`status.phase`<br/>*string* | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`
+| Attributes                 | &nbsp;                                                                               |
+| -------------------------- | ------------------------------------------------------------------------------------ |
+| `id` <br/>_string_         | The id of the namespace.                                                             |
+| `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object |
+| `kind` <br/>_string_       | A string value representing the REST resource this object represents                 |
+| `metadata` <br/>_object_   | The metadata of the namespace                                                        |
+| `spec`<br/>_object_        | The specification describes the attributes on a namespace.                           |
+| `status`<br/>_object_      | The status information of the namespace                                              |

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -20,34 +20,9 @@ curl -X GET \
       "images": [
         "aerospike/aerospike-server:4.5.0.5"
       ],
-      "metadata": {
-        "creationTimestamp": "2020-04-27T09:13:49.000-04:00",
-        "generation": 1,
-        "labels": {
-          "app": "aerospike",
-          "chart": "aerospike-0.3.2",
-          "heritage": "Helm",
-          "release": "test"
-        },
-        "name": "test-aerospike",
-        "namespace": "auth",
-        "resourceVersion": "117166675",
-        "selfLink": "/apis/apps/v1/namespaces/auth/statefulsets/test-aerospike",
-        "uid": "0aeff29e-e33d-48da-b933-651a9070d58c"
-      },
-      "spec": {
-        // ...
-      },
-      "status": {
-        "collisionCount": 0,
-        "currentReplicas": 1,
-        "currentRevision": "test-aerospike-6db7776c7d",
-        "observedGeneration": 1,
-        "readyReplicas": 1,
-        "replicas": 1,
-        "updateRevision": "test-aerospike-6db7776c7d",
-        "updatedReplicas": 1
-      }
+      "metadata": {},
+      "spec": {},
+      "status": {}
     }
   ],
   "metadata": {
@@ -64,11 +39,6 @@ Retrieve a list of all stateful sets in a given [environment](#administration-en
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `id` <br/>*string*                         | The id of the stateful set                                      |
 | `metadata` <br/>*object*                   | The metadata of the stateful set                                |
-| `metadata.creationTimestamp` <br/>*string* | The date of creation of the stateful set as a string            |
-| `metadata.labels` <br/>*map*               | The labels associated to the stateful set                       |
-| `metadata.name` <br/>*string*              | The name of the stateful set                                    |
-| `metadata.namespace` <br/>*string*         | The namespace in which the stateful set is created              |
-| `metadata.uid` <br/>*object*               | The UUID of the stateful set                                    |
 | `spec`<br/>*object*                        | The specification used to create and run the stateful set       |
 | `status`<br/>*object*                      | The status information of the stateful set                      |
 
@@ -96,34 +66,9 @@ curl -X GET \
     ],
     "apiVersion": "apps/v1",
     "kind": "StatefulSet",
-    "metadata": {
-      "creationTimestamp": "2020-04-27T09:13:49.000-04:00",
-      "generation": 1,
-      "labels": {
-        "app": "aerospike",
-        "chart": "aerospike-0.3.2",
-        "heritage": "Helm",
-        "release": "test"
-      },
-      "name": "test-aerospike",
-      "namespace": "auth",
-      "resourceVersion": "117166675",
-      "selfLink": "/apis/apps/v1/namespaces/auth/statefulsets/test-aerospike",
-      "uid": "0aeff29e-e33d-48da-b933-651a9070d58c"
-    },
-    "spec": {
-      // ...
-    },
-    "status": {
-      "collisionCount": 0,
-      "currentReplicas": 1,
-      "currentRevision": "test-aerospike-6db7776c7d",
-      "observedGeneration": 1,
-      "readyReplicas": 1,
-      "replicas": 1,
-      "updateRevision": "test-aerospike-6db7776c7d",
-      "updatedReplicas": 1
-    }
+    "metadata": {},
+    "spec": {},
+    "status": {}
   }
 }
 ```
@@ -136,11 +81,6 @@ Retrieve a stateful set and all its info in a given [environment](#administratio
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `id` <br/>*string*                         | The id of the stateful set                                      |
 | `metadata` <br/>*object*                   | The metadata of the stateful set                                |
-| `metadata.creationTimestamp` <br/>*string* | The date of creation of the stateful set as a string            |
-| `metadata.labels` <br/>*map*               | The labels associated to the stateful                           |
-| `metadata.name` <br/>*string*              | The name of the stateful set                                    |
-| `metadata.namespace` <br/>*string*         | The namespace in which the stateful set is created              |
-| `metadata.uid` <br/>*object*               | The UUID of the stateful set                                    |
 | `spec`<br/>*object*                        | The specification used to create and run the stateful set       |
 | `status`<br/>*object*                      | The status information of the stateful set                      |
 

--- a/source/includes/kubernetes_extension/_k8_configmaps.md
+++ b/source/includes/kubernetes_extension/_k8_configmaps.md
@@ -7,37 +7,51 @@
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/configmaps"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/configmaps?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
 
 ```js
 {
-  "data": [{
-      "id": "cert-manager-cainjector-leader-election/kube-system",
-      "apiVersion": "v1",
-      "kind": "ConfigMap",
-      "metadata": {
-        "annotations": {
-          "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"cert-manager-cainjector-54c4796c5d-9txng_7d63d35e-a197-497b-9b5f-c9722aabc6cd\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-06-14T02:01:27Z\",\"renewTime\":\"2020-06-16T19:54:04Z\",\"leaderTransitions\":23}"
+    "data": [
+        {
+            "id": "coredns/kube-system",
+            "data": {
+                "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
+            },
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"Corefile\":\".:53 {\\n    errors\\n    health\\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\\n      pods insecure\\n      upstream\\n      fallthrough in-addr.arpa ip6.arpa\\n    }\\n    prometheus :9153\\n    forward . /etc/resolv.conf\\n    cache 30\\n    loop\\n    reload\\n    loadbalance\\n    import custom/*.override\\n}\\nimport custom/*.server\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"}}\n"
+                },
+                "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
+                "labels": {
+                    "addonmanager.kubernetes.io/mode": "Reconcile",
+                    "k8s-app": "kube-dns",
+                    "kubernetes.io/cluster-service": "true"
+                },
+                "name": "coredns",
+                "namespace": "kube-system",
+                "resourceVersion": "92",
+                "selfLink": "/api/v1/namespaces/kube-system/configmaps/coredns",
+                "uid": "d77702d6-9f40-40ee-bf2f-b80ff313083f"
+            }
         },
-        "creationTimestamp": "2020-03-20T15:48:41.000-04:00",
-        "name": "cert-manager-cainjector-leader-election",
-        "namespace": "kube-system",
-        "resourceVersion": "25190285",
-        "selfLink": "/api/v1/namespaces/kube-system/configmaps/cert-manager-cainjector-leader-election",
-        "uid": "255fdf58-4f53-4260-abb9-334445c187a2"
-      }
-    }, {
-      etc...
-    } 
-  ]
+        ...
+    ],
+    "metadata": {
+        "recordCount": 4
+    }
+}
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps?cluster_id=:cluster_id</code>
 
 Retrieve a list of all config maps in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                                  |
+|----------------------------|---------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to list the config maps. |
 
 | Attributes                                 | &nbsp;                                                  |
 | ------------------------------------------ | ------------------------------------------------------- |
@@ -45,7 +59,7 @@ Retrieve a list of all config maps in a given [environment](#administration-envi
 | `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
 | `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
 | `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string       |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string      |
 | `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
 | `metadata.name` <br/>_string_              | The name of the config map                              |
 | `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
@@ -55,12 +69,12 @@ Retrieve a list of all config maps in a given [environment](#administration-envi
 
 <!-------------------- GET A configmap -------------------->
 
-### Get a configmap
+#### Get a configmap
 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/configmaps/cert-manager-cainjector-leader-election/kube-system"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/configmaps/coredns/kube-system?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -68,27 +82,39 @@ curl -X GET \
 ```js
 {
     "data": {
-      "id": "cert-manager-cainjector-leader-election/kube-system",
-      "apiVersion": "v1",
-      "kind": "ConfigMap",
-      "metadata": {
-        "annotations": {
-          "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"cert-manager-cainjector-54c4796c5d-9txng_7d63d35e-a197-497b-9b5f-c9722aabc6cd\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-06-14T02:01:27Z\",\"renewTime\":\"2020-06-16T19:54:04Z\",\"leaderTransitions\":23}"
+        "id": "coredns/kube-system",
+        "apiVersion": "v1",
+        "data": {
+            "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
         },
-        "creationTimestamp": "2020-03-20T15:48:41.000-04:00",
-        "name": "cert-manager-cainjector-leader-election",
-        "namespace": "kube-system",
-        "resourceVersion": "25190285",
-        "selfLink": "/api/v1/namespaces/kube-system/configmaps/cert-manager-cainjector-leader-election",
-        "uid": "255fdf58-4f53-4260-abb9-334445c187a2"
-      }
-  }
+        "kind": "ConfigMap",
+        "metadata": {
+            "annotations": {
+                "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"Corefile\":\".:53 {\\n    errors\\n    health\\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\\n      pods insecure\\n      upstream\\n      fallthrough in-addr.arpa ip6.arpa\\n    }\\n    prometheus :9153\\n    forward . /etc/resolv.conf\\n    cache 30\\n    loop\\n    reload\\n    loadbalance\\n    import custom/*.override\\n}\\nimport custom/*.server\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"}}\n"
+            },
+            "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
+            "labels": {
+                "addonmanager.kubernetes.io/mode": "Reconcile",
+                "k8s-app": "kube-dns",
+                "kubernetes.io/cluster-service": "true"
+            },
+            "name": "coredns",
+            "namespace": "kube-system",
+            "resourceVersion": "92",
+            "selfLink": "/api/v1/namespaces/kube-system/configmaps/coredns",
+            "uid": "d77702d6-9f40-40ee-bf2f-b80ff313083f"
+        }
+    }
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps/:id?cluster_id=:cluster_id</code>
 
 Retrieve a configmap and all its info in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                                |
+|----------------------------|-------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to get the config map. |
 
 | Attributes                                 | &nbsp;                                                  |
 | ------------------------------------------ | ------------------------------------------------------- |
@@ -96,7 +122,7 @@ Retrieve a configmap and all its info in a given [environment](#administration-e
 | `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
 | `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
 | `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string       |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string      |
 | `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
 | `metadata.name` <br/>_string_              | The name of the config map                              |
 | `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |

--- a/source/includes/kubernetes_extension/_k8_configmaps.md
+++ b/source/includes/kubernetes_extension/_k8_configmaps.md
@@ -12,36 +12,20 @@ curl -X GET \
 
 > The above command returns a JSON structured like this:
 
-```js
+```json
 {
-    "data": [
-        {
-            "id": "coredns/kube-system",
-            "data": {
-                "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
-            },
-            "metadata": {
-                "annotations": {
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"Corefile\":\".:53 {\\n    errors\\n    health\\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\\n      pods insecure\\n      upstream\\n      fallthrough in-addr.arpa ip6.arpa\\n    }\\n    prometheus :9153\\n    forward . /etc/resolv.conf\\n    cache 30\\n    loop\\n    reload\\n    loadbalance\\n    import custom/*.override\\n}\\nimport custom/*.server\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"}}\n"
-                },
-                "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
-                "labels": {
-                    "addonmanager.kubernetes.io/mode": "Reconcile",
-                    "k8s-app": "kube-dns",
-                    "kubernetes.io/cluster-service": "true"
-                },
-                "name": "coredns",
-                "namespace": "kube-system",
-                "resourceVersion": "92",
-                "selfLink": "/api/v1/namespaces/kube-system/configmaps/coredns",
-                "uid": "d77702d6-9f40-40ee-bf2f-b80ff313083f"
-            }
-        },
-        ...
-    ],
-    "metadata": {
-        "recordCount": 4
+  "data": [
+    {
+      "id": "coredns/kube-system",
+      "data": {
+        "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
+      },
+      "metadata": {}
     }
+  ],
+  "metadata": {
+    "recordCount": 4
+  }
 }
 ```
 
@@ -50,22 +34,15 @@ curl -X GET \
 Retrieve a list of all config maps in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                  |
-|----------------------------|---------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to list the config maps. |
+| -------------------------- | ------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the config maps. |
 
-| Attributes                                 | &nbsp;                                                  |
-| ------------------------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the config map                                |
-| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
-| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
-| `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string      |
-| `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
-| `metadata.name` <br/>_string_              | The name of the config map                              |
-| `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
-| `metadata.uid` <br/>_object_               | The UUID of the config map                              |
-| `metadata.selfLink` <br/>_object_          | A link that uniquely identifies this config map         |
-| `metadata.resourceVersion` <br/>_object_   | The resource version of the config map                  |
+| Attributes                                 | &nbsp;                                             |
+| ------------------------------------------ | -------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the config map                           |
+| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map   |
+| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap   |
+| `metadata` <br/>_object_                   | The metadata of the config map                     |
 
 <!-------------------- GET A configmap -------------------->
 
@@ -79,32 +56,17 @@ curl -X GET \
 
 > The above command returns a JSON structured like this:
 
-```js
+```json
 {
+  "data": {
+    "id": "coredns/kube-system",
+    "apiVersion": "v1",
     "data": {
-        "id": "coredns/kube-system",
-        "apiVersion": "v1",
-        "data": {
-            "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
-        },
-        "kind": "ConfigMap",
-        "metadata": {
-            "annotations": {
-                "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"Corefile\":\".:53 {\\n    errors\\n    health\\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\\n      pods insecure\\n      upstream\\n      fallthrough in-addr.arpa ip6.arpa\\n    }\\n    prometheus :9153\\n    forward . /etc/resolv.conf\\n    cache 30\\n    loop\\n    reload\\n    loadbalance\\n    import custom/*.override\\n}\\nimport custom/*.server\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"}}\n"
-            },
-            "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
-            "labels": {
-                "addonmanager.kubernetes.io/mode": "Reconcile",
-                "k8s-app": "kube-dns",
-                "kubernetes.io/cluster-service": "true"
-            },
-            "name": "coredns",
-            "namespace": "kube-system",
-            "resourceVersion": "92",
-            "selfLink": "/api/v1/namespaces/kube-system/configmaps/coredns",
-            "uid": "d77702d6-9f40-40ee-bf2f-b80ff313083f"
-        }
-    }
+      "Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n    import custom/*.override\n}\nimport custom/*.server\n"
+    },
+    "kind": "ConfigMap",
+    "metadata": {}
+  }
 }
 ```
 
@@ -113,19 +75,12 @@ curl -X GET \
 Retrieve a configmap and all its info in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                |
-|----------------------------|-------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to get the config map. |
+| -------------------------- | ----------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the config map. |
 
-| Attributes                                 | &nbsp;                                                  |
-| ------------------------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the config map                                |
-| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
-| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
-| `metadata` <br/>_object_                   | The metadata of the config map                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the config map as a string      |
-| `metadata.annotations` <br/>_map_          | The annotations associated to the config map            |
-| `metadata.name` <br/>_string_              | The name of the config map                              |
-| `metadata.namespace` <br/>_string_         | The namespace in which the config map is created        |
-| `metadata.uid` <br/>_object_               | The UUID of the config map                              |
-| `metadata.selfLink` <br/>_object_          | A link that uniquely identifies this config map         |
-| `metadata.resourceVersion` <br/>_object_   | The resource version of the config map                  |
+| Attributes                                 | &nbsp;                                             |
+| ------------------------------------------ | -------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the config map                           |
+| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map   |
+| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap   |
+| `metadata` <br/>_object_                   | The metadata of the config map                     |

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -7,59 +7,191 @@
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/daemonsets"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/daemonsets?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
 
 ```json
 {
-  "data": [
-    {
-      "id": "canal/kube-system",
-      "metadata": {
-        "annotations": {
-          "deprecated.daemonset.template.generation": "8",
-          "kubectl.kubernetes.io/last-applied-configuration": "{...}"
+    "data": [
+        {
+            "id": "kube-proxy/kube-system",
+            "readyRatio": "3/3",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1",
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"DaemonSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"component\":\"kube-proxy\",\"tier\":\"node\"},\"name\":\"kube-proxy\",\"namespace\":\"kube-system\"},\"spec\":{\"selector\":{\"matchLabels\":{\"component\":\"kube-proxy\",\"tier\":\"node\"}},\"template\":{\"metadata\":{\"annotations\":null,\"labels\":{\"component\":\"kube-proxy\",\"tier\":\"node\"}},\"spec\":{\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"labelSelector\":null,\"matchExpressions\":[{\"key\":\"kubernetes.azure.com/cluster\",\"operator\":\"Exists\"}]}]}}},\"containers\":[{\"command\":[\"/hyperkube\",\"kube-proxy\",\"--kubeconfig=/var/lib/kubelet/kubeconfig\",\"--cluster-cidr=10.244.0.0/16\",\"--v=3\"],\"image\":\"mcr.microsoft.com/oss/kubernetes/hyperkube:v1.18.2.1\",\"name\":\"kube-proxy\",\"resources\":{\"requests\":{\"cpu\":\"100m\"}},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/kubelet\",\"name\":\"kubeconfig\",\"readOnly\":true},{\"mountPath\":\"/etc/kubernetes/certs\",\"name\":\"certificates\",\"readOnly\":true},{\"mountPath\":\"/run/xtables.lock\",\"name\":\"iptableslock\"}]}],\"hostNetwork\":true,\"nodeSelector\":{\"beta.kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"tolerations\":[{\"key\":\"CriticalAddonsOnly\",\"operator\":\"Exists\"},{\"effect\":\"NoExecute\",\"operator\":\"Exists\"},{\"effect\":\"NoSchedule\",\"operator\":\"Exists\"}],\"volumes\":[{\"hostPath\":{\"path\":\"/var/lib/kubelet\"},\"name\":\"kubeconfig\"},{\"hostPath\":{\"path\":\"/etc/kubernetes/certs\"},\"name\":\"certificates\"},{\"hostPath\":{\"path\":\"/run/xtables.lock\",\"type\":\"FileOrCreate\"},\"name\":\"iptableslock\"}]}},\"updateStrategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"}}}\n"
+                },
+                "creationTimestamp": "2020-06-15T16:14:40.000-04:00",
+                "generation": 1,
+                "labels": {
+                    "addonmanager.kubernetes.io/mode": "Reconcile",
+                    "component": "kube-proxy",
+                    "tier": "node"
+                },
+                "name": "kube-proxy",
+                "namespace": "kube-system",
+                "resourceVersion": "630",
+                "selfLink": "/apis/apps/v1/namespaces/kube-system/daemonsets/kube-proxy",
+                "uid": "ed01c14c-e722-44a0-a0b8-e1d55662a917"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "component": "kube-proxy",
+                        "tier": "node"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "component": "kube-proxy",
+                            "tier": "node"
+                        }
+                    },
+                    "spec": {
+                        "affinity": {
+                            "nodeAffinity": {
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "nodeSelectorTerms": [
+                                        {
+                                            "matchExpressions": [
+                                                {
+                                                    "key": "kubernetes.azure.com/cluster",
+                                                    "operator": "Exists"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "containers": [
+                            {
+                                "command": [
+                                    "/hyperkube",
+                                    "kube-proxy",
+                                    "--kubeconfig=/var/lib/kubelet/kubeconfig",
+                                    "--cluster-cidr=10.244.0.0/16",
+                                    "--v=3"
+                                ],
+                                "image": "mcr.microsoft.com/oss/kubernetes/hyperkube:v1.18.2.1",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "kube-proxy",
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "100m"
+                                    }
+                                },
+                                "securityContext": {
+                                    "privileged": true
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/kubelet",
+                                        "name": "kubeconfig",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/kubernetes/certs",
+                                        "name": "certificates",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/run/xtables.lock",
+                                        "name": "iptableslock"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "hostNetwork": true,
+                        "nodeSelector": {
+                            "beta.kubernetes.io/os": "linux"
+                        },
+                        "priorityClassName": "system-node-critical",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "key": "CriticalAddonsOnly",
+                                "operator": "Exists"
+                            },
+                            {
+                                "effect": "NoExecute",
+                                "operator": "Exists"
+                            },
+                            {
+                                "effect": "NoSchedule",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/kubelet",
+                                    "type": ""
+                                },
+                                "name": "kubeconfig"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/etc/kubernetes/certs",
+                                    "type": ""
+                                },
+                                "name": "certificates"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/run/xtables.lock",
+                                    "type": "FileOrCreate"
+                                },
+                                "name": "iptableslock"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxUnavailable": "1"
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 3,
+                "desiredNumberScheduled": 3,
+                "numberAvailable": 3,
+                "numberMisscheduled": 0,
+                "numberReady": 3,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 3
+            }
         },
-        "creationTimestamp": "2019-03-12T14:22:52.000-04:00",
-        "generation": 8,
-        "labels": {
-          "k8s-app": "canal"
-        },
-        "name": "canal",
-        "namespace": "kube-system",
-        "resourceVersion": "117221602",
-        "selfLink": "/apis/apps/v1/namespaces/kube-system/daemonsets/canal",
-        "uid": "d946db1b-44f3-11e9-960d-02007a9a001f"
-      },
-      "spec": {
-        /*...*/
-      },
-      "status": {
-        "currentNumberScheduled": 10,
-        "desiredNumberScheduled": 10,
-        "numberAvailable": 10,
-        "numberMisscheduled": 0,
-        "numberReady": 10,
-        "observedGeneration": 8,
-        "updatedNumberScheduled": 10
-      }
+        ...
+    ],
+    "metadata": {
+        "recordCount": 5
     }
-  ],
-  // ...
-  "metadata": {
-    "recordCount": 9
-  }
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets?cluster_id=:cluster_id</code>
 
 Retrieve a list of all daemon sets in a given [environment](#administration-environments).
 
+| Required                   | &nbsp;                                                  |
+|----------------------------|---------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to list the daemon sets. |
+
 | Attributes                                 | &nbsp;                                                  |
-| ------------------------------------------ | ------------------------------------------------------- |
+|--------------------------------------------|---------------------------------------------------------|
 | `id` <br/>_string_                         | The id of the daemon set                                |
 | `metadata` <br/>_object_                   | The metadata of the daemon set                          |
 | `metadata.creationTimestamp` <br/>_string_ | The date of creation of the daemon set as a string      |
@@ -79,7 +211,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/daemonsets/test-aerospike/auth"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/daemonsets/test-aerospike/auth?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -87,53 +219,187 @@ curl -X GET \
 ```json
 {
     "data": {
-        "id": "canal/kube-system",
+        "id": "kube-proxy/kube-system",
+        "readyRatio": "3/3",
+        "apiVersion": "apps/v1",
+        "kind": "DaemonSet",
         "metadata": {
             "annotations": {
-                "deprecated.daemonset.template.generation": "8",
-                "kubectl.kubernetes.io/last-applied-configuration": "{...}"
+                "deprecated.daemonset.template.generation": "1",
+                "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"DaemonSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"component\":\"kube-proxy\",\"tier\":\"node\"},\"name\":\"kube-proxy\",\"namespace\":\"kube-system\"},\"spec\":{\"selector\":{\"matchLabels\":{\"component\":\"kube-proxy\",\"tier\":\"node\"}},\"template\":{\"metadata\":{\"annotations\":null,\"labels\":{\"component\":\"kube-proxy\",\"tier\":\"node\"}},\"spec\":{\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"labelSelector\":null,\"matchExpressions\":[{\"key\":\"kubernetes.azure.com/cluster\",\"operator\":\"Exists\"}]}]}}},\"containers\":[{\"command\":[\"/hyperkube\",\"kube-proxy\",\"--kubeconfig=/var/lib/kubelet/kubeconfig\",\"--cluster-cidr=10.244.0.0/16\",\"--v=3\"],\"image\":\"mcr.microsoft.com/oss/kubernetes/hyperkube:v1.18.2.1\",\"name\":\"kube-proxy\",\"resources\":{\"requests\":{\"cpu\":\"100m\"}},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/kubelet\",\"name\":\"kubeconfig\",\"readOnly\":true},{\"mountPath\":\"/etc/kubernetes/certs\",\"name\":\"certificates\",\"readOnly\":true},{\"mountPath\":\"/run/xtables.lock\",\"name\":\"iptableslock\"}]}],\"hostNetwork\":true,\"nodeSelector\":{\"beta.kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"tolerations\":[{\"key\":\"CriticalAddonsOnly\",\"operator\":\"Exists\"},{\"effect\":\"NoExecute\",\"operator\":\"Exists\"},{\"effect\":\"NoSchedule\",\"operator\":\"Exists\"}],\"volumes\":[{\"hostPath\":{\"path\":\"/var/lib/kubelet\"},\"name\":\"kubeconfig\"},{\"hostPath\":{\"path\":\"/etc/kubernetes/certs\"},\"name\":\"certificates\"},{\"hostPath\":{\"path\":\"/run/xtables.lock\",\"type\":\"FileOrCreate\"},\"name\":\"iptableslock\"}]}},\"updateStrategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"}}}\n"
             },
-            "creationTimestamp": "2019-03-12T14:22:52.000-04:00",
-            "generation": 8,
+            "creationTimestamp": "2020-06-15T16:14:40.000-04:00",
+            "generation": 1,
             "labels": {
-                "k8s-app": "canal"
+                "addonmanager.kubernetes.io/mode": "Reconcile",
+                "component": "kube-proxy",
+                "tier": "node"
             },
-            "name": "canal",
+            "name": "kube-proxy",
             "namespace": "kube-system",
-            "resourceVersion": "117221602",
-            "selfLink": "/apis/apps/v1/namespaces/kube-system/daemonsets/canal",
-            "uid": "d946db1b-44f3-11e9-960d-02007a9a001f"
+            "resourceVersion": "630",
+            "selfLink": "/apis/apps/v1/namespaces/kube-system/daemonsets/kube-proxy",
+            "uid": "ed01c14c-e722-44a0-a0b8-e1d55662a917"
         },
         "spec": {
-          // ...
+            "revisionHistoryLimit": 10,
+            "selector": {
+                "matchLabels": {
+                    "component": "kube-proxy",
+                    "tier": "node"
+                }
+            },
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "component": "kube-proxy",
+                        "tier": "node"
+                    }
+                },
+                "spec": {
+                    "affinity": {
+                        "nodeAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "nodeSelectorTerms": [
+                                    {
+                                        "matchExpressions": [
+                                            {
+                                                "key": "kubernetes.azure.com/cluster",
+                                                "operator": "Exists"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "containers": [
+                        {
+                            "command": [
+                                "/hyperkube",
+                                "kube-proxy",
+                                "--kubeconfig=/var/lib/kubelet/kubeconfig",
+                                "--cluster-cidr=10.244.0.0/16",
+                                "--v=3"
+                            ],
+                            "image": "mcr.microsoft.com/oss/kubernetes/hyperkube:v1.18.2.1",
+                            "imagePullPolicy": "IfNotPresent",
+                            "name": "kube-proxy",
+                            "resources": {
+                                "requests": {
+                                    "cpu": "100m"
+                                }
+                            },
+                            "securityContext": {
+                                "privileged": true
+                            },
+                            "terminationMessagePath": "/dev/termination-log",
+                            "terminationMessagePolicy": "File",
+                            "volumeMounts": [
+                                {
+                                    "mountPath": "/var/lib/kubelet",
+                                    "name": "kubeconfig",
+                                    "readOnly": true
+                                },
+                                {
+                                    "mountPath": "/etc/kubernetes/certs",
+                                    "name": "certificates",
+                                    "readOnly": true
+                                },
+                                {
+                                    "mountPath": "/run/xtables.lock",
+                                    "name": "iptableslock"
+                                }
+                            ]
+                        }
+                    ],
+                    "dnsPolicy": "ClusterFirst",
+                    "hostNetwork": true,
+                    "nodeSelector": {
+                        "beta.kubernetes.io/os": "linux"
+                    },
+                    "priorityClassName": "system-node-critical",
+                    "restartPolicy": "Always",
+                    "schedulerName": "default-scheduler",
+                    "securityContext": {},
+                    "terminationGracePeriodSeconds": 30,
+                    "tolerations": [
+                        {
+                            "key": "CriticalAddonsOnly",
+                            "operator": "Exists"
+                        },
+                        {
+                            "effect": "NoExecute",
+                            "operator": "Exists"
+                        },
+                        {
+                            "effect": "NoSchedule",
+                            "operator": "Exists"
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "hostPath": {
+                                "path": "/var/lib/kubelet",
+                                "type": ""
+                            },
+                            "name": "kubeconfig"
+                        },
+                        {
+                            "hostPath": {
+                                "path": "/etc/kubernetes/certs",
+                                "type": ""
+                            },
+                            "name": "certificates"
+                        },
+                        {
+                            "hostPath": {
+                                "path": "/run/xtables.lock",
+                                "type": "FileOrCreate"
+                            },
+                            "name": "iptableslock"
+                        }
+                    ]
+                }
+            },
+            "updateStrategy": {
+                "rollingUpdate": {
+                    "maxUnavailable": "1"
+                },
+                "type": "RollingUpdate"
+            }
         },
         "status": {
-            "currentNumberScheduled": 10,
-            "desiredNumberScheduled": 10,
-            "numberAvailable": 10,
+            "currentNumberScheduled": 3,
+            "desiredNumberScheduled": 3,
+            "numberAvailable": 3,
             "numberMisscheduled": 0,
-            "numberReady": 10,
-            "observedGeneration": 8,
-            "updatedNumberScheduled": 10
+            "numberReady": 3,
+            "observedGeneration": 1,
+            "updatedNumberScheduled": 3
         }
     }
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id?cluster_id=:cluster_id</code>
 
 Retrieve a daemon set and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the daemon set                                        |
-| `metadata` <br/>_object_                   | The metadata of the daemon set                                  |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the daemon set as a string              |
-| `metadata.labels` <br/>_map_               | The labels associated to the daemon                             |
-| `metadata.name` <br/>_string_              | The name of the daemon set                                      |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                |
-| `metadata.uid` <br/>_object_               | The UUID of the daemon set                                      |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set         |
-| `status`<br/>_object_                      | The status information of the daemon set                        |
+| Required                   | &nbsp;                                                |
+|----------------------------|-------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to get the daemon set. |
+
+| Attributes                                 | &nbsp;                                                  |
+|--------------------------------------------|---------------------------------------------------------|
+| `id` <br/>_string_                         | The id of the daemon set                                |
+| `metadata` <br/>_object_                   | The metadata of the daemon set                          |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the daemon set as a string      |
+| `metadata.labels` <br/>_map_               | The labels associated to the daemon set                 |
+| `metadata.name` <br/>_string_              | The name of the daemon set                              |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created        |
+| `metadata.uid` <br/>_object_               | The UUID of the daemon set                              |
+| `spec`<br/>_object_                        | The specification used to create and run the daemon set |
+| `status`<br/>_object_                      | The status information of the daemon set                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -14,171 +14,18 @@ curl -X GET \
 
 ```json
 {
-    "data": [
-        {
-            "id": "kube-proxy/kube-system",
-            "readyRatio": "3/3",
-            "metadata": {
-                "annotations": {
-                    "deprecated.daemonset.template.generation": "1",
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"DaemonSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"component\":\"kube-proxy\",\"tier\":\"node\"},\"name\":\"kube-proxy\",\"namespace\":\"kube-system\"},\"spec\":{\"selector\":{\"matchLabels\":{\"component\":\"kube-proxy\",\"tier\":\"node\"}},\"template\":{\"metadata\":{\"annotations\":null,\"labels\":{\"component\":\"kube-proxy\",\"tier\":\"node\"}},\"spec\":{\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"labelSelector\":null,\"matchExpressions\":[{\"key\":\"kubernetes.azure.com/cluster\",\"operator\":\"Exists\"}]}]}}},\"containers\":[{\"command\":[\"/hyperkube\",\"kube-proxy\",\"--kubeconfig=/var/lib/kubelet/kubeconfig\",\"--cluster-cidr=10.244.0.0/16\",\"--v=3\"],\"image\":\"mcr.microsoft.com/oss/kubernetes/hyperkube:v1.18.2.1\",\"name\":\"kube-proxy\",\"resources\":{\"requests\":{\"cpu\":\"100m\"}},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/kubelet\",\"name\":\"kubeconfig\",\"readOnly\":true},{\"mountPath\":\"/etc/kubernetes/certs\",\"name\":\"certificates\",\"readOnly\":true},{\"mountPath\":\"/run/xtables.lock\",\"name\":\"iptableslock\"}]}],\"hostNetwork\":true,\"nodeSelector\":{\"beta.kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"tolerations\":[{\"key\":\"CriticalAddonsOnly\",\"operator\":\"Exists\"},{\"effect\":\"NoExecute\",\"operator\":\"Exists\"},{\"effect\":\"NoSchedule\",\"operator\":\"Exists\"}],\"volumes\":[{\"hostPath\":{\"path\":\"/var/lib/kubelet\"},\"name\":\"kubeconfig\"},{\"hostPath\":{\"path\":\"/etc/kubernetes/certs\"},\"name\":\"certificates\"},{\"hostPath\":{\"path\":\"/run/xtables.lock\",\"type\":\"FileOrCreate\"},\"name\":\"iptableslock\"}]}},\"updateStrategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"}}}\n"
-                },
-                "creationTimestamp": "2020-06-15T16:14:40.000-04:00",
-                "generation": 1,
-                "labels": {
-                    "addonmanager.kubernetes.io/mode": "Reconcile",
-                    "component": "kube-proxy",
-                    "tier": "node"
-                },
-                "name": "kube-proxy",
-                "namespace": "kube-system",
-                "resourceVersion": "630",
-                "selfLink": "/apis/apps/v1/namespaces/kube-system/daemonsets/kube-proxy",
-                "uid": "ed01c14c-e722-44a0-a0b8-e1d55662a917"
-            },
-            "spec": {
-                "revisionHistoryLimit": 10,
-                "selector": {
-                    "matchLabels": {
-                        "component": "kube-proxy",
-                        "tier": "node"
-                    }
-                },
-                "template": {
-                    "metadata": {
-                        "labels": {
-                            "component": "kube-proxy",
-                            "tier": "node"
-                        }
-                    },
-                    "spec": {
-                        "affinity": {
-                            "nodeAffinity": {
-                                "requiredDuringSchedulingIgnoredDuringExecution": {
-                                    "nodeSelectorTerms": [
-                                        {
-                                            "matchExpressions": [
-                                                {
-                                                    "key": "kubernetes.azure.com/cluster",
-                                                    "operator": "Exists"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "containers": [
-                            {
-                                "command": [
-                                    "/hyperkube",
-                                    "kube-proxy",
-                                    "--kubeconfig=/var/lib/kubelet/kubeconfig",
-                                    "--cluster-cidr=10.244.0.0/16",
-                                    "--v=3"
-                                ],
-                                "image": "mcr.microsoft.com/oss/kubernetes/hyperkube:v1.18.2.1",
-                                "imagePullPolicy": "IfNotPresent",
-                                "name": "kube-proxy",
-                                "resources": {
-                                    "requests": {
-                                        "cpu": "100m"
-                                    }
-                                },
-                                "securityContext": {
-                                    "privileged": true
-                                },
-                                "terminationMessagePath": "/dev/termination-log",
-                                "terminationMessagePolicy": "File",
-                                "volumeMounts": [
-                                    {
-                                        "mountPath": "/var/lib/kubelet",
-                                        "name": "kubeconfig",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "mountPath": "/etc/kubernetes/certs",
-                                        "name": "certificates",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "mountPath": "/run/xtables.lock",
-                                        "name": "iptableslock"
-                                    }
-                                ]
-                            }
-                        ],
-                        "dnsPolicy": "ClusterFirst",
-                        "hostNetwork": true,
-                        "nodeSelector": {
-                            "beta.kubernetes.io/os": "linux"
-                        },
-                        "priorityClassName": "system-node-critical",
-                        "restartPolicy": "Always",
-                        "schedulerName": "default-scheduler",
-                        "securityContext": {},
-                        "terminationGracePeriodSeconds": 30,
-                        "tolerations": [
-                            {
-                                "key": "CriticalAddonsOnly",
-                                "operator": "Exists"
-                            },
-                            {
-                                "effect": "NoExecute",
-                                "operator": "Exists"
-                            },
-                            {
-                                "effect": "NoSchedule",
-                                "operator": "Exists"
-                            }
-                        ],
-                        "volumes": [
-                            {
-                                "hostPath": {
-                                    "path": "/var/lib/kubelet",
-                                    "type": ""
-                                },
-                                "name": "kubeconfig"
-                            },
-                            {
-                                "hostPath": {
-                                    "path": "/etc/kubernetes/certs",
-                                    "type": ""
-                                },
-                                "name": "certificates"
-                            },
-                            {
-                                "hostPath": {
-                                    "path": "/run/xtables.lock",
-                                    "type": "FileOrCreate"
-                                },
-                                "name": "iptableslock"
-                            }
-                        ]
-                    }
-                },
-                "updateStrategy": {
-                    "rollingUpdate": {
-                        "maxUnavailable": "1"
-                    },
-                    "type": "RollingUpdate"
-                }
-            },
-            "status": {
-                "currentNumberScheduled": 3,
-                "desiredNumberScheduled": 3,
-                "numberAvailable": 3,
-                "numberMisscheduled": 0,
-                "numberReady": 3,
-                "observedGeneration": 1,
-                "updatedNumberScheduled": 3
-            }
-        },
-        ...
-    ],
-    "metadata": {
-        "recordCount": 5
+  "data": [
+    {
+      "id": "kube-proxy/kube-system",
+      "readyRatio": "3/3",
+      "metadata": {},
+      "spec": {},
+      "status": {}
     }
+  ],
+  "metadata": {
+    "recordCount": 5
+  }
 }
 ```
 
@@ -187,20 +34,15 @@ curl -X GET \
 Retrieve a list of all daemon sets in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                  |
-|----------------------------|---------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to list the daemon sets. |
+| -------------------------- | ------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the daemon sets. |
 
-| Attributes                                 | &nbsp;                                                  |
-|--------------------------------------------|---------------------------------------------------------|
-| `id` <br/>_string_                         | The id of the daemon set                                |
-| `metadata` <br/>_object_                   | The metadata of the daemon set                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the daemon set as a string      |
-| `metadata.labels` <br/>_map_               | The labels associated to the daemon set                 |
-| `metadata.name` <br/>_string_              | The name of the daemon set                              |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created        |
-| `metadata.uid` <br/>_object_               | The UUID of the daemon set                              |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set |
-| `status`<br/>_object_                      | The status information of the daemon set                |
+| Attributes               | &nbsp;                                                  |
+| ------------------------ | ------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the daemon set                                |
+| `metadata` <br/>_object_ | The metadata of the daemon set                          |
+| `spec`<br/>_object_      | The specification used to create and run the daemon set |
+| `status`<br/>_object_    | The status information of the daemon set                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -218,167 +60,15 @@ curl -X GET \
 
 ```json
 {
-    "data": {
-        "id": "kube-proxy/kube-system",
-        "readyRatio": "3/3",
-        "apiVersion": "apps/v1",
-        "kind": "DaemonSet",
-        "metadata": {
-            "annotations": {
-                "deprecated.daemonset.template.generation": "1",
-                "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"DaemonSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"component\":\"kube-proxy\",\"tier\":\"node\"},\"name\":\"kube-proxy\",\"namespace\":\"kube-system\"},\"spec\":{\"selector\":{\"matchLabels\":{\"component\":\"kube-proxy\",\"tier\":\"node\"}},\"template\":{\"metadata\":{\"annotations\":null,\"labels\":{\"component\":\"kube-proxy\",\"tier\":\"node\"}},\"spec\":{\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"labelSelector\":null,\"matchExpressions\":[{\"key\":\"kubernetes.azure.com/cluster\",\"operator\":\"Exists\"}]}]}}},\"containers\":[{\"command\":[\"/hyperkube\",\"kube-proxy\",\"--kubeconfig=/var/lib/kubelet/kubeconfig\",\"--cluster-cidr=10.244.0.0/16\",\"--v=3\"],\"image\":\"mcr.microsoft.com/oss/kubernetes/hyperkube:v1.18.2.1\",\"name\":\"kube-proxy\",\"resources\":{\"requests\":{\"cpu\":\"100m\"}},\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/kubelet\",\"name\":\"kubeconfig\",\"readOnly\":true},{\"mountPath\":\"/etc/kubernetes/certs\",\"name\":\"certificates\",\"readOnly\":true},{\"mountPath\":\"/run/xtables.lock\",\"name\":\"iptableslock\"}]}],\"hostNetwork\":true,\"nodeSelector\":{\"beta.kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"tolerations\":[{\"key\":\"CriticalAddonsOnly\",\"operator\":\"Exists\"},{\"effect\":\"NoExecute\",\"operator\":\"Exists\"},{\"effect\":\"NoSchedule\",\"operator\":\"Exists\"}],\"volumes\":[{\"hostPath\":{\"path\":\"/var/lib/kubelet\"},\"name\":\"kubeconfig\"},{\"hostPath\":{\"path\":\"/etc/kubernetes/certs\"},\"name\":\"certificates\"},{\"hostPath\":{\"path\":\"/run/xtables.lock\",\"type\":\"FileOrCreate\"},\"name\":\"iptableslock\"}]}},\"updateStrategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"}}}\n"
-            },
-            "creationTimestamp": "2020-06-15T16:14:40.000-04:00",
-            "generation": 1,
-            "labels": {
-                "addonmanager.kubernetes.io/mode": "Reconcile",
-                "component": "kube-proxy",
-                "tier": "node"
-            },
-            "name": "kube-proxy",
-            "namespace": "kube-system",
-            "resourceVersion": "630",
-            "selfLink": "/apis/apps/v1/namespaces/kube-system/daemonsets/kube-proxy",
-            "uid": "ed01c14c-e722-44a0-a0b8-e1d55662a917"
-        },
-        "spec": {
-            "revisionHistoryLimit": 10,
-            "selector": {
-                "matchLabels": {
-                    "component": "kube-proxy",
-                    "tier": "node"
-                }
-            },
-            "template": {
-                "metadata": {
-                    "labels": {
-                        "component": "kube-proxy",
-                        "tier": "node"
-                    }
-                },
-                "spec": {
-                    "affinity": {
-                        "nodeAffinity": {
-                            "requiredDuringSchedulingIgnoredDuringExecution": {
-                                "nodeSelectorTerms": [
-                                    {
-                                        "matchExpressions": [
-                                            {
-                                                "key": "kubernetes.azure.com/cluster",
-                                                "operator": "Exists"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "containers": [
-                        {
-                            "command": [
-                                "/hyperkube",
-                                "kube-proxy",
-                                "--kubeconfig=/var/lib/kubelet/kubeconfig",
-                                "--cluster-cidr=10.244.0.0/16",
-                                "--v=3"
-                            ],
-                            "image": "mcr.microsoft.com/oss/kubernetes/hyperkube:v1.18.2.1",
-                            "imagePullPolicy": "IfNotPresent",
-                            "name": "kube-proxy",
-                            "resources": {
-                                "requests": {
-                                    "cpu": "100m"
-                                }
-                            },
-                            "securityContext": {
-                                "privileged": true
-                            },
-                            "terminationMessagePath": "/dev/termination-log",
-                            "terminationMessagePolicy": "File",
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/var/lib/kubelet",
-                                    "name": "kubeconfig",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/etc/kubernetes/certs",
-                                    "name": "certificates",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/run/xtables.lock",
-                                    "name": "iptableslock"
-                                }
-                            ]
-                        }
-                    ],
-                    "dnsPolicy": "ClusterFirst",
-                    "hostNetwork": true,
-                    "nodeSelector": {
-                        "beta.kubernetes.io/os": "linux"
-                    },
-                    "priorityClassName": "system-node-critical",
-                    "restartPolicy": "Always",
-                    "schedulerName": "default-scheduler",
-                    "securityContext": {},
-                    "terminationGracePeriodSeconds": 30,
-                    "tolerations": [
-                        {
-                            "key": "CriticalAddonsOnly",
-                            "operator": "Exists"
-                        },
-                        {
-                            "effect": "NoExecute",
-                            "operator": "Exists"
-                        },
-                        {
-                            "effect": "NoSchedule",
-                            "operator": "Exists"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "hostPath": {
-                                "path": "/var/lib/kubelet",
-                                "type": ""
-                            },
-                            "name": "kubeconfig"
-                        },
-                        {
-                            "hostPath": {
-                                "path": "/etc/kubernetes/certs",
-                                "type": ""
-                            },
-                            "name": "certificates"
-                        },
-                        {
-                            "hostPath": {
-                                "path": "/run/xtables.lock",
-                                "type": "FileOrCreate"
-                            },
-                            "name": "iptableslock"
-                        }
-                    ]
-                }
-            },
-            "updateStrategy": {
-                "rollingUpdate": {
-                    "maxUnavailable": "1"
-                },
-                "type": "RollingUpdate"
-            }
-        },
-        "status": {
-            "currentNumberScheduled": 3,
-            "desiredNumberScheduled": 3,
-            "numberAvailable": 3,
-            "numberMisscheduled": 0,
-            "numberReady": 3,
-            "observedGeneration": 1,
-            "updatedNumberScheduled": 3
-        }
-    }
+  "data": {
+    "id": "kube-proxy/kube-system",
+    "readyRatio": "3/3",
+    "apiVersion": "apps/v1",
+    "kind": "DaemonSet",
+    "metadata": {},
+    "spec": {},
+    "status": {}
+  }
 }
 ```
 
@@ -387,19 +77,14 @@ curl -X GET \
 Retrieve a daemon set and all its info in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                |
-|----------------------------|-------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to get the daemon set. |
+| -------------------------- | ----------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the daemon set. |
 
-| Attributes                                 | &nbsp;                                                  |
-|--------------------------------------------|---------------------------------------------------------|
-| `id` <br/>_string_                         | The id of the daemon set                                |
-| `metadata` <br/>_object_                   | The metadata of the daemon set                          |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the daemon set as a string      |
-| `metadata.labels` <br/>_map_               | The labels associated to the daemon set                 |
-| `metadata.name` <br/>_string_              | The name of the daemon set                              |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created        |
-| `metadata.uid` <br/>_object_               | The UUID of the daemon set                              |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set |
-| `status`<br/>_object_                      | The status information of the daemon set                |
+| Attributes               | &nbsp;                                                  |
+| ------------------------ | ------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the daemon set                                |
+| `metadata` <br/>_object_ | The metadata of the daemon set                          |
+| `spec`<br/>_object_      | The specification used to create and run the daemon set |
+| `status`<br/>_object_    | The status information of the daemon set                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -14,262 +14,19 @@ curl -X GET \
 
 ```json
 {
-    "data": [
-        {
-            "id": "coredns/kube-system",
-            "deploymentStatus": "Progressing",
-            "readyRatio": "2/2",
-            "metadata": {
-                "annotations": {
-                    "deployment.kubernetes.io/revision": "1",
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"kubernetes.io/name\":\"CoreDNS\",\"version\":\"v20\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"},\"spec\":{\"paused\":false,\"selector\":{\"matchLabels\":{\"k8s-app\":\"kube-dns\",\"version\":\"v20\"}},\"strategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"},\"template\":{\"metadata\":{\"annotations\":{\"prometheus.io/port\":\"9153\"},\"labels\":{\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"version\":\"v20\"}},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"k8s-app\",\"operator\":\"In\",\"values\":[\"kube-dns\"]}]},\"topologyKey\":\"failure-domain.beta.kubernetes.io/zone\"},\"weight\":10},{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"k8s-app\",\"operator\":\"In\",\"values\":[\"kube-dns\"]}]},\"topologyKey\":\"kubernetes.io/hostname\"},\"weight\":5}]}},\"containers\":[{\"args\":[\"-conf\",\"/etc/coredns/Corefile\"],\"image\":\"mcr.microsoft.com/oss/kubernetes/coredns:1.6.6\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"failureThreshold\":5,\"httpGet\":{\"path\":\"/health\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":60,\"successThreshold\":1,\"timeoutSeconds\":5},\"name\":\"coredns\",\"ports\":[{\"containerPort\":53,\"name\":\"dns\",\"protocol\":\"UDP\"},{\"containerPort\":53,\"name\":\"dns-tcp\",\"protocol\":\"TCP\"},{\"containerPort\":9153,\"name\":\"metrics\",\"protocol\":\"TCP\"}],\"resources\":{\"limits\":{\"memory\":\"170Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"70Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"add\":[\"NET_BIND_SERVICE\"],\"drop\":[\"all\"]},\"procMount\":\"Default\",\"readOnlyRootFilesystem\":true},\"volumeMounts\":[{\"mountPath\":\"/etc/coredns\",\"name\":\"config-volume\",\"readOnly\":true},{\"mountPath\":\"/etc/coredns/custom\",\"name\":\"custom-config-volume\",\"readOnly\":true},{\"mountPath\":\"/tmp\",\"name\":\"tmp\"}]}],\"dnsPolicy\":\"Default\",\"nodeSelector\":{\"beta.kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"serviceAccountName\":\"coredns\",\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"},{\"key\":\"CriticalAddonsOnly\",\"operator\":\"Exists\"}],\"volumes\":[{\"configMap\":{\"items\":[{\"key\":\"Corefile\",\"path\":\"Corefile\"}],\"name\":\"coredns\"},\"name\":\"config-volume\"},{\"configMap\":{\"name\":\"coredns-custom\",\"optional\":true},\"name\":\"custom-config-volume\"},{\"emptyDir\":{},\"name\":\"tmp\"}]}}}}\n"
-                },
-                "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
-                "generation": 2,
-                "labels": {
-                    "addonmanager.kubernetes.io/mode": "Reconcile",
-                    "k8s-app": "kube-dns",
-                    "kubernetes.io/cluster-service": "true",
-                    "kubernetes.io/name": "CoreDNS",
-                    "version": "v20"
-                },
-                "name": "coredns",
-                "namespace": "kube-system",
-                "resourceVersion": "653",
-                "selfLink": "/apis/apps/v1/namespaces/kube-system/deployments/coredns",
-                "uid": "4c15009d-1e32-4b73-9c82-559b81f1bd93"
-            },
-            "spec": {
-                "progressDeadlineSeconds": 600,
-                "replicas": 2,
-                "revisionHistoryLimit": 10,
-                "selector": {
-                    "matchLabels": {
-                        "k8s-app": "kube-dns",
-                        "version": "v20"
-                    }
-                },
-                "strategy": {
-                    "rollingUpdate": {
-                        "maxSurge": "25%",
-                        "maxUnavailable": 1
-                    },
-                    "type": "RollingUpdate"
-                },
-                "template": {
-                    "metadata": {
-                        "annotations": {
-                            "prometheus.io/port": "9153"
-                        },
-                        "labels": {
-                            "k8s-app": "kube-dns",
-                            "kubernetes.io/cluster-service": "true",
-                            "version": "v20"
-                        }
-                    },
-                    "spec": {
-                        "affinity": {
-                            "podAntiAffinity": {
-                                "preferredDuringSchedulingIgnoredDuringExecution": [
-                                    {
-                                        "podAffinityTerm": {
-                                            "labelSelector": {
-                                                "matchExpressions": [
-                                                    {
-                                                        "key": "k8s-app",
-                                                        "operator": "In",
-                                                        "values": [
-                                                            "kube-dns"
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "topologyKey": "failure-domain.beta.kubernetes.io/zone"
-                                        },
-                                        "weight": 10
-                                    },
-                                    {
-                                        "podAffinityTerm": {
-                                            "labelSelector": {
-                                                "matchExpressions": [
-                                                    {
-                                                        "key": "k8s-app",
-                                                        "operator": "In",
-                                                        "values": [
-                                                            "kube-dns"
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            "topologyKey": "kubernetes.io/hostname"
-                                        },
-                                        "weight": 5
-                                    }
-                                ]
-                            }
-                        },
-                        "containers": [
-                            {
-                                "args": [
-                                    "-conf",
-                                    "/etc/coredns/Corefile"
-                                ],
-                                "image": "mcr.microsoft.com/oss/kubernetes/coredns:1.6.6",
-                                "imagePullPolicy": "IfNotPresent",
-                                "livenessProbe": {
-                                    "failureThreshold": 5,
-                                    "httpGet": {
-                                        "path": "/health",
-                                        "port": 8080,
-                                        "scheme": "HTTP"
-                                    },
-                                    "initialDelaySeconds": 60,
-                                    "periodSeconds": 10,
-                                    "successThreshold": 1,
-                                    "timeoutSeconds": 5
-                                },
-                                "name": "coredns",
-                                "ports": [
-                                    {
-                                        "containerPort": 53,
-                                        "name": "dns",
-                                        "protocol": "UDP"
-                                    },
-                                    {
-                                        "containerPort": 53,
-                                        "name": "dns-tcp",
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "containerPort": 9153,
-                                        "name": "metrics",
-                                        "protocol": "TCP"
-                                    }
-                                ],
-                                "resources": {
-                                    "limits": {
-                                        "memory": "170Mi"
-                                    },
-                                    "requests": {
-                                        "cpu": "100m",
-                                        "memory": "70Mi"
-                                    }
-                                },
-                                "securityContext": {
-                                    "allowPrivilegeEscalation": false,
-                                    "capabilities": {
-                                        "add": [
-                                            "NET_BIND_SERVICE"
-                                        ],
-                                        "drop": [
-                                            "all"
-                                        ]
-                                    },
-                                    "procMount": "Default",
-                                    "readOnlyRootFilesystem": true
-                                },
-                                "terminationMessagePath": "/dev/termination-log",
-                                "terminationMessagePolicy": "File",
-                                "volumeMounts": [
-                                    {
-                                        "mountPath": "/etc/coredns",
-                                        "name": "config-volume",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "mountPath": "/etc/coredns/custom",
-                                        "name": "custom-config-volume",
-                                        "readOnly": true
-                                    },
-                                    {
-                                        "mountPath": "/tmp",
-                                        "name": "tmp"
-                                    }
-                                ]
-                            }
-                        ],
-                        "dnsPolicy": "Default",
-                        "nodeSelector": {
-                            "beta.kubernetes.io/os": "linux"
-                        },
-                        "priorityClassName": "system-node-critical",
-                        "restartPolicy": "Always",
-                        "schedulerName": "default-scheduler",
-                        "securityContext": {},
-                        "serviceAccount": "coredns",
-                        "serviceAccountName": "coredns",
-                        "terminationGracePeriodSeconds": 30,
-                        "tolerations": [
-                            {
-                                "effect": "NoSchedule",
-                                "key": "node-role.kubernetes.io/master"
-                            },
-                            {
-                                "key": "CriticalAddonsOnly",
-                                "operator": "Exists"
-                            }
-                        ],
-                        "volumes": [
-                            {
-                                "configMap": {
-                                    "defaultMode": 420,
-                                    "items": [
-                                        {
-                                            "key": "Corefile",
-                                            "path": "Corefile"
-                                        }
-                                    ],
-                                    "name": "coredns"
-                                },
-                                "name": "config-volume"
-                            },
-                            {
-                                "configMap": {
-                                    "defaultMode": 420,
-                                    "name": "coredns-custom",
-                                    "optional": true
-                                },
-                                "name": "custom-config-volume"
-                            },
-                            {
-                                "emptyDir": {},
-                                "name": "tmp"
-                            }
-                        ]
-                    }
-                }
-            },
-            "status": {
-                "availableReplicas": 2,
-                "conditions": [
-                    {
-                        "lastTransitionTime": "2020-06-15T16:16:23.000-04:00",
-                        "lastUpdateTime": "2020-06-15T16:16:23.000-04:00",
-                        "message": "Deployment has minimum availability.",
-                        "reason": "MinimumReplicasAvailable",
-                        "status": "True",
-                        "type": "Available"
-                    },
-                    {
-                        "lastTransitionTime": "2020-06-15T16:14:37.000-04:00",
-                        "lastUpdateTime": "2020-06-15T16:16:27.000-04:00",
-                        "message": "ReplicaSet \"coredns-698df7b9b5\" has successfully progressed.",
-                        "reason": "NewReplicaSetAvailable",
-                        "status": "True",
-                        "type": "Progressing"
-                    }
-                ],
-                "observedGeneration": 2,
-                "readyReplicas": 2,
-                "replicas": 2,
-                "updatedReplicas": 2
-            }
-        },
-        ...
-    ],
-    "metadata": {
-        "recordCount": 6
+  "data": [
+    {
+      "id": "coredns/kube-system",
+      "deploymentStatus": "Progressing",
+      "readyRatio": "2/2",
+      "metadata": {},
+      "spec": {},
+      "status": {}
     }
+  ],
+  "metadata": {
+    "recordCount": 6
+  }
 }
 ```
 
@@ -278,19 +35,16 @@ curl -X GET \
 Retrieve a list of all deployments in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                  |
-|----------------------------|---------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to list the deployments. |
+| -------------------------- | ------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the deployments. |
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the deployment                                        |
-| `metadata` <br/>_object_                   | The metadata of the deployment                                  |
-| `metadata.name` <br/>_string_              | The name of the deployment                                      |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                |
-| `metadata.uid` <br/>_object_               | The UUID of the deployment                                      |
-| `images` <br/>_object_                     | The container images within a deployment                        |
-| `spec`<br/>_object_                        | The specification used to create and run the deployment         |
-| `status`<br/>_object_                      | The status information of the deployment                        |
+| Attributes                         | &nbsp;                                                  |
+| ---------------------------------- | ------------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the deployment                                |
+| `metadata` <br/>_object_           | The metadata of the deployment                          |
+| `images` <br/>_object_             | The container images within a deployment                |
+| `spec`<br/>_object_                | The specification used to create and run the deployment |
+| `status`<br/>_object_              | The status information of the deployment                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -308,258 +62,16 @@ curl -X GET \
 
 ```json
 {
-    "data": {
-        "id": "coredns/kube-system",
-        "deploymentStatus": "Progressing",
-        "readyRatio": "2/2",
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {
-            "annotations": {
-                "deployment.kubernetes.io/revision": "1",
-                "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"kubernetes.io/name\":\"CoreDNS\",\"version\":\"v20\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"},\"spec\":{\"paused\":false,\"selector\":{\"matchLabels\":{\"k8s-app\":\"kube-dns\",\"version\":\"v20\"}},\"strategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"},\"template\":{\"metadata\":{\"annotations\":{\"prometheus.io/port\":\"9153\"},\"labels\":{\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"version\":\"v20\"}},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"k8s-app\",\"operator\":\"In\",\"values\":[\"kube-dns\"]}]},\"topologyKey\":\"failure-domain.beta.kubernetes.io/zone\"},\"weight\":10},{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"k8s-app\",\"operator\":\"In\",\"values\":[\"kube-dns\"]}]},\"topologyKey\":\"kubernetes.io/hostname\"},\"weight\":5}]}},\"containers\":[{\"args\":[\"-conf\",\"/etc/coredns/Corefile\"],\"image\":\"mcr.microsoft.com/oss/kubernetes/coredns:1.6.6\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"failureThreshold\":5,\"httpGet\":{\"path\":\"/health\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":60,\"successThreshold\":1,\"timeoutSeconds\":5},\"name\":\"coredns\",\"ports\":[{\"containerPort\":53,\"name\":\"dns\",\"protocol\":\"UDP\"},{\"containerPort\":53,\"name\":\"dns-tcp\",\"protocol\":\"TCP\"},{\"containerPort\":9153,\"name\":\"metrics\",\"protocol\":\"TCP\"}],\"resources\":{\"limits\":{\"memory\":\"170Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"70Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"add\":[\"NET_BIND_SERVICE\"],\"drop\":[\"all\"]},\"procMount\":\"Default\",\"readOnlyRootFilesystem\":true},\"volumeMounts\":[{\"mountPath\":\"/etc/coredns\",\"name\":\"config-volume\",\"readOnly\":true},{\"mountPath\":\"/etc/coredns/custom\",\"name\":\"custom-config-volume\",\"readOnly\":true},{\"mountPath\":\"/tmp\",\"name\":\"tmp\"}]}],\"dnsPolicy\":\"Default\",\"nodeSelector\":{\"beta.kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"serviceAccountName\":\"coredns\",\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"},{\"key\":\"CriticalAddonsOnly\",\"operator\":\"Exists\"}],\"volumes\":[{\"configMap\":{\"items\":[{\"key\":\"Corefile\",\"path\":\"Corefile\"}],\"name\":\"coredns\"},\"name\":\"config-volume\"},{\"configMap\":{\"name\":\"coredns-custom\",\"optional\":true},\"name\":\"custom-config-volume\"},{\"emptyDir\":{},\"name\":\"tmp\"}]}}}}\n"
-            },
-            "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
-            "generation": 2,
-            "labels": {
-                "addonmanager.kubernetes.io/mode": "Reconcile",
-                "k8s-app": "kube-dns",
-                "kubernetes.io/cluster-service": "true",
-                "kubernetes.io/name": "CoreDNS",
-                "version": "v20"
-            },
-            "name": "coredns",
-            "namespace": "kube-system",
-            "resourceVersion": "653",
-            "selfLink": "/apis/apps/v1/namespaces/kube-system/deployments/coredns",
-            "uid": "4c15009d-1e32-4b73-9c82-559b81f1bd93"
-        },
-        "spec": {
-            "progressDeadlineSeconds": 600,
-            "replicas": 2,
-            "revisionHistoryLimit": 10,
-            "selector": {
-                "matchLabels": {
-                    "k8s-app": "kube-dns",
-                    "version": "v20"
-                }
-            },
-            "strategy": {
-                "rollingUpdate": {
-                    "maxSurge": "25%",
-                    "maxUnavailable": 1
-                },
-                "type": "RollingUpdate"
-            },
-            "template": {
-                "metadata": {
-                    "annotations": {
-                        "prometheus.io/port": "9153"
-                    },
-                    "labels": {
-                        "k8s-app": "kube-dns",
-                        "kubernetes.io/cluster-service": "true",
-                        "version": "v20"
-                    }
-                },
-                "spec": {
-                    "affinity": {
-                        "podAntiAffinity": {
-                            "preferredDuringSchedulingIgnoredDuringExecution": [
-                                {
-                                    "podAffinityTerm": {
-                                        "labelSelector": {
-                                            "matchExpressions": [
-                                                {
-                                                    "key": "k8s-app",
-                                                    "operator": "In",
-                                                    "values": [
-                                                        "kube-dns"
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "topologyKey": "failure-domain.beta.kubernetes.io/zone"
-                                    },
-                                    "weight": 10
-                                },
-                                {
-                                    "podAffinityTerm": {
-                                        "labelSelector": {
-                                            "matchExpressions": [
-                                                {
-                                                    "key": "k8s-app",
-                                                    "operator": "In",
-                                                    "values": [
-                                                        "kube-dns"
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "topologyKey": "kubernetes.io/hostname"
-                                    },
-                                    "weight": 5
-                                }
-                            ]
-                        }
-                    },
-                    "containers": [
-                        {
-                            "args": [
-                                "-conf",
-                                "/etc/coredns/Corefile"
-                            ],
-                            "image": "mcr.microsoft.com/oss/kubernetes/coredns:1.6.6",
-                            "imagePullPolicy": "IfNotPresent",
-                            "livenessProbe": {
-                                "failureThreshold": 5,
-                                "httpGet": {
-                                    "path": "/health",
-                                    "port": 8080,
-                                    "scheme": "HTTP"
-                                },
-                                "initialDelaySeconds": 60,
-                                "periodSeconds": 10,
-                                "successThreshold": 1,
-                                "timeoutSeconds": 5
-                            },
-                            "name": "coredns",
-                            "ports": [
-                                {
-                                    "containerPort": 53,
-                                    "name": "dns",
-                                    "protocol": "UDP"
-                                },
-                                {
-                                    "containerPort": 53,
-                                    "name": "dns-tcp",
-                                    "protocol": "TCP"
-                                },
-                                {
-                                    "containerPort": 9153,
-                                    "name": "metrics",
-                                    "protocol": "TCP"
-                                }
-                            ],
-                            "resources": {
-                                "limits": {
-                                    "memory": "170Mi"
-                                },
-                                "requests": {
-                                    "cpu": "100m",
-                                    "memory": "70Mi"
-                                }
-                            },
-                            "securityContext": {
-                                "allowPrivilegeEscalation": false,
-                                "capabilities": {
-                                    "add": [
-                                        "NET_BIND_SERVICE"
-                                    ],
-                                    "drop": [
-                                        "all"
-                                    ]
-                                },
-                                "procMount": "Default",
-                                "readOnlyRootFilesystem": true
-                            },
-                            "terminationMessagePath": "/dev/termination-log",
-                            "terminationMessagePolicy": "File",
-                            "volumeMounts": [
-                                {
-                                    "mountPath": "/etc/coredns",
-                                    "name": "config-volume",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/etc/coredns/custom",
-                                    "name": "custom-config-volume",
-                                    "readOnly": true
-                                },
-                                {
-                                    "mountPath": "/tmp",
-                                    "name": "tmp"
-                                }
-                            ]
-                        }
-                    ],
-                    "dnsPolicy": "Default",
-                    "nodeSelector": {
-                        "beta.kubernetes.io/os": "linux"
-                    },
-                    "priorityClassName": "system-node-critical",
-                    "restartPolicy": "Always",
-                    "schedulerName": "default-scheduler",
-                    "securityContext": {},
-                    "serviceAccount": "coredns",
-                    "serviceAccountName": "coredns",
-                    "terminationGracePeriodSeconds": 30,
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "node-role.kubernetes.io/master"
-                        },
-                        {
-                            "key": "CriticalAddonsOnly",
-                            "operator": "Exists"
-                        }
-                    ],
-                    "volumes": [
-                        {
-                            "configMap": {
-                                "defaultMode": 420,
-                                "items": [
-                                    {
-                                        "key": "Corefile",
-                                        "path": "Corefile"
-                                    }
-                                ],
-                                "name": "coredns"
-                            },
-                            "name": "config-volume"
-                        },
-                        {
-                            "configMap": {
-                                "defaultMode": 420,
-                                "name": "coredns-custom",
-                                "optional": true
-                            },
-                            "name": "custom-config-volume"
-                        },
-                        {
-                            "emptyDir": {},
-                            "name": "tmp"
-                        }
-                    ]
-                }
-            }
-        },
-        "status": {
-            "availableReplicas": 2,
-            "conditions": [
-                {
-                    "lastTransitionTime": "2020-06-15T16:16:23.000-04:00",
-                    "lastUpdateTime": "2020-06-15T16:16:23.000-04:00",
-                    "message": "Deployment has minimum availability.",
-                    "reason": "MinimumReplicasAvailable",
-                    "status": "True",
-                    "type": "Available"
-                },
-                {
-                    "lastTransitionTime": "2020-06-15T16:14:37.000-04:00",
-                    "lastUpdateTime": "2020-06-15T16:16:27.000-04:00",
-                    "message": "ReplicaSet \"coredns-698df7b9b5\" has successfully progressed.",
-                    "reason": "NewReplicaSetAvailable",
-                    "status": "True",
-                    "type": "Progressing"
-                }
-            ],
-            "observedGeneration": 2,
-            "readyReplicas": 2,
-            "replicas": 2,
-            "updatedReplicas": 2
-        }
-    }
+  "data": {
+    "id": "coredns/kube-system",
+    "deploymentStatus": "Progressing",
+    "readyRatio": "2/2",
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {},
+    "spec": {},
+    "status": {}
+  }
 }
 ```
 
@@ -568,18 +80,15 @@ curl -X GET \
 Retrieve a deployment and all its info in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                |
-|----------------------------|-------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to get the deployment. |
+| -------------------------- | ----------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the deployment. |
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the deployment                                        |
-| `metadata` <br/>_object_                   | The metadata of the deployment                                  |
-| `metadata.name` <br/>_string_              | The name of the deployment                                      |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                |
-| `metadata.uid` <br/>_object_               | The UUID of the deployment                                      |
-| `images` <br/>_object_                     | The container images within a deployment                        |
-| `spec`<br/>_object_                        | The specification used to create and run the deployment         |
-| `status`<br/>_object_                      | The status information of the deployment                        |
+| Attributes                         | &nbsp;                                                  |
+| ---------------------------------- | ------------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the deployment                                |
+| `metadata` <br/>_object_           | The metadata of the deployment                          |
+| `images` <br/>_object_             | The container images within a deployment                |
+| `spec`<br/>_object_                | The specification used to create and run the deployment |
+| `status`<br/>_object_              | The status information of the deployment                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -7,66 +7,279 @@
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/deployments"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/deployments?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
 
 ```json
 {
-  "data": [
-    {
-      "id": "apm-server-1585600296-apm-server/monitoring",
-      "deploymentStatus": "Available",
-      "readyRatio": "1/1",
-      "metadata": {
-        "annotations": {
-          "deployment.kubernetes.io/revision": "1"
+    "data": [
+        {
+            "id": "coredns/kube-system",
+            "deploymentStatus": "Progressing",
+            "readyRatio": "2/2",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1",
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"kubernetes.io/name\":\"CoreDNS\",\"version\":\"v20\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"},\"spec\":{\"paused\":false,\"selector\":{\"matchLabels\":{\"k8s-app\":\"kube-dns\",\"version\":\"v20\"}},\"strategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"},\"template\":{\"metadata\":{\"annotations\":{\"prometheus.io/port\":\"9153\"},\"labels\":{\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"version\":\"v20\"}},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"k8s-app\",\"operator\":\"In\",\"values\":[\"kube-dns\"]}]},\"topologyKey\":\"failure-domain.beta.kubernetes.io/zone\"},\"weight\":10},{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"k8s-app\",\"operator\":\"In\",\"values\":[\"kube-dns\"]}]},\"topologyKey\":\"kubernetes.io/hostname\"},\"weight\":5}]}},\"containers\":[{\"args\":[\"-conf\",\"/etc/coredns/Corefile\"],\"image\":\"mcr.microsoft.com/oss/kubernetes/coredns:1.6.6\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"failureThreshold\":5,\"httpGet\":{\"path\":\"/health\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":60,\"successThreshold\":1,\"timeoutSeconds\":5},\"name\":\"coredns\",\"ports\":[{\"containerPort\":53,\"name\":\"dns\",\"protocol\":\"UDP\"},{\"containerPort\":53,\"name\":\"dns-tcp\",\"protocol\":\"TCP\"},{\"containerPort\":9153,\"name\":\"metrics\",\"protocol\":\"TCP\"}],\"resources\":{\"limits\":{\"memory\":\"170Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"70Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"add\":[\"NET_BIND_SERVICE\"],\"drop\":[\"all\"]},\"procMount\":\"Default\",\"readOnlyRootFilesystem\":true},\"volumeMounts\":[{\"mountPath\":\"/etc/coredns\",\"name\":\"config-volume\",\"readOnly\":true},{\"mountPath\":\"/etc/coredns/custom\",\"name\":\"custom-config-volume\",\"readOnly\":true},{\"mountPath\":\"/tmp\",\"name\":\"tmp\"}]}],\"dnsPolicy\":\"Default\",\"nodeSelector\":{\"beta.kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"serviceAccountName\":\"coredns\",\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"},{\"key\":\"CriticalAddonsOnly\",\"operator\":\"Exists\"}],\"volumes\":[{\"configMap\":{\"items\":[{\"key\":\"Corefile\",\"path\":\"Corefile\"}],\"name\":\"coredns\"},\"name\":\"config-volume\"},{\"configMap\":{\"name\":\"coredns-custom\",\"optional\":true},\"name\":\"custom-config-volume\"},{\"emptyDir\":{},\"name\":\"tmp\"}]}}}}\n"
+                },
+                "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
+                "generation": 2,
+                "labels": {
+                    "addonmanager.kubernetes.io/mode": "Reconcile",
+                    "k8s-app": "kube-dns",
+                    "kubernetes.io/cluster-service": "true",
+                    "kubernetes.io/name": "CoreDNS",
+                    "version": "v20"
+                },
+                "name": "coredns",
+                "namespace": "kube-system",
+                "resourceVersion": "653",
+                "selfLink": "/apis/apps/v1/namespaces/kube-system/deployments/coredns",
+                "uid": "4c15009d-1e32-4b73-9c82-559b81f1bd93"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 2,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "k8s-app": "kube-dns",
+                        "version": "v20"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "prometheus.io/port": "9153"
+                        },
+                        "labels": {
+                            "k8s-app": "kube-dns",
+                            "kubernetes.io/cluster-service": "true",
+                            "version": "v20"
+                        }
+                    },
+                    "spec": {
+                        "affinity": {
+                            "podAntiAffinity": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": [
+                                    {
+                                        "podAffinityTerm": {
+                                            "labelSelector": {
+                                                "matchExpressions": [
+                                                    {
+                                                        "key": "k8s-app",
+                                                        "operator": "In",
+                                                        "values": [
+                                                            "kube-dns"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "topologyKey": "failure-domain.beta.kubernetes.io/zone"
+                                        },
+                                        "weight": 10
+                                    },
+                                    {
+                                        "podAffinityTerm": {
+                                            "labelSelector": {
+                                                "matchExpressions": [
+                                                    {
+                                                        "key": "k8s-app",
+                                                        "operator": "In",
+                                                        "values": [
+                                                            "kube-dns"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "topologyKey": "kubernetes.io/hostname"
+                                        },
+                                        "weight": 5
+                                    }
+                                ]
+                            }
+                        },
+                        "containers": [
+                            {
+                                "args": [
+                                    "-conf",
+                                    "/etc/coredns/Corefile"
+                                ],
+                                "image": "mcr.microsoft.com/oss/kubernetes/coredns:1.6.6",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "failureThreshold": 5,
+                                    "httpGet": {
+                                        "path": "/health",
+                                        "port": 8080,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 60,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 5
+                                },
+                                "name": "coredns",
+                                "ports": [
+                                    {
+                                        "containerPort": 53,
+                                        "name": "dns",
+                                        "protocol": "UDP"
+                                    },
+                                    {
+                                        "containerPort": 53,
+                                        "name": "dns-tcp",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9153,
+                                        "name": "metrics",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "memory": "170Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "70Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "allowPrivilegeEscalation": false,
+                                    "capabilities": {
+                                        "add": [
+                                            "NET_BIND_SERVICE"
+                                        ],
+                                        "drop": [
+                                            "all"
+                                        ]
+                                    },
+                                    "procMount": "Default",
+                                    "readOnlyRootFilesystem": true
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/etc/coredns",
+                                        "name": "config-volume",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/etc/coredns/custom",
+                                        "name": "custom-config-volume",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "mountPath": "/tmp",
+                                        "name": "tmp"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "Default",
+                        "nodeSelector": {
+                            "beta.kubernetes.io/os": "linux"
+                        },
+                        "priorityClassName": "system-node-critical",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "serviceAccount": "coredns",
+                        "serviceAccountName": "coredns",
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master"
+                            },
+                            {
+                                "key": "CriticalAddonsOnly",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "configMap": {
+                                    "defaultMode": 420,
+                                    "items": [
+                                        {
+                                            "key": "Corefile",
+                                            "path": "Corefile"
+                                        }
+                                    ],
+                                    "name": "coredns"
+                                },
+                                "name": "config-volume"
+                            },
+                            {
+                                "configMap": {
+                                    "defaultMode": 420,
+                                    "name": "coredns-custom",
+                                    "optional": true
+                                },
+                                "name": "custom-config-volume"
+                            },
+                            {
+                                "emptyDir": {},
+                                "name": "tmp"
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 2,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2020-06-15T16:16:23.000-04:00",
+                        "lastUpdateTime": "2020-06-15T16:16:23.000-04:00",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2020-06-15T16:14:37.000-04:00",
+                        "lastUpdateTime": "2020-06-15T16:16:27.000-04:00",
+                        "message": "ReplicaSet \"coredns-698df7b9b5\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 2,
+                "readyReplicas": 2,
+                "replicas": 2,
+                "updatedReplicas": 2
+            }
         },
-        "creationTimestamp": "2020-03-30T16:31:43.000-04:00",
-        "generation": 1,
-        "labels": {
-          "app": "apm-server",
-          "release": "apm-server-1585600296"
-        },
-        "name": "apm-server-1585600296-apm-server",
-        "namespace": "monitoring",
-        "resourceVersion": "117204237",
-        "selfLink": "/apis/apps/v1/namespaces/monitoring/deployments/apm-server-1585600296-apm-server",
-        "uid": "783030e4-72c5-11ea-a953-02007a9a001f"
-      },
-      "spec": {
-        /*...*/
-      },
-      "status": {
-        "availableReplicas": 1,
-        "conditions": [
-          {
-            "lastTransitionTime": "2020-04-24T15:06:15.000-04:00",
-            "lastUpdateTime": "2020-04-24T15:08:43.000-04:00",
-            "message": "ReplicaSet \"cert-manager-webhook-6ff9487489\" has successfully progressed.",
-            "reason": "NewReplicaSetAvailable",
-            "status": "True",
-            "type": "Progressing"
-          }
-        ],
-        "observedGeneration": 1,
-        "readyReplicas": 1,
-        "replicas": 1,
-        "updatedReplicas": 1
-      }
+        ...
+    ],
+    "metadata": {
+        "recordCount": 6
     }
-  ],
-  // ...
-  "metadata": {
-    "recordCount": 9
-  }
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments?cluster_id=:cluster_id</code>
 
 Retrieve a list of all deployments in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                                  |
+|----------------------------|---------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to list the deployments. |
 
 | Attributes                                 | &nbsp;                                                          |
 | ------------------------------------------ | --------------------------------------------------------------- |
@@ -88,7 +301,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/deployments/test-aerospike/auth"
+   "https://cloudmc_endpoint/v1/services/k8s/an_environment/deployments/coredns/kube-system?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -96,52 +309,267 @@ curl -X GET \
 ```json
 {
     "data": {
-      "id": "apm-server-1585600296-apm-server/monitoring",
-      "deploymentStatus": "Available",
-      "readyRatio": "1/1",
-      "metadata": {
-        "annotations": {
-          "deployment.kubernetes.io/revision": "1"
+        "id": "coredns/kube-system",
+        "deploymentStatus": "Progressing",
+        "readyRatio": "2/2",
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "annotations": {
+                "deployment.kubernetes.io/revision": "1",
+                "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"addonmanager.kubernetes.io/mode\":\"Reconcile\",\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"kubernetes.io/name\":\"CoreDNS\",\"version\":\"v20\"},\"name\":\"coredns\",\"namespace\":\"kube-system\"},\"spec\":{\"paused\":false,\"selector\":{\"matchLabels\":{\"k8s-app\":\"kube-dns\",\"version\":\"v20\"}},\"strategy\":{\"rollingUpdate\":{\"maxUnavailable\":1},\"type\":\"RollingUpdate\"},\"template\":{\"metadata\":{\"annotations\":{\"prometheus.io/port\":\"9153\"},\"labels\":{\"k8s-app\":\"kube-dns\",\"kubernetes.io/cluster-service\":\"true\",\"version\":\"v20\"}},\"spec\":{\"affinity\":{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"k8s-app\",\"operator\":\"In\",\"values\":[\"kube-dns\"]}]},\"topologyKey\":\"failure-domain.beta.kubernetes.io/zone\"},\"weight\":10},{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"k8s-app\",\"operator\":\"In\",\"values\":[\"kube-dns\"]}]},\"topologyKey\":\"kubernetes.io/hostname\"},\"weight\":5}]}},\"containers\":[{\"args\":[\"-conf\",\"/etc/coredns/Corefile\"],\"image\":\"mcr.microsoft.com/oss/kubernetes/coredns:1.6.6\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"failureThreshold\":5,\"httpGet\":{\"path\":\"/health\",\"port\":8080,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":60,\"successThreshold\":1,\"timeoutSeconds\":5},\"name\":\"coredns\",\"ports\":[{\"containerPort\":53,\"name\":\"dns\",\"protocol\":\"UDP\"},{\"containerPort\":53,\"name\":\"dns-tcp\",\"protocol\":\"TCP\"},{\"containerPort\":9153,\"name\":\"metrics\",\"protocol\":\"TCP\"}],\"resources\":{\"limits\":{\"memory\":\"170Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"70Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"add\":[\"NET_BIND_SERVICE\"],\"drop\":[\"all\"]},\"procMount\":\"Default\",\"readOnlyRootFilesystem\":true},\"volumeMounts\":[{\"mountPath\":\"/etc/coredns\",\"name\":\"config-volume\",\"readOnly\":true},{\"mountPath\":\"/etc/coredns/custom\",\"name\":\"custom-config-volume\",\"readOnly\":true},{\"mountPath\":\"/tmp\",\"name\":\"tmp\"}]}],\"dnsPolicy\":\"Default\",\"nodeSelector\":{\"beta.kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"serviceAccountName\":\"coredns\",\"tolerations\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"},{\"key\":\"CriticalAddonsOnly\",\"operator\":\"Exists\"}],\"volumes\":[{\"configMap\":{\"items\":[{\"key\":\"Corefile\",\"path\":\"Corefile\"}],\"name\":\"coredns\"},\"name\":\"config-volume\"},{\"configMap\":{\"name\":\"coredns-custom\",\"optional\":true},\"name\":\"custom-config-volume\"},{\"emptyDir\":{},\"name\":\"tmp\"}]}}}}\n"
+            },
+            "creationTimestamp": "2020-06-15T16:14:37.000-04:00",
+            "generation": 2,
+            "labels": {
+                "addonmanager.kubernetes.io/mode": "Reconcile",
+                "k8s-app": "kube-dns",
+                "kubernetes.io/cluster-service": "true",
+                "kubernetes.io/name": "CoreDNS",
+                "version": "v20"
+            },
+            "name": "coredns",
+            "namespace": "kube-system",
+            "resourceVersion": "653",
+            "selfLink": "/apis/apps/v1/namespaces/kube-system/deployments/coredns",
+            "uid": "4c15009d-1e32-4b73-9c82-559b81f1bd93"
         },
-        "creationTimestamp": "2020-03-30T16:31:43.000-04:00",
-        "generation": 1,
-        "labels": {
-          "app": "apm-server",
-          "release": "apm-server-1585600296"
+        "spec": {
+            "progressDeadlineSeconds": 600,
+            "replicas": 2,
+            "revisionHistoryLimit": 10,
+            "selector": {
+                "matchLabels": {
+                    "k8s-app": "kube-dns",
+                    "version": "v20"
+                }
+            },
+            "strategy": {
+                "rollingUpdate": {
+                    "maxSurge": "25%",
+                    "maxUnavailable": 1
+                },
+                "type": "RollingUpdate"
+            },
+            "template": {
+                "metadata": {
+                    "annotations": {
+                        "prometheus.io/port": "9153"
+                    },
+                    "labels": {
+                        "k8s-app": "kube-dns",
+                        "kubernetes.io/cluster-service": "true",
+                        "version": "v20"
+                    }
+                },
+                "spec": {
+                    "affinity": {
+                        "podAntiAffinity": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": [
+                                {
+                                    "podAffinityTerm": {
+                                        "labelSelector": {
+                                            "matchExpressions": [
+                                                {
+                                                    "key": "k8s-app",
+                                                    "operator": "In",
+                                                    "values": [
+                                                        "kube-dns"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "topologyKey": "failure-domain.beta.kubernetes.io/zone"
+                                    },
+                                    "weight": 10
+                                },
+                                {
+                                    "podAffinityTerm": {
+                                        "labelSelector": {
+                                            "matchExpressions": [
+                                                {
+                                                    "key": "k8s-app",
+                                                    "operator": "In",
+                                                    "values": [
+                                                        "kube-dns"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "topologyKey": "kubernetes.io/hostname"
+                                    },
+                                    "weight": 5
+                                }
+                            ]
+                        }
+                    },
+                    "containers": [
+                        {
+                            "args": [
+                                "-conf",
+                                "/etc/coredns/Corefile"
+                            ],
+                            "image": "mcr.microsoft.com/oss/kubernetes/coredns:1.6.6",
+                            "imagePullPolicy": "IfNotPresent",
+                            "livenessProbe": {
+                                "failureThreshold": 5,
+                                "httpGet": {
+                                    "path": "/health",
+                                    "port": 8080,
+                                    "scheme": "HTTP"
+                                },
+                                "initialDelaySeconds": 60,
+                                "periodSeconds": 10,
+                                "successThreshold": 1,
+                                "timeoutSeconds": 5
+                            },
+                            "name": "coredns",
+                            "ports": [
+                                {
+                                    "containerPort": 53,
+                                    "name": "dns",
+                                    "protocol": "UDP"
+                                },
+                                {
+                                    "containerPort": 53,
+                                    "name": "dns-tcp",
+                                    "protocol": "TCP"
+                                },
+                                {
+                                    "containerPort": 9153,
+                                    "name": "metrics",
+                                    "protocol": "TCP"
+                                }
+                            ],
+                            "resources": {
+                                "limits": {
+                                    "memory": "170Mi"
+                                },
+                                "requests": {
+                                    "cpu": "100m",
+                                    "memory": "70Mi"
+                                }
+                            },
+                            "securityContext": {
+                                "allowPrivilegeEscalation": false,
+                                "capabilities": {
+                                    "add": [
+                                        "NET_BIND_SERVICE"
+                                    ],
+                                    "drop": [
+                                        "all"
+                                    ]
+                                },
+                                "procMount": "Default",
+                                "readOnlyRootFilesystem": true
+                            },
+                            "terminationMessagePath": "/dev/termination-log",
+                            "terminationMessagePolicy": "File",
+                            "volumeMounts": [
+                                {
+                                    "mountPath": "/etc/coredns",
+                                    "name": "config-volume",
+                                    "readOnly": true
+                                },
+                                {
+                                    "mountPath": "/etc/coredns/custom",
+                                    "name": "custom-config-volume",
+                                    "readOnly": true
+                                },
+                                {
+                                    "mountPath": "/tmp",
+                                    "name": "tmp"
+                                }
+                            ]
+                        }
+                    ],
+                    "dnsPolicy": "Default",
+                    "nodeSelector": {
+                        "beta.kubernetes.io/os": "linux"
+                    },
+                    "priorityClassName": "system-node-critical",
+                    "restartPolicy": "Always",
+                    "schedulerName": "default-scheduler",
+                    "securityContext": {},
+                    "serviceAccount": "coredns",
+                    "serviceAccountName": "coredns",
+                    "terminationGracePeriodSeconds": 30,
+                    "tolerations": [
+                        {
+                            "effect": "NoSchedule",
+                            "key": "node-role.kubernetes.io/master"
+                        },
+                        {
+                            "key": "CriticalAddonsOnly",
+                            "operator": "Exists"
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "configMap": {
+                                "defaultMode": 420,
+                                "items": [
+                                    {
+                                        "key": "Corefile",
+                                        "path": "Corefile"
+                                    }
+                                ],
+                                "name": "coredns"
+                            },
+                            "name": "config-volume"
+                        },
+                        {
+                            "configMap": {
+                                "defaultMode": 420,
+                                "name": "coredns-custom",
+                                "optional": true
+                            },
+                            "name": "custom-config-volume"
+                        },
+                        {
+                            "emptyDir": {},
+                            "name": "tmp"
+                        }
+                    ]
+                }
+            }
         },
-        "name": "apm-server-1585600296-apm-server",
-        "namespace": "monitoring",
-        "resourceVersion": "117204237",
-        "selfLink": "/apis/apps/v1/namespaces/monitoring/deployments/apm-server-1585600296-apm-server",
-        "uid": "783030e4-72c5-11ea-a953-02007a9a001f"
-      },
-      "spec": {
-        /*...*/
-      },
-      "status": {
-        "availableReplicas": 1,
-        "conditions": [
-          {
-            "lastTransitionTime": "2020-04-24T15:06:15.000-04:00",
-            "lastUpdateTime": "2020-04-24T15:08:43.000-04:00",
-            "message": "ReplicaSet \"cert-manager-webhook-6ff9487489\" has successfully progressed.",
-            "reason": "NewReplicaSetAvailable",
-            "status": "True",
-            "type": "Progressing"
-          }
-        ],
-        "observedGeneration": 1,
-        "readyReplicas": 1,
-        "replicas": 1,
-        "updatedReplicas": 1
-      }
+        "status": {
+            "availableReplicas": 2,
+            "conditions": [
+                {
+                    "lastTransitionTime": "2020-06-15T16:16:23.000-04:00",
+                    "lastUpdateTime": "2020-06-15T16:16:23.000-04:00",
+                    "message": "Deployment has minimum availability.",
+                    "reason": "MinimumReplicasAvailable",
+                    "status": "True",
+                    "type": "Available"
+                },
+                {
+                    "lastTransitionTime": "2020-06-15T16:14:37.000-04:00",
+                    "lastUpdateTime": "2020-06-15T16:16:27.000-04:00",
+                    "message": "ReplicaSet \"coredns-698df7b9b5\" has successfully progressed.",
+                    "reason": "NewReplicaSetAvailable",
+                    "status": "True",
+                    "type": "Progressing"
+                }
+            ],
+            "observedGeneration": 2,
+            "readyReplicas": 2,
+            "replicas": 2,
+            "updatedReplicas": 2
+        }
     }
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id?cluster_id=:cluster_id</code>
 
 Retrieve a deployment and all its info in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                                |
+|----------------------------|-------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to get the deployment. |
 
 | Attributes                                 | &nbsp;                                                          |
 | ------------------------------------------ | --------------------------------------------------------------- |

--- a/source/includes/kubernetes_extension/_k8_namespaces.md
+++ b/source/includes/kubernetes_extension/_k8_namespaces.md
@@ -1,6 +1,5 @@
 ### Namespaces
 
-
 <!-------------------- LIST NAMESPACES -------------------->
 
 #### List namespaces
@@ -8,99 +7,64 @@
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/namespaces"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/namespaces?cluster_id=a_cluster_id"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
 {
-  "data": [
-    {
-      "id": "auth",
-      "metadata": {
-        "creationTimestamp": "2019-06-06T16:55:32.000-04:00",
-        "name": "auth",
-        "resourceVersion": "17516456",
-        "selfLink": "/api/v1/namespaces/auth",
-        "uid": "6cd793ae-889d-11e9-95db-02007a9a453g"
-      },
-      "spec": {
-        "finalizers": [
-          "kubernetes"
-        ]
-      },
-      "status": {
-        "phase": "Active"
-      }
-    },
-    {
-      "id": "cert-manager",
-      "metadata": {
-        "annotations": {
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"cert-manager\"}}\n"
+    "data": [
+        {
+            "id": "default",
+            "metadata": {
+                "creationTimestamp": "2020-06-15T16:14:16.000-04:00",
+                "name": "default",
+                "resourceVersion": "42",
+                "selfLink": "/api/v1/namespaces/default",
+                "uid": "74fa5ce7-4537-45d8-a683-e73f8772f785"
+            },
+            "spec": {
+                "finalizers": [
+                    "kubernetes"
+                ]
+            },
+            "status": {
+                "phase": "Active"
+            }
         },
-        "creationTimestamp": "2020-04-24T15:06:10.000-04:00",
-        "name": "cert-manager",
-        "resourceVersion": "110011696",
-        "selfLink": "/api/v1/namespaces/cert-manager",
-        "uid": "ab4376c2-bb6d-44ae-a576-hdyr45839djs"
-      },
-      "spec": {
-        "finalizers": [
-          "kubernetes"
-        ]
-      },
-      "status": {
-        "phase": "Active"
-      }
-    },
-    {
-      "id": "lab",
-      "metadata": {
-        "creationTimestamp": "2019-07-10T16:51:13.000-04:00",
-        "name": "lab",
-        "resourceVersion": "25347372",
-        "selfLink": "/api/v1/namespaces/lab",
-        "uid": "74716eb1-a354-11e9-8c9b-1029384wedad"
-      },
-      "spec": {
-        "finalizers": [
-          "kubernetes"
-        ]
-      },
-      "status": {
-        "phase": "Active"
-      }
+        ...
+    ],
+    "metadata": {
+        "recordCount": 4
     }
-  ],
-  "metadata": {
-    "recordCount": 3
-  }
 }
 ```
 
-
-
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/namespaces</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/namespaces?cluster_id=:cluster_id</code>
 
 Retrieve a list of all namespaces in a given [environment](#administration-environments).
 
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id of the namespace.  
-`metadata` <br/>*object* | The metadata of the namespace
-`metadata.annotations` <br/>*map* | The annotations of the namespace
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string
-`metadata.name` <br/>*string* | The name of the namespace
-`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of the namespace object
-`metadata.selfLink` <br/>*string* | A URL representing the namespace object
-`metadata.uid` <br/>*object* | The UUID of the namespace
-`spec`<br/>*object* | The specification describes the attributes on a namespace.
-`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove the object from storage
-`status`<br/>*object* | The status information of the namespace
-`status.phase`<br/>*string* | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`
+| Required                   | &nbsp;                                                 |
+|----------------------------|--------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to list the namespaces. |
 
-
+| Attributes                                 | &nbsp;                                                                                    |
+|--------------------------------------------|-------------------------------------------------------------------------------------------|
+| `id` <br/>*string*                         | The id of the namespace.                                                                  |
+| `apiVersion` <br/>*string*                 | APIVersion defines the versioned schema of this representation of a namespace object      |
+| `kind` <br/>*string*                       | A string value representing the REST resource this object represents                      |
+| `metadata` <br/>*object*                   | The metadata of the namespace                                                             |
+| `metadata.annotations` <br/>*map*          | The annotations of the namespace                                                          |
+| `metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string                                         |
+| `metadata.name` <br/>*string*              | The name of the namespace                                                                 |
+| `metadata.resourceVersion` <br/>*string*   | An opaque value that represents the internal version of the namespace object              |
+| `metadata.selfLink` <br/>*string*          | A URL representing the namespace object                                                   |
+| `metadata.uid` <br/>*object*               | The UUID of the namespace                                                                 |
+| `spec`<br/>*object*                        | The specification describes the attributes on a namespace.                                |
+| `spec.finalizers`<br/>*string*             | An opaque list of values that must be empty to permanently remove the object from storage |
+| `status`<br/>*object*                      | The status information of the namespace                                                   |
+| `status.phase`<br/>*string*                | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`  |
 
 <!-------------------- GET A NAMESPACE -------------------->
 
@@ -109,57 +73,57 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/namespaces/cert-manager"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/namespaces/cert-manager?cluster_id=a_cluster_id"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
 {
-  "data": {
-    "id": "cert-manager",
-    "apiVersion": "v1",
-    "kind": "Namespace",
-    "metadata": {
-      "annotations": {
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"cert-manager\"}}\n"
-      },
-      "creationTimestamp": "2020-04-24T15:06:10.000-04:00",
-      "name": "cert-manager",
-      "resourceVersion": "110011696",
-      "selfLink": "/api/v1/namespaces/cert-manager",
-      "uid": "ab4376c2-bb6d-44ae-a576-f9b24f2ea624"
-    },
-    "spec": {
-      "finalizers": [
-        "kubernetes"
-      ]
-    },
-    "status": {
-      "phase": "Active"
+    "data": {
+        "id": "default",
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+            "creationTimestamp": "2020-06-15T16:14:16.000-04:00",
+            "name": "default",
+            "resourceVersion": "42",
+            "selfLink": "/api/v1/namespaces/default",
+            "uid": "74fa5ce7-4537-45d8-a683-e73f8772f785"
+        },
+        "spec": {
+            "finalizers": [
+                "kubernetes"
+            ]
+        },
+        "status": {
+            "phase": "Active"
+        }
     }
-  }
 }
 ```
 
-
-
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/namespaces/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/namespaces/:id?cluster_id=:cluster_id</code>
 
 Retrieve a namespace and all its info in a given [environment](#administration-environments).
 
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id of the namespace.
-`apiVersion` <br/>*string* | APIVersion defines the versioned schema of this representation of a namespace object
-`kind` <br/>*string* | A string value representing the REST resource this object represents
-`metadata` <br/>*object* | The metadata of the namespace
-`metadata.annotations` <br/>*map* | The annotations of the namespace
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string
-`metadata.name` <br/>*string* | The name of the namespace
-`metadata.resourceVersion` <br/>*string* | An opaque value that represents the internal version of the namespace object
-`metadata.selfLink` <br/>*string* | A URL representing the namespace object
-`metadata.uid` <br/>*object* | The UUID of the namespace
-`spec`<br/>*object* | The specification describes the attributes on a namespace.
-`spec.finalizers`<br/>*string* | An opaque list of values that must be empty to permanently remove the object from storage
-`status`<br/>*object* | The status information of the namespace
-`status.phase`<br/>*string* | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`
+| Required                   | &nbsp;                                               |
+|----------------------------|------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to get the namespace. |
+
+| Attributes                                 | &nbsp;                                                                                    |
+|--------------------------------------------|-------------------------------------------------------------------------------------------|
+| `id` <br/>*string*                         | The id of the namespace.                                                                  |
+| `apiVersion` <br/>*string*                 | APIVersion defines the versioned schema of this representation of a namespace object      |
+| `kind` <br/>*string*                       | A string value representing the REST resource this object represents                      |
+| `metadata` <br/>*object*                   | The metadata of the namespace                                                             |
+| `metadata.annotations` <br/>*map*          | The annotations of the namespace                                                          |
+| `metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string                                         |
+| `metadata.name` <br/>*string*              | The name of the namespace                                                                 |
+| `metadata.resourceVersion` <br/>*string*   | An opaque value that represents the internal version of the namespace object              |
+| `metadata.selfLink` <br/>*string*          | A URL representing the namespace object                                                   |
+| `metadata.uid` <br/>*object*               | The UUID of the namespace                                                                 |
+| `spec`<br/>*object*                        | The specification describes the attributes on a namespace.                                |
+| `spec.finalizers`<br/>*string*             | An opaque list of values that must be empty to permanently remove the object from storage |
+| `status`<br/>*object*                      | The status information of the namespace                                                   |
+| `status.phase`<br/>*string*                | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`  |

--- a/source/includes/kubernetes_extension/_k8_namespaces.md
+++ b/source/includes/kubernetes_extension/_k8_namespaces.md
@@ -14,30 +14,17 @@ curl -X GET \
 
 ```json
 {
-    "data": [
-        {
-            "id": "default",
-            "metadata": {
-                "creationTimestamp": "2020-06-15T16:14:16.000-04:00",
-                "name": "default",
-                "resourceVersion": "42",
-                "selfLink": "/api/v1/namespaces/default",
-                "uid": "74fa5ce7-4537-45d8-a683-e73f8772f785"
-            },
-            "spec": {
-                "finalizers": [
-                    "kubernetes"
-                ]
-            },
-            "status": {
-                "phase": "Active"
-            }
-        },
-        ...
-    ],
-    "metadata": {
-        "recordCount": 4
+  "data": [
+    {
+      "id": "default",
+      "metadata": {},
+      "spec": {},
+      "status": {}
     }
+  ],
+  "metadata": {
+    "recordCount": 4
+  }
 }
 ```
 
@@ -46,25 +33,17 @@ curl -X GET \
 Retrieve a list of all namespaces in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                 |
-|----------------------------|--------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to list the namespaces. |
+| -------------------------- | ------------------------------------------------------ |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the namespaces. |
 
 | Attributes                                 | &nbsp;                                                                                    |
-|--------------------------------------------|-------------------------------------------------------------------------------------------|
-| `id` <br/>*string*                         | The id of the namespace.                                                                  |
-| `apiVersion` <br/>*string*                 | APIVersion defines the versioned schema of this representation of a namespace object      |
-| `kind` <br/>*string*                       | A string value representing the REST resource this object represents                      |
-| `metadata` <br/>*object*                   | The metadata of the namespace                                                             |
-| `metadata.annotations` <br/>*map*          | The annotations of the namespace                                                          |
-| `metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string                                         |
-| `metadata.name` <br/>*string*              | The name of the namespace                                                                 |
-| `metadata.resourceVersion` <br/>*string*   | An opaque value that represents the internal version of the namespace object              |
-| `metadata.selfLink` <br/>*string*          | A URL representing the namespace object                                                   |
-| `metadata.uid` <br/>*object*               | The UUID of the namespace                                                                 |
-| `spec`<br/>*object*                        | The specification describes the attributes on a namespace.                                |
-| `spec.finalizers`<br/>*string*             | An opaque list of values that must be empty to permanently remove the object from storage |
-| `status`<br/>*object*                      | The status information of the namespace                                                   |
-| `status.phase`<br/>*string*                | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`  |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the namespace.                                                                  |
+| `apiVersion` <br/>_string_                 | APIVersion defines the versioned schema of this representation of a namespace object      |
+| `kind` <br/>_string_                       | A string value representing the REST resource this object represents                      |
+| `metadata` <br/>_object_                   | The metadata of the namespace                                                             |
+| `spec`<br/>_object_                        | The specification describes the attributes on a namespace.                                |
+| `status`<br/>_object_                      | The status information of the namespace                                                   |
 
 <!-------------------- GET A NAMESPACE -------------------->
 
@@ -80,26 +59,14 @@ curl -X GET \
 
 ```json
 {
-    "data": {
-        "id": "default",
-        "apiVersion": "v1",
-        "kind": "Namespace",
-        "metadata": {
-            "creationTimestamp": "2020-06-15T16:14:16.000-04:00",
-            "name": "default",
-            "resourceVersion": "42",
-            "selfLink": "/api/v1/namespaces/default",
-            "uid": "74fa5ce7-4537-45d8-a683-e73f8772f785"
-        },
-        "spec": {
-            "finalizers": [
-                "kubernetes"
-            ]
-        },
-        "status": {
-            "phase": "Active"
-        }
-    }
+  "data": {
+    "id": "default",
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {},
+    "spec": {},
+    "status": {}
+  }
 }
 ```
 
@@ -108,22 +75,14 @@ curl -X GET \
 Retrieve a namespace and all its info in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                               |
-|----------------------------|------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to get the namespace. |
+| -------------------------- | ---------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the namespace. |
 
 | Attributes                                 | &nbsp;                                                                                    |
-|--------------------------------------------|-------------------------------------------------------------------------------------------|
-| `id` <br/>*string*                         | The id of the namespace.                                                                  |
-| `apiVersion` <br/>*string*                 | APIVersion defines the versioned schema of this representation of a namespace object      |
-| `kind` <br/>*string*                       | A string value representing the REST resource this object represents                      |
-| `metadata` <br/>*object*                   | The metadata of the namespace                                                             |
-| `metadata.annotations` <br/>*map*          | The annotations of the namespace                                                          |
-| `metadata.creationTimestamp` <br/>*string* | The date of creation of the namespace as a string                                         |
-| `metadata.name` <br/>*string*              | The name of the namespace                                                                 |
-| `metadata.resourceVersion` <br/>*string*   | An opaque value that represents the internal version of the namespace object              |
-| `metadata.selfLink` <br/>*string*          | A URL representing the namespace object                                                   |
-| `metadata.uid` <br/>*object*               | The UUID of the namespace                                                                 |
-| `spec`<br/>*object*                        | The specification describes the attributes on a namespace.                                |
-| `spec.finalizers`<br/>*string*             | An opaque list of values that must be empty to permanently remove the object from storage |
-| `status`<br/>*object*                      | The status information of the namespace                                                   |
-| `status.phase`<br/>*string*                | The status of the namespace. Possible statuses are `Active`, `Terminating` and `Unknown`  |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the namespace.                                                                  |
+| `apiVersion` <br/>_string_                 | APIVersion defines the versioned schema of this representation of a namespace object      |
+| `kind` <br/>_string_                       | A string value representing the REST resource this object represents                      |
+| `metadata` <br/>_object_                   | The metadata of the namespace                                                             |
+| `spec`<br/>_object_                        | The specification describes the attributes on a namespace.                                |
+| `status`<br/>_object_                      | The status information of the namespace                                                   |

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -7,7 +7,7 @@
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/statefulsets"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -48,17 +48,22 @@ curl -X GET \
         "updateRevision": "test-aerospike-6db7776c7d",
         "updatedReplicas": 1
       }
-    }
+    },
+    ...
   ],
   "metadata": {
-    "recordCount": 1
+    "recordCount": 4
   }
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets?cluster_id=:cluster_id</code>
 
 Retrieve a list of all stateful sets in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                                    |
+|----------------------------|-----------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to list the stateful sets. |
 
 | Attributes                                 | &nbsp;                                                          |
 | ------------------------------------------ | --------------------------------------------------------------- |
@@ -81,7 +86,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/k8s/an_environment/statefulsets/test-aerospike/auth"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets/test-aerospike/auth?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -128,16 +133,20 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id?cluster_id=:cluster_id</code>
 
 Retrieve a stateful set and all its info in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                                  |
+|----------------------------|---------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to get the stateful set. |
 
 | Attributes                                 | &nbsp;                                                          |
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `id` <br/>*string*                         | The id of the stateful set                                      |
 | `metadata` <br/>*object*                   | The metadata of the stateful set                                |
 | `metadata.creationTimestamp` <br/>*string* | The date of creation of the stateful set as a string            |
-| `metadata.labels` <br/>*map*               | The labels associated to the stateful                           |
+| `metadata.labels` <br/>*map*               | The labels associated to the stateful set                       |
 | `metadata.name` <br/>*string*              | The name of the stateful set                                    |
 | `metadata.namespace` <br/>*string*         | The namespace in which the stateful set is created              |
 | `metadata.uid` <br/>*object*               | The UUID of the stateful set                                    |

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -17,39 +17,11 @@ curl -X GET \
   "data": [
     {
       "id": "test-aerospike/auth",
-      "images": [
-        "aerospike/aerospike-server:4.5.0.5"
-      ],
-      "metadata": {
-        "creationTimestamp": "2020-04-27T09:13:49.000-04:00",
-        "generation": 1,
-        "labels": {
-          "app": "aerospike",
-          "chart": "aerospike-0.3.2",
-          "heritage": "Helm",
-          "release": "test"
-        },
-        "name": "test-aerospike",
-        "namespace": "auth",
-        "resourceVersion": "117166675",
-        "selfLink": "/apis/apps/v1/namespaces/auth/statefulsets/test-aerospike",
-        "uid": "0aeff29e-e33d-48da-b933-651a9070d58c"
-      },
-      "spec": {
-        // ...
-      },
-      "status": {
-        "collisionCount": 0,
-        "currentReplicas": 1,
-        "currentRevision": "test-aerospike-6db7776c7d",
-        "observedGeneration": 1,
-        "readyReplicas": 1,
-        "replicas": 1,
-        "updateRevision": "test-aerospike-6db7776c7d",
-        "updatedReplicas": 1
-      }
-    },
-    ...
+      "images": ["aerospike/aerospike-server:4.5.0.5"],
+      "metadata": {},
+      "spec": {},
+      "status": {}
+    }
   ],
   "metadata": {
     "recordCount": 4
@@ -62,20 +34,15 @@ curl -X GET \
 Retrieve a list of all stateful sets in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                    |
-|----------------------------|-----------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to list the stateful sets. |
+| -------------------------- | --------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the stateful sets. |
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>*string*                         | The id of the stateful set                                      |
-| `metadata` <br/>*object*                   | The metadata of the stateful set                                |
-| `metadata.creationTimestamp` <br/>*string* | The date of creation of the stateful set as a string            |
-| `metadata.labels` <br/>*map*               | The labels associated to the stateful set                       |
-| `metadata.name` <br/>*string*              | The name of the stateful set                                    |
-| `metadata.namespace` <br/>*string*         | The namespace in which the stateful set is created              |
-| `metadata.uid` <br/>*object*               | The UUID of the stateful set                                    |
-| `spec`<br/>*object*                        | The specification used to create and run the stateful set       |
-| `status`<br/>*object*                      | The status information of the stateful set                      |
+| Attributes                                 | &nbsp;                                                    |
+| ------------------------------------------ | --------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the stateful set                                |
+| `metadata` <br/>_object_                   | The metadata of the stateful set                          |
+| `spec`<br/>_object_                        | The specification used to create and run the stateful set |
+| `status`<br/>_object_                      | The status information of the stateful set                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -96,39 +63,12 @@ curl -X GET \
   "data": {
     "id": "test-aerospike/auth",
     "replicaRatio": "1 / 1",
-    "images": [
-      "aerospike/aerospike-server:4.5.0.5"
-    ],
+    "images": ["aerospike/aerospike-server:4.5.0.5"],
     "apiVersion": "apps/v1",
     "kind": "StatefulSet",
-    "metadata": {
-      "creationTimestamp": "2020-04-27T09:13:49.000-04:00",
-      "generation": 1,
-      "labels": {
-        "app": "aerospike",
-        "chart": "aerospike-0.3.2",
-        "heritage": "Helm",
-        "release": "test"
-      },
-      "name": "test-aerospike",
-      "namespace": "auth",
-      "resourceVersion": "117166675",
-      "selfLink": "/apis/apps/v1/namespaces/auth/statefulsets/test-aerospike",
-      "uid": "0aeff29e-e33d-48da-b933-651a9070d58c"
-    },
-    "spec": {
-      // ...
-    },
-    "status": {
-      "collisionCount": 0,
-      "currentReplicas": 1,
-      "currentRevision": "test-aerospike-6db7776c7d",
-      "observedGeneration": 1,
-      "readyReplicas": 1,
-      "replicas": 1,
-      "updateRevision": "test-aerospike-6db7776c7d",
-      "updatedReplicas": 1
-    }
+    "metadata": {},
+    "spec": {},
+    "status": {}
   }
 }
 ```
@@ -138,19 +78,14 @@ curl -X GET \
 Retrieve a stateful set and all its info in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                  |
-|----------------------------|---------------------------------------------------------|
-| `cluster_id` <br/>*string* | The id of the cluster in which to get the stateful set. |
+| -------------------------- | ------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the stateful set. |
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>*string*                         | The id of the stateful set                                      |
-| `metadata` <br/>*object*                   | The metadata of the stateful set                                |
-| `metadata.creationTimestamp` <br/>*string* | The date of creation of the stateful set as a string            |
-| `metadata.labels` <br/>*map*               | The labels associated to the stateful set                       |
-| `metadata.name` <br/>*string*              | The name of the stateful set                                    |
-| `metadata.namespace` <br/>*string*         | The namespace in which the stateful set is created              |
-| `metadata.uid` <br/>*object*               | The UUID of the stateful set                                    |
-| `spec`<br/>*object*                        | The specification used to create and run the stateful set       |
-| `status`<br/>*object*                      | The status information of the stateful set                      |
+| Attributes                                 | &nbsp;                                                    |
+| ------------------------------------------ | --------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the stateful set                                |
+| `metadata` <br/>_object_                   | The metadata of the stateful set                          |
+| `spec`<br/>_object_                        | The specification used to create and run the stateful set |
+| `status`<br/>_object_                      | The status information of the stateful set                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).


### PR DESCRIPTION
### Fixes [MC-11900](https://cloud-ops.atlassian.net/browse/MC-11900)

#### Changes made
The kubernetes documentation for the hypercloud did not mention the `cluster id` mandatory field for some of the entities. It was added.