### PR TITLE
MC-11501: Added api doc of the trial settings

### DIFF
--- a/source/includes/administration/_trials.md
+++ b/source/includes/administration/_trials.md
@@ -1,5 +1,5 @@
 ### Trials
-Manage trials and trials configuration.
+Manage trials and trials settings.
 
 <!-------------------- LIST TRIALS SETTINGS -------------------->
 
@@ -46,9 +46,9 @@ Attributes | &nbsp;
 `id`<br/>*UUID* | The id of the trial settings.
 `duration`<br/>*integer* | The number of days a trial account will remain active.
 `extensionDays`<br/>*integer* | The number of days that a trial administrator adds when extending an active trial.
-`maxConcurrentTrials`<br/>*integer* | The number of organization that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
-`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system delete the trial's resources.
-`expirationReminderDays`<br/>*integer* | The number of days before the trial's end the trial administrator will receive an email notification that the trial is about to expire.
+`maxConcurrentTrials`<br/>*integer* | The number of organizations that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
+`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system will delete the trial's resources.
+`expirationReminderDays`<br/>*integer* | The number of days before the trial's end that the trial administrator will receive an email notification that the trial is about to expire.
 `allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
 `contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
 `contactUsPhone`<br/>*string* | The phone number that trial user can contact for more info/support.
@@ -100,9 +100,9 @@ Attributes | &nbsp;
 `id`<br/>*UUID* | The id of the trial settings.
 `duration`<br/>*integer* | The number of days a trial account will remain active.
 `extensionDays`<br/>*integer* | The number of days that a trial administrator adds when extending an active trial.
-`maxConcurrentTrials`<br/>*integer* | The number of organization that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
-`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system delete the trial's resources.
-`expirationReminderDays`<br/>*integer* | The number of days before the trial's end the trial administrator will receive an email notification that the trial is about to expire.
+`maxConcurrentTrials`<br/>*integer* | The number of organizations that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
+`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system will delete the trial's resources.
+`expirationReminderDays`<br/>*integer* | The number of days before the trial's end that the trial administrator will receive an email notification that the trial is about to expire.
 `allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
 `contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
 `contactUsPhone`<br/>*string* | The phone number that trial user can contact for more info/support.
@@ -117,7 +117,7 @@ Attributes | &nbsp;
 `PUT /trials_settings/:id`
 
 ```shell
-# Updates an existing trial settings
+# Updates an existing trial's settings
 curl -X PUT "https://cloudmc_endpoint/rest/trials_settings/:id" \
    -H "MC-Api-Key: your_api_key"
 ```
