### PR TITLE
MC-11568: Add API docs for services

### DIFF
--- a/source/includes/azure/_k8_services.md.erb
+++ b/source/includes/azure/_k8_services.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_services.md" %>

--- a/source/includes/gcp/_k8_services.md.erb
+++ b/source/includes/gcp/_k8_services.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_services.md" %>

--- a/source/includes/kubernetes/_k8_services.md
+++ b/source/includes/kubernetes/_k8_services.md
@@ -1,0 +1,120 @@
+## Services
+
+<!-------------------- LIST SERVICES -------------------->
+
+#### List services
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "alaintest-aerospike/default",
+      "ports": [
+        "3000/TCP",
+        "3002/TCP"
+      ],
+      "type": "ClusterIP",
+      "metadata": {},
+      "spec": {},
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "id": "alertmanager-operated/monitoring",
+      "ports": [
+        "9093/TCP",
+        "9094/TCP",
+        "9094/UDP"
+      ],
+      "type": "NodePort",
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {},
+      "spec": {},
+      "status": {
+       "loadBalancer": {}
+      }
+    }
+  ],
+    "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services</code>
+
+Retrieve a list of all services in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the service                                           |
+| `metadata` <br/>_object_                   | The metadata of the service                                     |
+| `metadata.name` <br/>_string_              | The name of the service                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service is created                   |
+| `metadata.uid` <br/>_object_               | The UUID of the service                                         |
+| `type` <br/>_object_                       | The container images within a service                           |
+| `ports`<br/>_object_                       | The list of ports that are exposed by this service              |
+| `spec`<br/>_object_                        | The attributes that a user creates on a service                 |
+| `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET A SERVICE -------------------->
+
+#### Get a service
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services/test-aerospike/auth"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "test-aerospike/auth",
+    "ports": [
+      "3000/TCP",
+      "3002/TCP"
+    ],
+    "type": "ClusterIP",
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {},
+    "spec": {},
+    "status": {
+      "loadBalancer": {}
+    }
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services/:id</code>
+
+Retrieve a service and all its info in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the service                                           |
+| `metadata` <br/>_object_                   | The metadata of the service                                     |
+| `metadata.name` <br/>_string_              | The name of the service                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service is created                   |
+| `metadata.uid` <br/>_object_               | The UUID of the service                                         |
+| `type` <br/>_object_                       | The container images within a service                           |
+| `ports`<br/>_object_                       | The list of ports that are exposed by this service              |
+| `spec`<br/>_object_                        | The attributes that a user creates on a service                 |
+| `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_services.md
+++ b/source/includes/kubernetes_extension/_k8_services.md
@@ -105,6 +105,10 @@ curl -X GET \
 
 Retrieve a service and all its info in a given [environment](#administration-environments).
 
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the service. |
+
 | Attributes                                 | &nbsp;                                                          |
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `id` <br/>_string_                         | The id of the service                                           |

--- a/source/includes/kubernetes_extension/_k8_services.md
+++ b/source/includes/kubernetes_extension/_k8_services.md
@@ -51,9 +51,12 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services?cluster_id=:cluster_id</code>
 
 Retrieve a list of all services in a given [environment](#administration-environments).
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the service. |
 
 | Attributes                                 | &nbsp;                                                          |
 | ------------------------------------------ | --------------------------------------------------------------- |
@@ -101,7 +104,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services/:id?cluster_id=:cluster_id</code>
 
 Retrieve a service and all its info in a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes_extension/_k8_services.md
+++ b/source/includes/kubernetes_extension/_k8_services.md
@@ -7,7 +7,7 @@
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -76,7 +76,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services/test-aerospike/auth"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services/test-aerospike/auth?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:

--- a/source/includes/kubernetes_extension/_k8_services.md
+++ b/source/includes/kubernetes_extension/_k8_services.md
@@ -1,0 +1,120 @@
+### Services
+
+<!-------------------- LIST SERVICES -------------------->
+
+#### List services
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "alaintest-aerospike/default",
+      "ports": [
+        "3000/TCP",
+        "3002/TCP"
+      ],
+      "type": "ClusterIP",
+      "metadata": {},
+      "spec": {},
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "id": "alertmanager-operated/monitoring",
+      "ports": [
+        "9093/TCP",
+        "9094/TCP",
+        "9094/UDP"
+      ],
+      "type": "NodePort",
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {},
+      "spec": {},
+      "status": {
+       "loadBalancer": {}
+      }
+    }
+  ],
+    "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services</code>
+
+Retrieve a list of all services in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the service                                           |
+| `metadata` <br/>_object_                   | The metadata of the service                                     |
+| `metadata.name` <br/>_string_              | The name of the service                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service is created                   |
+| `metadata.uid` <br/>_object_               | The UUID of the service                                         |
+| `type` <br/>_object_                       | The container images within a service                           |
+| `ports`<br/>_object_                       | The list of ports that are exposed by this service              |
+| `spec`<br/>_object_                        | The attributes that a user creates on a service                 |
+| `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET A SERVICE -------------------->
+
+#### Get a service
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services/test-aerospike/auth"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "test-aerospike/auth",
+    "ports": [
+      "3000/TCP",
+      "3002/TCP"
+    ],
+    "type": "ClusterIP",
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {},
+    "spec": {},
+    "status": {
+      "loadBalancer": {}
+    }
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services/:id</code>
+
+Retrieve a service and all its info in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the service                                           |
+| `metadata` <br/>_object_                   | The metadata of the service                                     |
+| `metadata.name` <br/>_string_              | The name of the service                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service is created                   |
+| `metadata.uid` <br/>_object_               | The UUID of the service                                         |
+| `type` <br/>_object_                       | The container images within a service                           |
+| `ports`<br/>_object_                       | The list of ports that are exposed by this service              |
+| `spec`<br/>_object_                        | The attributes that a user creates on a service                 |
+| `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -93,6 +93,7 @@ includes:
   - gcp/k8_statefulsets
   - gcp/k8_daemonsets
   - gcp/k8_deployments
+  - gcp/k8_services
   - gcp/k8_configmaps
   - gcp/k8_secrets
   - gcp/k8_releases
@@ -105,6 +106,7 @@ includes:
   - kubernetes/k8_statefulsets
   - kubernetes/k8_daemonsets
   - kubernetes/k8_deployments
+  - kubernetes/k8_services
   - kubernetes/k8_configmaps
   - kubernetes/k8_secrets
   - kubernetes/k8_releases
@@ -128,6 +130,7 @@ includes:
   - azure/k8_statefulsets
   - azure/k8_daemonsets
   - azure/k8_deployments
+  - azure/k8_services
   - azure/k8_configmaps
   - azure/k8_secrets
   - masterportal


### PR DESCRIPTION
### Fixes [MC-11568](https://cloud-ops.atlassian.net/browse/MC-11568)

#### Changes made
<!-- Changes should match the template provided below -->
- Added docs for services

#### Related PRs
- You already saw them ;)
<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->