### PR TITLE
MC-11611: Create snapshot from a disk (GCP)

### DIFF
--- a/source/includes/gcp/_disks.md
+++ b/source/includes/gcp/_disks.md
@@ -266,3 +266,32 @@ Resize an existing disk.
 Required | &nbsp;
 ---------- | -----
 `sizeGb` <br/>*string* | The size of the disk in GB. Valid values are 1 to 65536, inclusive, unless this is an [instance](#gcp-instances)'s boot disk, then the valid values are 1 to 2000.
+
+<!-------------------- TAKE SNAPSHOT -------------------->
+
+#### Take a snapshot of a disk
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/disks/5333546534174463697?operation=snapshot"
+```
+> Request body example:
+
+```json
+{
+   "snapshotName": "my-snapshot"
+}
+```
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/disks/:id?operation=snapshot</code>
+
+Take a snapshot of a persistent disk.
+
+<aside class="notice">
+Snapshots are incremental to avoid billing for redundant data and minimize use of storage. However, snapshots may occasionally capture the full disk for reliability. See the link for more information on <a href="https://cloud.google.com/compute/docs/disks/create-snapshots">creating snapshots</a>
+</aside>
+
+Required | &nbsp;
+---------- | -----
+`snapshotName` <br/>*string* | The name of the snapshot. The name cannot exceed 64 characters.

--- a/source/includes/gcp/_disks.md
+++ b/source/includes/gcp/_disks.md
@@ -289,9 +289,9 @@ curl -X POST \
 Take a snapshot of a persistent disk.
 
 <aside class="notice">
-Snapshots are incremental to avoid billing for redundant data and minimize use of storage. However, snapshots may occasionally capture the full disk for reliability. See the link for more information on <a href="https://cloud.google.com/compute/docs/disks/create-snapshots">creating snapshots</a>
+Snapshots are incremental to avoid billing for redundant data and minimize use of storage. However, snapshots may occasionally capture the full disk for reliability. See the link for more information on <a href="https://cloud.google.com/compute/docs/disks/create-snapshots">creating snapshots.</a>
 </aside>
 
-Required | &nbsp;
+Optional | &nbsp;
 ---------- | -----
-`snapshotName` <br/>*string* | The name of the snapshot. The name cannot exceed 64 characters.
+`snapshotName` <br/>*string* | The name of the snapshot. A default value set if a snapshot name is not provided.

--- a/source/includes/gcp/_health_checks.md
+++ b/source/includes/gcp/_health_checks.md
@@ -53,7 +53,7 @@ Attributes | &nbsp;
 `checkIntervalSec`<br/>*int* | How often (in seconds) to send a health check. The default value is 5 seconds.
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
 `description` <br/>*string* | An optional description of this resource. Provide this property when you create the resource.
-`healthyThreshold`ç | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
+`healthyThreshold` | A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
 `httpHealthCheck` <br/>*object* | When the type is set to HTTP, this object represents the health check.
 `httpSHealthCheck` <br/>*object* | When the type is set to HTTPS, this object represents the health check.
 `id`<br/>*string* | The unique identifier for the resource. This identifier is defined by the server.

--- a/source/includes/gcp/_snapshots.md
+++ b/source/includes/gcp/_snapshots.md
@@ -144,3 +144,9 @@ Attributes | &nbsp;
 `downloadBytes` <br/>*string* | Number of bytes downloaded to restore a snapshot to a disk.
 `id` <br/>*string* | The unique identifier for the resource. This identifier is defined by the server.
 `name` <br/>*string* | Name of the resource; provided by the client when the resource is created. 
+
+<!-------------------- CREATE A SNAPSHOT -------------------->
+
+#### Create a snapshot
+
+See [take a snapshot of a disk](#gcp-take-a-snapshot-of-a-disk) to create a snapshot.


### PR DESCRIPTION
### Fixes [MC-11611](https://cloud-ops.atlassian.net/browse/MC-11611)

#### Changes made
<!-- Changes should match the template provided below -->
- Document how to create a snapshot from a source disk
- The snapshot name is optional because we set a default one if none is provided
- I don't see this documented elsewhere and not sure what other resources support this in gcp
- Think we should make it standard before documenting, any thoughts?

#### Related PRs
- [gcp / create snapshot from disk](https://github.com/cloudops/cloudmc-gcp-plugin/pull/270)

![take-snapshot-1](https://user-images.githubusercontent.com/8960233/86052829-98e62f80-ba25-11ea-96f3-d93163176146.jpg)

![take-snapshot-2](https://user-images.githubusercontent.com/8960233/86052845-9daae380-ba25-11ea-9df3-af7b94166f89.jpg)


<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->