### PR TITLE
MC-11930 Add subnetwork name api doc

### DIFF
--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -313,6 +313,7 @@ curl -X POST \
   "cpuCount": "2",
   "memoryInGB": "4.5",
   "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
+  "subnetworkName": "production-net",
   "shortIP": "my-ip-name",
   "startupScript": "#! /bin/bash\napt-get update\nEOF"
 }
@@ -327,6 +328,7 @@ curl -X POST \
   "cpuCount": "2",
   "memoryInGB": "4.5",
   "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
+  "subnetworkName": "staging-net",
   "reserveStaticIP": true
 }
 
@@ -340,6 +342,7 @@ curl -X POST \
   "cpuCount": "2",
   "memoryInGB": "4.5",
   "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
+  "subnetworkName": "development-net",
   "ephemeralIP": true
 }
 
@@ -352,7 +355,8 @@ curl -X POST \
   "bootDiskSizeInGb": "10",
   "cpuCount": "2",
   "memoryInGB": "4.5",
-  "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514"
+  "osImageSelfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-9-stretch-v20190514",
+  "subnetworkName": "demo-net",
 }
 ```
 
@@ -370,6 +374,7 @@ Required | &nbsp;
 `cpuCount`<br/>*string* | Updated number of vCPUs of instance.
 `memoryInGB`<br/>*string* | Updated memory of instance.
 `osImageSelfLink`<br/>*string* | The full URL to the OS image.
+`subnetworkName`<br/>*string* | The subnet to which the instance is to be attached upon creation _(must be in the same region as the region provided for the instance)_.
 
 Optional | &nbsp;
 ------- | -----------

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -374,7 +374,7 @@ Required | &nbsp;
 `cpuCount`<br/>*string* | Updated number of vCPUs of instance.
 `memoryInGB`<br/>*string* | Updated memory of instance.
 `osImageSelfLink`<br/>*string* | The full URL to the OS image.
-`subnetworkName`<br/>*string* | The subnet to which the instance is to be attached upon creation _(must be in the same region as the region provided for the instance)_.
+`subnetworkName`<br/>*string* | The subnet that the instance is attached to upon creation. _(Note that the subnet must be in the same region as the instance)_.
 
 Optional | &nbsp;
 ------- | -----------


### PR DESCRIPTION
### Fixes [MC-11930](https://cloud-ops.atlassian.net/browse/MC-11930)

#### Changes made
- Adding a required field for **subnetworkName**  when creating a new instance in GCP

#### Related PRs
- [PR#285](https://github.com/cloudops/cloudmc-gcp-plugin/pull/285) of [cloudmc-gcp-plugin](https://github.com/cloudops/cloudmc-gcp-plugin)

![image](https://user-images.githubusercontent.com/7249208/86598008-7f377180-bf6a-11ea-85ae-5d34aedf9a9a.png)