@@ -171,16 +171,16 @@ curl -X PUT "https://cloudmc_endpoint/rest/trials_settings/:id" \
 }
 ```
 
-Updates a specific trial settings
+Updates a specific trial's settings.
 
 Required | &nbsp;
 ---------- | -----------
 `id`<br/>*UUID* | The id of the trial settings.
 `duration`<br/>*integer* | The number of days a trial account will remain active.
 `extensionDays`<br/>*integer* | The number of days that a trial administrator adds when extending an active trial.
-`maxConcurrentTrials`<br/>*integer* | The number of organization that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
-`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system delete the trial's resources.
-`expirationReminderDays`<br/>*integer* | The number of days before the trial's end the trial administrator will receive an email notification that the trial is about to expire.
+`maxConcurrentTrials`<br/>*integer* | The number of organizations that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
+`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system will delete the trial's resources.
+`expirationReminderDays`<br/>*integer* | The number of days before the trial's end that the trial administrator will receive an email notification that the trial is about to expire.
 `allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
 `contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
 `registrationHTML`<br/>*Object* | Mapped object containing the registration information HTML in different languages.

--- a/source/includes/administration/_trials.md
+++ b/source/includes/administration/_trials.md
@@ -1,0 +1,191 @@
+### Trials
+Manage trials and trials configuration.
+
+<!-------------------- LIST TRIALS SETTINGS -------------------->
+
+#### List trials settings
+
+`GET /trials_settings`
+
+```shell
+# Retrieve trials settings
+curl "https://cloudmc_endpoint/v1/trials_settings" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "b41f2aa3-e2d1-48d8-9760-8b874c20e8ae",
+      "duration": 14,
+      "extensionDays": 7,
+      "maxConcurrentTrials": 5,
+      "cleanupDelayDays": 5,
+      "expirationReminderDays": 3,
+      "allowMultipleTrialSameEmail": false,
+      "contactUsEmail": "email@gmail.com",
+      "contactUsPhone": "555-555-555",
+      "registrationHTML": {
+        "en": "<div>Registration HTML EN</div>",
+        "fr": "<div>Registration HTML FR</div>"
+      },
+      "termsAndConditionsHTML": {
+        "en": "<div>Terms and conditions HTML EN</div>",
+        "fr": "<div>Terms and conditions HTML FR</div>"
+      }
+    }
+  ]
+}
+```
+List the trials settings configured on the system.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the trial settings.
+`duration`<br/>*integer* | The number of days a trial account will remain active.
+`extensionDays`<br/>*integer* | The number of days that a trial administrator adds when extending an active trial.
+`maxConcurrentTrials`<br/>*integer* | The number of organization that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
+`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system delete the trial's resources.
+`expirationReminderDays`<br/>*integer* | The number of days before the trial's end the trial administrator will receive an email notification that the trial is about to expire.
+`allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
+`contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
+`contactUsPhone`<br/>*string* | The phone number that trial user can contact for more info/support.
+`registrationHTML`<br/>*Object* | Mapped object containing the registration information HTML in different languages.
+`termsAndConditionsHTML`<br/>*Object* | Mapped object containing the terms and conditions HTML name in different languages.
+
+
+
+<!-------------------- GET TRIAL SETTINGS -------------------->
+
+#### Retrieve trial settings
+
+`GET /trials_settings/:id`
+
+```shell
+# Retrieve trial settings
+curl "https://cloudmc_endpoint/v1/trials_settings/b41f2aa3-e2d1-48d8-9760-8b874c20e8ae" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "b41f2aa3-e2d1-48d8-9760-8b874c20e8ae",
+    "duration": 14,
+    "extensionDays": 7,
+    "maxConcurrentTrials": 5,
+    "cleanupDelayDays": 5,
+    "expirationReminderDays": 3,
+    "allowMultipleTrialSameEmail": false,
+    "contactUsEmail": "email@gmail.com",
+    "contactUsPhone": "555-555-555",
+    "registrationHTML": {
+      "en": "<div>Registration HTML EN</div>",
+      "fr": "<div>Registration HTML FR</div>"
+    },
+    "termsAndConditionsHTML": {
+      "en": "<div>Terms and conditions HTML EN</div>",
+      "fr": "<div>Terms and conditions HTML FR</div>"
+    }
+  }
+}
+```
+Return the trial settings configured associated to the id on the system.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the trial settings.
+`duration`<br/>*integer* | The number of days a trial account will remain active.
+`extensionDays`<br/>*integer* | The number of days that a trial administrator adds when extending an active trial.
+`maxConcurrentTrials`<br/>*integer* | The number of organization that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
+`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system delete the trial's resources.
+`expirationReminderDays`<br/>*integer* | The number of days before the trial's end the trial administrator will receive an email notification that the trial is about to expire.
+`allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
+`contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
+`contactUsPhone`<br/>*string* | The phone number that trial user can contact for more info/support.
+`registrationHTML`<br/>*Object* | Mapped object containing the registration information HTML in different languages.
+`termsAndConditionsHTML`<br/>*Object* | Mapped object containing the terms and conditions HTML name in different languages.
+
+
+<!-------------------- UPDATE TRIALS SETTINGS -------------------->
+
+#### Update trial settings
+
+`PUT /trials_settings/:id`
+
+```shell
+# Updates an existing trial settings
+curl -X PUT "https://cloudmc_endpoint/rest/trials_settings/:id" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```js
+{
+  "id": "b41f2aa3-e2d1-48d8-9760-8b874c20e8ae",
+  "duration": 14,
+  "extensionDays": 7,
+  "maxConcurrentTrials": 5,
+  "cleanupDelayDays": 5,
+  "expirationReminderDays": 3,
+  "allowMultipleTrialSameEmail": false,
+  "contactUsEmail": "email@gmail.com",
+  "contactUsPhone": "555-555-555",
+  "registrationHTML": {
+    "en": "<div>Registration HTML EN</div>",
+    "fr": "<div>Registration HTML FR</div>",
+  },
+  "termsAndConditionsHTML": {
+    "en": "<div>Terms and conditions HTML EN</div>",
+    "fr": "<div>Terms and conditions HTML FR</div>",
+  }
+}
+```
+> The above command return JSON structured like this:
+
+```js
+{
+  "data": {
+    "id": "b41f2aa3-e2d1-48d8-9760-8b874c20e8ae",
+    "duration": 14,
+    "extensionDays": 7,
+    "maxConcurrentTrials": 5,
+    "cleanupDelayDays": 5,
+    "expirationReminderDays": 3,
+    "allowMultipleTrialSameEmail": false,
+    "contactUsEmail": "email@gmail.com",
+    "contactUsPhone": "555-555-555",
+    "registrationHTML": {
+      "en": "<div>Registration HTML EN</div>",
+      "fr": "<div>Registration HTML FR</div>",
+    },
+    "termsAndConditionsHTML": {
+      "en": "<div>Terms and conditions HTML EN</div>",
+      "fr": "<div>Terms and conditions HTML FR</div>",
+    }
+  }
+}
+```
+
+Updates a specific trial settings
+
+Required | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the trial settings.
+`duration`<br/>*integer* | The number of days a trial account will remain active.
+`extensionDays`<br/>*integer* | The number of days that a trial administrator adds when extending an active trial.
+`maxConcurrentTrials`<br/>*integer* | The number of organization that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
+`cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system delete the trial's resources.
+`expirationReminderDays`<br/>*integer* | The number of days before the trial's end the trial administrator will receive an email notification that the trial is about to expire.
+`allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
+`contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
+`registrationHTML`<br/>*Object* | Mapped object containing the registration information HTML in different languages.
+`termsAndConditionsHTML`<br/>*Object* | Mapped object containing the terms and conditions HTML name in different languages.
+
+Optional | &nbsp;
+---------- | -----------
+`contactUsPhone`<br/>*string* | The phone number that trial user can contact for more info/support.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -23,6 +23,7 @@ includes:
   - administration/identity_providers
   - administration/service_providers
   - administration/saml_settings
+  - administration/trials
   - cloudstack
   - cloudstack/compute # Compute section
   - cloudstack/instances


### PR DESCRIPTION
### Fixes [MC-11501](https://cloud-ops.atlassian.net/browse/MC-11501)

#### Changes made
- Added the API documentation for Trials Settings

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->