### PR TITLE
Feature/mc 11569 list ingress in cluster

### DIFF
--- a/source/includes/azure/_k8_ingresses.md.erb
+++ b/source/includes/azure/_k8_ingresses.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_ingresses.md" %>

--- a/source/includes/gcp/_k8_ingresses.md.erb
+++ b/source/includes/gcp/_k8_ingresses.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_ingresses.md" %>

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -17,7 +17,7 @@ curl -X GET \
   "data": [
     {
       "id": "cloudmc/cmc-stg",
-      "endpoint": "http://example.endpoint.com",
+      "endpoint": "http://cmc.cloudmc-staging-endpoint.com",
       "service": {
         "port": "8080",
         "name": "cloudmc"
@@ -42,7 +42,7 @@ curl -X GET \
     },
     {
       "id": "cm-acme-http-solver-75png/auth",
-      "endpoint": "http://fake.endpoint.com",
+      "endpoint": "http://cmc.cloudmc-staging-endpoint.com",
       "service": {
         "port": "8089",
         "name": "cm-acme-http-solver-2x5gv"
@@ -111,7 +111,7 @@ curl -X GET \
 {
   "data": {
     "id": "cloudmc/cmc-stg",
-    "endpoint": "http://example.endpoint.com",
+    "endpoint": "http://cmc.cloudmc-staging-endpoint.com",
     "service": {
       "port": "8080",
       "name": "cloudmc"

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -69,6 +69,7 @@ curl -X GET \
       },
       "status": {
         "loadBalancer": {}
+      }
     }
   ]
 }

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -17,7 +17,7 @@ curl -X GET \
   "data": [
     {
       "id": "cloudmc/cmc-stg",
-      "endpoint": "http://cloudmc-stg.cloudops-devteam.com",
+      "endpoint": "http://example.endpoint.com",
       "service": {
         "port": "8080",
         "name": "cloudmc"
@@ -42,7 +42,7 @@ curl -X GET \
     },
     {
       "id": "cm-acme-http-solver-75png/auth",
-      "endpoint": "http://dex.cloudops-devteam.com",
+      "endpoint": "http://fake.endpoint.com",
       "service": {
         "port": "8089",
         "name": "cm-acme-http-solver-2x5gv"
@@ -111,7 +111,7 @@ curl -X GET \
 {
   "data": {
     "id": "cloudmc/cmc-stg",
-    "endpoint": "http://cloudmc-stg.cloudops-devteam.com",
+    "endpoint": "http://example.endpoint.com",
     "service": {
       "port": "8080",
       "name": "cloudmc"

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -1,0 +1,157 @@
+## Ingresses
+
+<!-------------------- LIST INGRESSES -------------------->
+
+#### List ingresses
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/ingresses"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "cloudmc/cmc-stg",
+      "endpoint": "http://cloudmc-stg.cloudops-devteam.com",
+      "service": {
+        "port": "8080",
+        "name": "cloudmc"
+      },
+      "metadata": {
+        "annotations": {},
+        "creationTimestamp": "2019-07-11T10:00:18.000-04:00",
+        "generation": 10,
+        "name": "cloudmc",
+        "namespace": "cmc-stg",
+        "resourceVersion": "143213903",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/cmc-stg/ingresses/cloudmc",
+        "uid": "376bc4c5-a3e4-11e9-b6bd-02006e76001e"
+      },
+      "spec": {
+        "rules": [],
+        "tls": []
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "id": "cm-acme-http-solver-75png/auth",
+      "endpoint": "http://dex.cloudops-devteam.com",
+      "service": {
+        "port": "8089",
+        "name": "cm-acme-http-solver-2x5gv"
+      },
+      "metadata": {
+        "annotations": {},
+        "creationTimestamp": "2020-06-24T11:00:49.000-04:00",
+        "generateName": "cm-acme-http-solver-",
+        "generation": 1,
+        "labels": {
+          "acme.cert-manager.io/http-domain": "1965164889",
+          "acme.cert-manager.io/http-token": "820448657",
+          "acme.cert-manager.io/http01-solver": "true"
+        },
+        "name": "cm-acme-http-solver-75png",
+        "namespace": "auth",
+        "ownerReferences": [],
+        "resourceVersion": "143213968",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/auth/ingresses/cm-acme-http-solver-75png",
+        "uid": "48720f48-f2bc-45fc-95c5-60cae8ffe11e"
+      },
+      "spec":{
+        "rules":[]
+      },
+      "status": {
+        "loadBalancer": {}
+    }
+  ]
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses</code>
+
+Retrieve a list of all ingresses in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the ingress                                           |
+| `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
+| `service` <br/>_object_                    | The service associated with the ingress                         |
+| `service.port` <br/>_string_               | The name of the service associated with the ingress             |
+| `service.name` <br/>_string_               | The name of the service associated with the ingress             |
+| `metadata` <br/>_object_                   | The metadata of the ingress                                     |
+| `metadata.name` <br/>_string_              | The name of the ingress                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
+| `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
+| `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
+| `spec`<br/>_object_                        | The attributes that a user creates on an ingress                |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET AN INGRESS -------------------->
+
+#### Get an ingress
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/ingresses/cloudmc/cmc-stg"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "cloudmc/cmc-stg",
+    "endpoint": "http://cloudmc-stg.cloudops-devteam.com",
+    "service": {
+      "port": "8080",
+      "name": "cloudmc"
+    },
+    "metadata": {
+      "annotations": {},
+      "creationTimestamp": "2019-07-11T10:00:18.000-04:00",
+      "generation": 10,
+      "name": "cloudmc",
+      "namespace": "cmc-stg",
+      "resourceVersion": "143213903",
+      "selfLink": "/apis/extensions/v1beta1/namespaces/cmc-stg/ingresses/cloudmc",
+      "uid": "376bc4c5-a3e4-11e9-b6bd-02006e76001e"
+    },
+    "spec": {
+      "rules": [],
+      "tls": []
+    },
+    "status": {
+      "loadBalancer": {}
+    }
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingress/:id</code>
+
+Retrieve an ingress and all its info in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the ingress                                           |
+| `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
+| `service` <br/>_object_                    | The service associated with the ingress                         |
+| `service.port` <br/>_string_               | The name of the service associated with the ingress             |
+| `service.name` <br/>_string_               | The name of the service associated with the ingress             |
+| `metadata` <br/>_object_                   | The metadata of the ingress                                     |
+| `metadata.name` <br/>_string_              | The name of the ingress                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
+| `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
+| `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
+| `spec`<br/>_object_                        | The attributes that a user creates on an ingress                |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -91,7 +91,7 @@ Retrieve a list of all ingresses in a given [environment](#administration-enviro
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
 | `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
 | `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user specifies on an ingress              |
+| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -153,6 +153,6 @@ Retrieve an ingress and all its info in a given [environment](#administration-en
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
 | `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
 | `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user specifies on an ingress              |
+| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -84,14 +84,14 @@ Retrieve a list of all ingresses in a given [environment](#administration-enviro
 | `id` <br/>_string_                         | The id of the ingress                                           |
 | `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
 | `service` <br/>_object_                    | The service associated with the ingress                         |
-| `service.port` <br/>_string_               | The name of the service associated with the ingress             |
+| `service.port` <br/>_string_               | The port of the service associated with the ingress             |
 | `service.name` <br/>_string_               | The name of the service associated with the ingress             |
 | `metadata` <br/>_object_                   | The metadata of the ingress                                     |
 | `metadata.name` <br/>_string_              | The name of the ingress                                         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
 | `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
 | `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user creates on an ingress                |
+| `spec`<br/>_object_                        | The attributes that a user specifies on an ingress              |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -146,13 +146,13 @@ Retrieve an ingress and all its info in a given [environment](#administration-en
 | `id` <br/>_string_                         | The id of the ingress                                           |
 | `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
 | `service` <br/>_object_                    | The service associated with the ingress                         |
-| `service.port` <br/>_string_               | The name of the service associated with the ingress             |
+| `service.port` <br/>_string_               | The port of the service associated with the ingress             |
 | `service.name` <br/>_string_               | The name of the service associated with the ingress             |
 | `metadata` <br/>_object_                   | The metadata of the ingress                                     |
 | `metadata.name` <br/>_string_              | The name of the ingress                                         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
 | `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
 | `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user creates on an ingress                |
+| `spec`<br/>_object_                        | The attributes that a user specifies on an ingress              |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -95,7 +95,7 @@ Retrieve a list of all ingresses in a given [environment](#administration-enviro
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
 | `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
 | `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user specifies on an ingress              |
+| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -161,6 +161,6 @@ Retrieve an ingress and all its info in a given [environment](#administration-en
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
 | `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
 | `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user specifies on an ingress              |
+| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -1,0 +1,166 @@
+### Ingresses
+
+<!-------------------- LIST INGRESSES -------------------->
+
+#### List ingresses
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/ingresses?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "cloudmc/cmc-stg",
+      "endpoint": "http://cloudmc-stg.cloudops-devteam.com",
+      "service": {
+        "port": "8080",
+        "name": "cloudmc"
+      },
+      "metadata": {
+        "annotations": {},
+        "creationTimestamp": "2019-07-11T10:00:18.000-04:00",
+        "generation": 10,
+        "name": "cloudmc",
+        "namespace": "cmc-stg",
+        "resourceVersion": "143213903",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/cmc-stg/ingresses/cloudmc",
+        "uid": "376bc4c5-a3e4-11e9-b6bd-02006e76001e"
+      },
+      "spec": {
+        "rules": [],
+        "tls": []
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "id": "cm-acme-http-solver-75png/auth",
+      "endpoint": "http://dex.cloudops-devteam.com",
+      "service": {
+        "port": "8089",
+        "name": "cm-acme-http-solver-2x5gv"
+      },
+      "metadata": {
+        "annotations": {},
+        "creationTimestamp": "2020-06-24T11:00:49.000-04:00",
+        "generateName": "cm-acme-http-solver-",
+        "generation": 1,
+        "labels": {
+          "acme.cert-manager.io/http-domain": "1965164889",
+          "acme.cert-manager.io/http-token": "820448657",
+          "acme.cert-manager.io/http01-solver": "true"
+        },
+        "name": "cm-acme-http-solver-75png",
+        "namespace": "auth",
+        "ownerReferences": [],
+        "resourceVersion": "143213968",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/auth/ingresses/cm-acme-http-solver-75png",
+        "uid": "48720f48-f2bc-45fc-95c5-60cae8ffe11e"
+      },
+      "spec":{
+        "rules":[]
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses?cluster_id=:cluster_id</code>
+
+Retrieve a list of all ingresses in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the ingress                                           |
+| `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
+| `service` <br/>_object_                    | The service associated with the ingress                         |
+| `service.port` <br/>_string_               | The name of the service associated with the ingress             |
+| `service.name` <br/>_string_               | The name of the service associated with the ingress             |
+| `metadata` <br/>_object_                   | The metadata of the ingress                                     |
+| `metadata.name` <br/>_string_              | The name of the ingress                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
+| `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
+| `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
+| `spec`<br/>_object_                        | The attributes that a user creates on an ingress                |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET AN INGRESS -------------------->
+
+#### Get an ingress
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/ingresses/cloudmc/cmc-stg?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "cloudmc/cmc-stg",
+    "endpoint": "http://cloudmc-stg.cloudops-devteam.com",
+    "service": {
+      "port": "8080",
+      "name": "cloudmc"
+    },
+    "metadata": {
+      "annotations": {},
+      "creationTimestamp": "2019-07-11T10:00:18.000-04:00",
+      "generation": 10,
+      "name": "cloudmc",
+      "namespace": "cmc-stg",
+      "resourceVersion": "143213903",
+      "selfLink": "/apis/extensions/v1beta1/namespaces/cmc-stg/ingresses/cloudmc",
+      "uid": "376bc4c5-a3e4-11e9-b6bd-02006e76001e"
+    },
+    "spec": {
+      "rules": [],
+      "tls": []
+    },
+    "status": {
+      "loadBalancer": {}
+    }
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingress/:id??cluster_id=:cluster_id</code>
+
+Retrieve an ingress and all its info in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
+
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the ingress                                           |
+| `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
+| `service` <br/>_object_                    | The service associated with the ingress                         |
+| `service.port` <br/>_string_               | The name of the service associated with the ingress             |
+| `service.name` <br/>_string_               | The name of the service associated with the ingress             |
+| `metadata` <br/>_object_                   | The metadata of the ingress                                     |
+| `metadata.name` <br/>_string_              | The name of the ingress                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
+| `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
+| `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
+| `spec`<br/>_object_                        | The attributes that a user creates on an ingress                |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -17,7 +17,7 @@ curl -X GET \
   "data": [
     {
       "id": "cloudmc/cmc-stg",
-      "endpoint": "http://cloudmc-stg.cloudops-devteam.com",
+      "endpoint": "http://example.endpoint.com",
       "service": {
         "port": "8080",
         "name": "cloudmc"
@@ -42,7 +42,7 @@ curl -X GET \
     },
     {
       "id": "cm-acme-http-solver-75png/auth",
-      "endpoint": "http://dex.cloudops-devteam.com",
+      "endpoint": "http://fake.endpoint.com",
       "service": {
         "port": "8089",
         "name": "cm-acme-http-solver-2x5gv"
@@ -115,7 +115,7 @@ curl -X GET \
 {
   "data": {
     "id": "cloudmc/cmc-stg",
-    "endpoint": "http://cloudmc-stg.cloudops-devteam.com",
+    "endpoint": "http://example.endpoint.com",
     "service": {
       "port": "8080",
       "name": "cloudmc"

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -17,7 +17,7 @@ curl -X GET \
   "data": [
     {
       "id": "cloudmc/cmc-stg",
-      "endpoint": "http://example.endpoint.com",
+      "endpoint": "http://cmc.cloudmc-staging-endpoint.com",
       "service": {
         "port": "8080",
         "name": "cloudmc"
@@ -42,7 +42,7 @@ curl -X GET \
     },
     {
       "id": "cm-acme-http-solver-75png/auth",
-      "endpoint": "http://fake.endpoint.com",
+      "endpoint": "http://cmc.cloudmc-staging-endpoint.com",
       "service": {
         "port": "8089",
         "name": "cm-acme-http-solver-2x5gv"
@@ -115,7 +115,7 @@ curl -X GET \
 {
   "data": {
     "id": "cloudmc/cmc-stg",
-    "endpoint": "http://example.endpoint.com",
+    "endpoint": "http://cmc.cloudmc-staging-endpoint.com",
     "service": {
       "port": "8080",
       "name": "cloudmc"

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -88,14 +88,14 @@ Retrieve a list of all ingresses in a given [environment](#administration-enviro
 | `id` <br/>_string_                         | The id of the ingress                                           |
 | `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
 | `service` <br/>_object_                    | The service associated with the ingress                         |
-| `service.port` <br/>_string_               | The name of the service associated with the ingress             |
+| `service.port` <br/>_string_               | The port of the service associated with the ingress             |
 | `service.name` <br/>_string_               | The name of the service associated with the ingress             |
 | `metadata` <br/>_object_                   | The metadata of the ingress                                     |
 | `metadata.name` <br/>_string_              | The name of the ingress                                         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
 | `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
 | `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user creates on an ingress                |
+| `spec`<br/>_object_                        | The attributes that a user specifies on an ingress              |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -154,13 +154,13 @@ Retrieve an ingress and all its info in a given [environment](#administration-en
 | `id` <br/>_string_                         | The id of the ingress                                           |
 | `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
 | `service` <br/>_object_                    | The service associated with the ingress                         |
-| `service.port` <br/>_string_               | The name of the service associated with the ingress             |
+| `service.port` <br/>_string_               | The port of the service associated with the ingress             |
 | `service.name` <br/>_string_               | The name of the service associated with the ingress             |
 | `metadata` <br/>_object_                   | The metadata of the ingress                                     |
 | `metadata.name` <br/>_string_              | The name of the ingress                                         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
 | `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
 | `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user creates on an ingress                |
+| `spec`<br/>_object_                        | The attributes that a user specifies on an ingress              |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -95,6 +95,7 @@ includes:
   - gcp/k8_daemonsets
   - gcp/k8_deployments
   - gcp/k8_services
+  - gcp/k8_ingresses
   - gcp/k8_configmaps
   - gcp/k8_secrets
   - gcp/k8_releases
@@ -108,6 +109,7 @@ includes:
   - kubernetes/k8_daemonsets
   - kubernetes/k8_deployments
   - kubernetes/k8_services
+  - kubernetes/k8_ingresses
   - kubernetes/k8_configmaps
   - kubernetes/k8_secrets
   - kubernetes/k8_releases
@@ -132,6 +134,7 @@ includes:
   - azure/k8_daemonsets
   - azure/k8_deployments
   - azure/k8_services
+  - azure/k8_ingresses
   - azure/k8_configmaps
   - azure/k8_secrets
   - masterportal


### PR DESCRIPTION
### Fixes [MC-11569](https://cloud-ops.atlassian.net/browse/MC-11569)

#### Changes made
Added API docs for ingresses

#### Related PRs

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->