### PR TITLE
MC-11608: delete network doc added

### DIFF
--- a/source/includes/gcp/_networks.md
+++ b/source/includes/gcp/_networks.md
@@ -65,7 +65,7 @@ Attributes | &nbsp;
 
 ```shell
 curl -H "MC-Api-Key: your_api_key" \
-    "https://api.your.cloudmc/v1/services/gcp/test-area/networks/6402509859159933821"
+    "https://cloudmc_endpoint/v1/services/gcp/test-area/networks/6402509859159933821"
 ```
 > The above command returns a JSON structured like this:
 
@@ -161,3 +161,17 @@ Required in custom mode | &nbsp;
 Optional | &nbsp;
 ------- | -----------
 `description`<br/>*string* | Description of the network.
+
+<!-------------------- DELETE A NETWORK -------------------->
+
+#### Delete a network
+
+```shell
+curl -X DELETE \
+  -H "mc-api-key: your_api_key" \
+  "https://cloudmc_endpoint/v1/services/gcp/test-area/networks/6402509859159933821"
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks/:id</code>
+
+Delete an existing network

--- a/source/includes/gcp/_networks.md
+++ b/source/includes/gcp/_networks.md
@@ -174,4 +174,4 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networks/:id</code>
 
-Delete an existing network
+Delete an existing network.


### PR DESCRIPTION
### Fixes [MC-11608](https://cloud-ops.atlassian.net/browse/MC-11608)

#### Changes made
-Add doc regarding deletion of VPC network in GCP

#### Related PRs
-https://github.com/cloudops/cloudmc-gcp-plugin/pull/267

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->