### PR TITLE
MC-10548: add doc for create network and attach subnet

### DIFF
--- a/source/includes/gcp/_networks.md
+++ b/source/includes/gcp/_networks.md
@@ -109,3 +109,57 @@ Attributes | &nbsp;
 `routingConfig`<br/>*object* | The network-level routing configuration for this network. Used by Cloud Router to determine what type of network-wide routing behavior to enforce. RoutingMode is either REGIONAL or GLOBAL.
 `selfLink`<br/>*string* | Server-defined URL for this resource.
 `subnetworks`<br/>*Array[URL]* | Server-defined fully-qualified URLs for all subnetworks in this VPC network.
+
+<!-------------------- CREATE A NETWORK -------------------->
+
+#### Create a network
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/networks"
+```
+
+> Request body example for network in auto subnet creation mode:
+
+```json
+{
+	"name": "vpc-name",
+	"autoCreateSubnetworks": true
+}
+```
+
+> Request body example for network in custom subnet creation mode:
+
+```json
+{
+	"name": "vpc-name",
+	"autoCreateSubnetworks": false,
+	"subnetName": "subnet-name",
+	"subnetShortRegion": "northamerica-northeast1",
+	"subnetIpCidrRange": "10.0.0.0/20"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks</code>
+
+Create a new network and attach subnet
+
+Required in auto mode | &nbsp;
+--------------------- | -----------
+`name`<br/>*string* | The display name of the network.
+`autoCreateSubnetworks`<br/>*boolean* | Whether subnets will be automatically created for each region.
+
+Required in custom mode | &nbsp;
+----------------------- | -----------
+`name`<br/>*string* | The display name of the network.
+`autoCreateSubnetworks`<br/>*boolean* | Whether subnets will be automatically created for each region.
+`subnetName`<br/>*string* | The display name of the subnet.
+`subnetShortRegion`<br/>*string* | A short version of the region name of the subnet.
+`subnetIpCidrRange`<br/>*string* | The CIDR IP range of the subnet.
+
+Optional | &nbsp;
+------- | -----------
+`description`<br/>*string* | Description of the network.

--- a/source/includes/gcp/_networks.md
+++ b/source/includes/gcp/_networks.md
@@ -136,7 +136,6 @@ curl -X POST \
 ```json
 {
 	"name": "vpc-name",
-	"autoCreateSubnetworks": false,
 	"subnetName": "subnet-name",
 	"subnetShortRegion": "northamerica-northeast1",
 	"subnetIpCidrRange": "10.0.0.0/20"
@@ -155,7 +154,6 @@ Required in auto mode | &nbsp;
 Required in custom mode | &nbsp;
 ----------------------- | -----------
 `name`<br/>*string* | The display name of the network.
-`autoCreateSubnetworks`<br/>*boolean* | Whether subnets will be automatically created for each region.
 `subnetName`<br/>*string* | The display name of the subnet.
 `subnetShortRegion`<br/>*string* | A short version of the region name of the subnet.
 `subnetIpCidrRange`<br/>*string* | The CIDR IP range of the subnet.


### PR DESCRIPTION
### Fixes [MC-10548](https://cloud-ops.atlassian.net/browse/MC-10548)

#### Changes made
-add doc for create and attach subnet

#### Related PRs
- https://github.com/cloudops/cloudmc-gcp-plugin/pull/258

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->