### PR TITLE
MC-11763: Create Workloads docs updated

### DIFF
--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -135,7 +135,6 @@ Create a daemon set in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set                      |
 | `metadata` <br/>_object_                   | The metadata of the daemon set                                            |
 | `metadata.name` <br/>_string_              | The name of the daemon set                                                |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the daemon set                   |
 | `spec.selector`<br/>_object_               | The label query over the daemon set's resources                           |
 | `spec.template`<br/>_object_               | The data a daemon set's pod should have when created                      |
@@ -145,6 +144,7 @@ Create a daemon set in a given [environment](#administration-environments).
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
 
 Return value:

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -76,3 +76,73 @@ Retrieve a daemon set and all its info in a given [environment](#administration-
 | `status`<br/>_object_                      | The status information of the daemon set                        |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE DAEMON SET -------------------->
+
+### Create a daemon set
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "metadata": {
+    "name": "daemonset-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "name": "fluentd-elasticsearch"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "fluentd-elasticsearch"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "fluentd-elasticsearch",
+            "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets</code>
+
+Create a daemon set in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                    |
+| ------------------------------------------ | --------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set                      |
+| `metadata` <br/>_object_                   | The metadata of the daemon set                                            |
+| `metadata.name` <br/>_string_              | The name of the daemon set                                                |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
+| `spec`<br/>_object_                        | The specification used to create and run the daemon set                   |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
+| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set |
+
+Return value:
+
+| Attributes                 | &nbsp;                                              |
+---------------------------- | ----------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the daemon set create task. |
+| `taskStatus` <br/>*string* | The status of the operation.                        |

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -83,10 +83,11 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/daemonsets"
   Content-Type: application/json
   {
   "apiVersion": "apps/v1",
+  "kind": "DaemonSet",
   "metadata": {
     "name": "daemonset-name",
     "namespace": "default"
@@ -129,20 +130,26 @@ curl -X POST \
 
 Create a daemon set in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                                    |
+| Required Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | --------------------------------------------------------------------------|
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set                      |
 | `metadata` <br/>_object_                   | The metadata of the daemon set                                            |
 | `metadata.name` <br/>_string_              | The name of the daemon set                                                |
 | `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the daemon set                   |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
+| `spec.selector`<br/>_object_               | The label query over the daemon set's resources                           |
 | `spec.template`<br/>_object_               | The data a daemon set's pod should have when created                      |
 | `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set |
+
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
 
 Return value:
 
 | Attributes                 | &nbsp;                                              |
 ---------------------------- | ----------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the daemon set create task. |
+| `taskId` <br/>*string*     | The id corresponding to the create daemon set task. |
 | `taskStatus` <br/>*string* | The status of the operation.                        |

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -76,13 +76,13 @@ curl -X GET \
 
 Retrieve a deployment and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the deployment                                        |
-| `deplomentStatus`<br/>_object_             | The status information of the deployment                        |
-| `readyRatio` <br/>_object_                 | The ratio of ready replicas to total replicas for a deployment  |
-| `metadata` <br/>_object_                   | The metadata of the deployment                                  |
-| `spec`<br/>_object_                        | The specification used to create and run the deployment         |
+| Attributes                                 | &nbsp;                                                            |
+| ------------------------------------------ | ----------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the deployment                                          |
+| `deplomentStatus`<br/>_object_             | The status information of the deployment                          |
+| `readyRatio` <br/>_object_                 | The ready replicas to total replicas ratio of this deployment set |
+| `metadata` <br/>_object_                   | The metadata of the deployment                                    |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment           |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -92,10 +92,11 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/deployments"
   Content-Type: application/json
   {
   "apiVersion": "apps/v1",
+  "kind": "Deployment",
   "metadata": {
     "name": "api-test-deployment-name",
     "namespace": "default"
@@ -138,20 +139,25 @@ curl -X POST \
 
 Create a deployment in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                                    |
+| Required Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment                      |
 | `metadata` <br/>_object_                   | The metadata of the deployment                                            |
 | `metadata.name` <br/>_string_              | The name of the deployment                                                |
 | `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the deployment                   |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
+| `spec.selector`<br/>_object_               | The label query over the deployment's set of resources                    |
 | `spec.template`<br/>_object_               | The data a deployment's pod should have when created                      |
 | `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
 
 Return value:
 
 | Attributes                 | &nbsp;                                                |
 ---------------------------- | ----------------------------------------------------- |
-| `taskId` <br/>*string*     | The id corresponding to the deployment create task.   |
+| `taskId` <br/>*string*     | The id corresponding to the create deployment task.   |
 | `taskStatus` <br/>*string* | The status of the operation.                          |

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -144,7 +144,6 @@ Create a deployment in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment                      |
 | `metadata` <br/>_object_                   | The metadata of the deployment                                            |
 | `metadata.name` <br/>_string_              | The name of the deployment                                                |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the deployment                   |
 | `spec.selector`<br/>_object_               | The label query over the deployment's set of resources                    |
 | `spec.template`<br/>_object_               | The data a deployment's pod should have when created                      |
@@ -153,6 +152,7 @@ Create a deployment in a given [environment](#administration-environments).
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
 
 Return value:

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -79,9 +79,79 @@ Retrieve a deployment and all its info in a given [environment](#administration-
 | Attributes                                 | &nbsp;                                                          |
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `id` <br/>_string_                         | The id of the deployment                                        |
+| `deplomentStatus`<br/>_object_             | The status information of the deployment                        |
+| `readyRatio` <br/>_object_                 | The ratio of ready replicas to total replicas for a deployment  |
 | `metadata` <br/>_object_                   | The metadata of the deployment                                  |
-| `images` <br/>_object_                     | The container images within a deployment                        |
 | `spec`<br/>_object_                        | The specification used to create and run the deployment         |
-| `status`<br/>_object_                      | The status information of the deployment                        |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE DEPLOYMENT -------------------->
+
+### Create a deployment
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "metadata": {
+    "name": "api-test-deployment-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments</code>
+
+Create a deployment in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment                      |
+| `metadata` <br/>_object_                   | The metadata of the deployment                                            |
+| `metadata.name` <br/>_string_              | The name of the deployment                                                |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment                   |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
+| `spec.template`<br/>_object_               | The data a deployment's pod should have when created                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                |
+---------------------------- | ----------------------------------------------------- |
+| `taskId` <br/>*string*     | The id corresponding to the deployment create task.   |
+| `taskStatus` <br/>*string* | The status of the operation.                          |

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -501,7 +501,6 @@ Required Attributes                 | &nbsp;
 `apiVersion` <br/>*string*          | The api version (versioned schema) of the pod
 `metadata` <br/>*object*            | The metadata of the pod
 `metadata.name` <br/>*string*       | The name of the pod
-`metadata.namespace` <br/>*string*  | The namespace in which the pod is created
 `spec`<br/>*object*                 | The specification used to create and run the pod
 `spec.container.image`<br/>*string* | The docker image name
 `spec.container.name`<br/>*string*  | The (unique) name of the container specified as a DNS_LABEL
@@ -509,6 +508,7 @@ Required Attributes                 | &nbsp;
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
 | `kind`<br/>_string_                       | The string value representing the REST resource this object represents  |
+| `metadata.namespace` <br/>*string*        | The namespace in which the pod is created                               |
 
 Return value:
 

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -457,6 +457,60 @@ Attributes | &nbsp;
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
+<!-------------------- CREATE POD -------------------->
+
+### Create a pod
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+  Content-Type: application/json
+  {
+	  "apiVersion": "v1",
+	  "metadata": {
+	  	"name": "edgar-allen-pod",
+		  "namespace": "default"
+  	},
+	  "spec": {
+		"containers": [
+			{
+				"image": "nginx",
+				"name": "nginx"
+			}
+		  ]
+	  }
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods</code>
+
+Create a pod in a given [environment](#administration-environments).
+
+Attributes                          | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>*string*          | The api version (versioned schema) of the pod
+`metadata` <br/>*object*            | The metadata of the pod
+`metadata.name` <br/>*string*       | The name of the pod
+`metadata.namespace` <br/>*string*  | The namespace in which the pod is created
+`spec`<br/>*object*                 | The specification used to create and run the pod
+`spec.container.image`<br/>*string* | The docker image name
+`spec.container.name`<br/>*string*  | The (unique) name of the container specified as a DNS_LABEL
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+---------------------------- | ---------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the pod create task. |
+| `taskStatus` <br/>*string* | The status of the operation.                 |
 
 
 <!-------------------- DELETE POD -------------------->
@@ -483,7 +537,7 @@ curl -X DELETE \
 
 Delete a pod from a given [environment](#administration-environments).
 
-Attributes | &nbsp;
-------- | -----------
-`taskId` <br/>*string* | The task id related to the delete pod.
-`taskStatus` <br/>*string* | The status of the operation
+| Attributes                 | &nbsp;                                       |
+---------------------------- | ---------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the pod delete task. |
+| `taskStatus` <br/>*string* | The status of the operation.                 |

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -467,6 +467,7 @@ curl -X POST \
   Content-Type: application/json
   {
 	  "apiVersion": "v1",
+    "kind": "Pod",
 	  "metadata": {
 	  	"name": "edgar-allen-pod",
 		  "namespace": "default"
@@ -495,7 +496,7 @@ curl -X POST \
 
 Create a pod in a given [environment](#administration-environments).
 
-Attributes                          | &nbsp;
+Required Attributes                 | &nbsp;
 ----------------------------------- | ------------------------------------------------------------
 `apiVersion` <br/>*string*          | The api version (versioned schema) of the pod
 `metadata` <br/>*object*            | The metadata of the pod
@@ -505,11 +506,15 @@ Attributes                          | &nbsp;
 `spec.container.image`<br/>*string* | The docker image name
 `spec.container.name`<br/>*string*  | The (unique) name of the container specified as a DNS_LABEL
 
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                       | The string value representing the REST resource this object represents  |
+
 Return value:
 
 | Attributes                 | &nbsp;                                       |
 ---------------------------- | ---------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the pod create task. |
+| `taskId` <br/>*string*     | The id corresponding to the create pod task. |
 | `taskStatus` <br/>*string* | The status of the operation.                 |
 
 
@@ -539,5 +544,5 @@ Delete a pod from a given [environment](#administration-environments).
 
 | Attributes                 | &nbsp;                                       |
 ---------------------------- | ---------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the pod delete task. |
+| `taskId` <br/>*string*     | The id corresponding to the delete pod task. |
 | `taskStatus` <br/>*string* | The status of the operation.                 |

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -96,6 +96,7 @@ curl -X POST \
   Content-Type: application/json
   {
   "apiVersion": "apps/v1",
+  "kind": "StatefulSet",
   "metadata": {
     "name": "stateful-set-name",
     "namespace": "default"
@@ -139,20 +140,25 @@ curl -X POST \
 
 Create a stateful set in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                                      |
+| Required Attributes                        | &nbsp;                                                                      |
 | ------------------------------------------ | ----------------------------------------------------------------------------|
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set                      |
 | `metadata` <br/>_object_                   | The metadata of the stateful set                                            |
 | `metadata.name` <br/>_string_              | The name of the stateful set                                                |
 | `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the stateful set                   |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set          |
+| `spec.selector`<br/>_object_               | The label query over the stateful set's of resources                        |
 | `spec.template`<br/>_object_               | The data a stateful set's pod should have when created                      |
 | `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the stateful set |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set        |
 
 Return value:
 
 | Attributes                 | &nbsp;                                                |
 ---------------------------- | ------------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the stateful set create task. |
+| `taskId` <br/>*string*     | The id corresponding to the create stateful set task. |
 | `taskStatus` <br/>*string* | The status of the operation.                          |

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -145,7 +145,6 @@ Create a stateful set in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set                      |
 | `metadata` <br/>_object_                   | The metadata of the stateful set                                            |
 | `metadata.name` <br/>_string_              | The name of the stateful set                                                |
-| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the stateful set                   |
 | `spec.selector`<br/>_object_               | The label query over the stateful set's of resources                        |
 | `spec.template`<br/>_object_               | The data a stateful set's pod should have when created                      |
@@ -154,6 +153,7 @@ Create a stateful set in a given [environment](#administration-environments).
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                        |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set        |
 
 Return value:

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -85,3 +85,74 @@ Retrieve a stateful set and all its info in a given [environment](#administratio
 | `status`<br/>*object*                      | The status information of the stateful set                      |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE A STATEFUL SET -------------------->
+
+### Create a stateful set
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "metadata": {
+    "name": "stateful-set-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "k8s.gcr.io/nginx-slim:0.8"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets</code>
+
+
+Create a stateful set in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                      |
+| ------------------------------------------ | ----------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set                      |
+| `metadata` <br/>_object_                   | The metadata of the stateful set                                            |
+| `metadata.name` <br/>_string_              | The name of the stateful set                                                |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                          |
+| `spec`<br/>_object_                        | The specification used to create and run the stateful set                   |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set          |
+| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the stateful set |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                |
+---------------------------- | ------------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the stateful set create task. |
+| `taskStatus` <br/>*string* | The status of the operation.                          |

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -88,3 +88,73 @@ Retrieve a daemon set and all its info in a given [environment](#administration-
 | `status`<br/>_object_    | The status information of the daemon set                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE DAEMON SET -------------------->
+
+#### Create a daemon set
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "metadata": {
+    "name": "daemonset-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "name": "fluentd-elasticsearch"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "fluentd-elasticsearch"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "fluentd-elasticsearch",
+            "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets</code>
+
+Create a daemon set in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                    |
+| ------------------------------------------ | --------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set                      |
+| `metadata` <br/>_object_                   | The metadata of the daemon set                                            |
+| `metadata.name` <br/>_string_              | The name of the daemon set                                                |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
+| `spec`<br/>_object_                        | The specification used to create and run the daemon set                   |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
+| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set |
+
+Return value:
+
+| Attributes                 | &nbsp;                                              |
+---------------------------- | ----------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the daemon set create task. |
+| `taskStatus` <br/>*string* | The status of the operation.                        |

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -146,7 +146,6 @@ Create a daemon set in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set                      |
 | `metadata` <br/>_object_                   | The metadata of the daemon set                                            |
 | `metadata.name` <br/>_string_              | The name of the daemon set                                                |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the daemon set                   |
 | `spec.selector`<br/>_object_               | The label query over the daemon set's resources                           |
 | `spec.template`<br/>_object_               | The data a daemon set's pod should have when created                      |
@@ -155,6 +154,7 @@ Create a daemon set in a given [environment](#administration-environments).
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
 
 Return value:

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -95,7 +95,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/daemonsets?cluster_id=a_cluster_id"
   Content-Type: application/json
   {
   "apiVersion": "apps/v1",
@@ -137,24 +137,29 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets?cluster_id=:cluster_id</code>
 
 Create a daemon set in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                                    |
+| Required Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | --------------------------------------------------------------------------|
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set                      |
 | `metadata` <br/>_object_                   | The metadata of the daemon set                                            |
 | `metadata.name` <br/>_string_              | The name of the daemon set                                                |
 | `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the daemon set                   |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
+| `spec.selector`<br/>_object_               | The label query over the daemon set's resources                           |
 | `spec.template`<br/>_object_               | The data a daemon set's pod should have when created                      |
 | `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
 
 Return value:
 
 | Attributes                 | &nbsp;                                              |
 ---------------------------- | ----------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the daemon set create task. |
+| `taskId` <br/>*string*     | The id corresponding to the create daemon set task. |
 | `taskStatus` <br/>*string* | The status of the operation.                        |

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -38,13 +38,14 @@ Retrieve a list of all deployments in a given [environment](#administration-envi
 | -------------------------- | ------------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to list the deployments. |
 
-| Attributes                         | &nbsp;                                                  |
-| ---------------------------------- | ------------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the deployment                                |
-| `metadata` <br/>_object_           | The metadata of the deployment                          |
-| `images` <br/>_object_             | The container images within a deployment                |
-| `spec`<br/>_object_                | The specification used to create and run the deployment |
-| `status`<br/>_object_              | The status information of the deployment                |
+| Attributes                         | &nbsp;                                                            |
+| ---------------------------------- | ----------------------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the deployment                                          |
+| `metadata` <br/>_object_           | The metadata of the deployment                                    |
+| `images` <br/>_object_             | The container images within a deployment                          |
+| `spec`<br/>_object_                | The specification used to create and run the deployment           |
+| `readyRatio` <br/>_object_         | The ready replicas to total replicas ratio of this deployment set |
+| `deploymentStatus`<br/>_object_    | The status information of the deployment                          |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -83,13 +84,14 @@ Retrieve a deployment and all its info in a given [environment](#administration-
 | -------------------------- | ----------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to get the deployment. |
 
-| Attributes                         | &nbsp;                                                  |
-| ---------------------------------- | ------------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the deployment                                |
-| `metadata` <br/>_object_           | The metadata of the deployment                          |
-| `images` <br/>_object_             | The container images within a deployment                |
-| `spec`<br/>_object_                | The specification used to create and run the deployment |
-| `status`<br/>_object_              | The status information of the deployment                |
+| Attributes                         | &nbsp;                                                            |
+| ---------------------------------- | ----------------------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the deployment                                          |
+| `metadata` <br/>_object_           | The metadata of the deployment                                    |
+| `images` <br/>_object_             | The container images within a deployment                          |
+| `spec`<br/>_object_                | The specification used to create and run the deployment           |
+| `readyRatio` <br/>_object_         | The ready replicas to total replicas ratio of this deployment set |
+| `deploymentStatus`<br/>_object_    | The status information of the deployment                          |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -99,10 +101,11 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/deployments?cluster_id=a_cluster_id"
   Content-Type: application/json
   {
   "apiVersion": "apps/v1",
+  "kind": "Deployment",
   "metadata": {
     "name": "api-test-deployment-name",
     "namespace": "default"
@@ -141,24 +144,29 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments?cluster_id=:cluster_id</code>
 
 Create a deployment in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                                    |
+| Required Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment                      |
 | `metadata` <br/>_object_                   | The metadata of the deployment                                            |
 | `metadata.name` <br/>_string_              | The name of the deployment                                                |
 | `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the deployment                   |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
+| `spec.selector`<br/>_object_               | The label query over the deployment's set of resources                    |
 | `spec.template`<br/>_object_               | The data a deployment's pod should have when created                      |
 | `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
 
 Return value:
 
 | Attributes                 | &nbsp;                                                |
 ---------------------------- | ----------------------------------------------------- |
-| `taskId` <br/>*string*     | The id corresponding to the deployment create task.   |
+| `taskId` <br/>*string*     | The id corresponding to the create deployment task.   |
 | `taskStatus` <br/>*string* | The status of the operation.                          |

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -153,7 +153,6 @@ Create a deployment in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment                      |
 | `metadata` <br/>_object_                   | The metadata of the deployment                                            |
 | `metadata.name` <br/>_string_              | The name of the deployment                                                |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the deployment                   |
 | `spec.selector`<br/>_object_               | The label query over the deployment's set of resources                    |
 | `spec.template`<br/>_object_               | The data a deployment's pod should have when created                      |
@@ -162,6 +161,7 @@ Create a deployment in a given [environment](#administration-environments).
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
 
 Return value:

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -92,3 +92,73 @@ Retrieve a deployment and all its info in a given [environment](#administration-
 | `status`<br/>_object_              | The status information of the deployment                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE DEPLOYMENT -------------------->
+
+### Create a deployment
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "metadata": {
+    "name": "api-test-deployment-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments</code>
+
+Create a deployment in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment                      |
+| `metadata` <br/>_object_                   | The metadata of the deployment                                            |
+| `metadata.name` <br/>_string_              | The name of the deployment                                                |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment                   |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
+| `spec.template`<br/>_object_               | The data a deployment's pod should have when created                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                |
+---------------------------- | ----------------------------------------------------- |
+| `taskId` <br/>*string*     | The id corresponding to the deployment create task.   |
+| `taskStatus` <br/>*string* | The status of the operation.                          |

--- a/source/includes/kubernetes_extension/_k8_pods.md
+++ b/source/includes/kubernetes_extension/_k8_pods.md
@@ -510,7 +510,6 @@ Required Attributes                 | &nbsp;
 `apiVersion` <br/>*string*          | The api version (versioned schema) of the pod
 `metadata` <br/>*object*            | The metadata of the pod
 `metadata.name` <br/>*string*       | The name of the pod
-`metadata.namespace` <br/>*string*  | The namespace in which the pod is created
 `spec`<br/>*object*                 | The specification used to create and run the pod
 `spec.container.image`<br/>*string* | The docker image name
 `spec.container.name`<br/>*string*  | The (unique) name of the container specified as a DNS_LABEL
@@ -518,6 +517,7 @@ Required Attributes                 | &nbsp;
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
 | `kind`<br/>_string_                       | The string value representing the REST resource this object represents  |
+| `metadata.namespace` <br/>*string*        | The namespace in which the pod is created                               |
 
 Return value:
 

--- a/source/includes/kubernetes_extension/_k8_pods.md
+++ b/source/includes/kubernetes_extension/_k8_pods.md
@@ -476,6 +476,7 @@ curl -X POST \
   Content-Type: application/json
   {
 	  "apiVersion": "v1",
+    "kind": "Pod",
 	  "metadata": {
 	  	"name": "edgar-allen-pod",
 		  "namespace": "default"
@@ -504,7 +505,7 @@ curl -X POST \
 
 Create a pod in a given [environment](#administration-environments).
 
-Attributes                          | &nbsp;
+Required Attributes                 | &nbsp;
 ----------------------------------- | ------------------------------------------------------------
 `apiVersion` <br/>*string*          | The api version (versioned schema) of the pod
 `metadata` <br/>*object*            | The metadata of the pod
@@ -514,11 +515,15 @@ Attributes                          | &nbsp;
 `spec.container.image`<br/>*string* | The docker image name
 `spec.container.name`<br/>*string*  | The (unique) name of the container specified as a DNS_LABEL
 
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                       | The string value representing the REST resource this object represents  |
+
 Return value:
 
 | Attributes                 | &nbsp;                                       |
 ---------------------------- | ---------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the pod create task. |
+| `taskId` <br/>*string*     | The id corresponding to the create pod task. |
 | `taskStatus` <br/>*string* | The status of the operation.                 |
 
 
@@ -554,5 +559,5 @@ Required | &nbsp;
 
 Attributes | &nbsp;
 ------- | -----------
-`taskId` <br/>*string* | The task id related to the delete pod.
+`taskId` <br/>*string* | The task id related to the delete pod task.
 `taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/kubernetes_extension/_k8_pods.md
+++ b/source/includes/kubernetes_extension/_k8_pods.md
@@ -466,6 +466,61 @@ Attributes | &nbsp;
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
+<!-------------------- CREATE POD -------------------->
+
+#### Create a pod
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
+  Content-Type: application/json
+  {
+	  "apiVersion": "v1",
+	  "metadata": {
+	  	"name": "edgar-allen-pod",
+		  "namespace": "default"
+  	},
+	  "spec": {
+		"containers": [
+			{
+				"image": "nginx",
+				"name": "nginx"
+			}
+		  ]
+	  }
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods</code>
+
+Create a pod in a given [environment](#administration-environments).
+
+Attributes                          | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>*string*          | The api version (versioned schema) of the pod
+`metadata` <br/>*object*            | The metadata of the pod
+`metadata.name` <br/>*string*       | The name of the pod
+`metadata.namespace` <br/>*string*  | The namespace in which the pod is created
+`spec`<br/>*object*                 | The specification used to create and run the pod
+`spec.container.image`<br/>*string* | The docker image name
+`spec.container.name`<br/>*string*  | The (unique) name of the container specified as a DNS_LABEL
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+---------------------------- | ---------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the pod create task. |
+| `taskStatus` <br/>*string* | The status of the operation.                 |
+
 
 
 <!-------------------- DELETE POD -------------------->

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -96,10 +96,11 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets?cluster_id=a_cluster_id"
   Content-Type: application/json
   {
   "apiVersion": "apps/v1",
+  "kind":"StatefulSet",
   "metadata": {
     "name": "stateful-set-name",
     "namespace": "default"
@@ -138,25 +139,30 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets?cluster_id=:cluster_id</code>
 
 
 Create a stateful set in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                                      |
+| Required Attributes                        | &nbsp;                                                                      |
 | ------------------------------------------ | ----------------------------------------------------------------------------|
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set                      |
 | `metadata` <br/>_object_                   | The metadata of the stateful set                                            |
 | `metadata.name` <br/>_string_              | The name of the stateful set                                                |
 | `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the stateful set                   |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set          |
+| `spec.selector`<br/>_object_               | The label query over the stateful set's resources                           |
 | `spec.template`<br/>_object_               | The data a stateful set's pod should have when created                      |
 | `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the stateful set |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set        |
 
 Return value:
 
 | Attributes                 | &nbsp;                                                |
 ---------------------------- | ------------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the stateful set create task. |
+| `taskId` <br/>*string*     | The id corresponding to the create stateful set task. |
 | `taskStatus` <br/>*string* | The status of the operation.                          |

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -89,3 +89,74 @@ Retrieve a stateful set and all its info in a given [environment](#administratio
 | `status`<br/>_object_                      | The status information of the stateful set                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE A STATEFUL SET -------------------->
+
+#### Create a stateful set
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "metadata": {
+    "name": "stateful-set-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "k8s.gcr.io/nginx-slim:0.8"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets</code>
+
+
+Create a stateful set in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                      |
+| ------------------------------------------ | ----------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set                      |
+| `metadata` <br/>_object_                   | The metadata of the stateful set                                            |
+| `metadata.name` <br/>_string_              | The name of the stateful set                                                |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                          |
+| `spec`<br/>_object_                        | The specification used to create and run the stateful set                   |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set          |
+| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the stateful set |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                |
+---------------------------- | ------------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the stateful set create task. |
+| `taskStatus` <br/>*string* | The status of the operation.                          |

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -149,7 +149,6 @@ Create a stateful set in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set                      |
 | `metadata` <br/>_object_                   | The metadata of the stateful set                                            |
 | `metadata.name` <br/>_string_              | The name of the stateful set                                                |
-| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                          |
 | `spec`<br/>_object_                        | The specification used to create and run the stateful set                   |
 | `spec.selector`<br/>_object_               | The label query over the stateful set's resources                           |
 | `spec.template`<br/>_object_               | The data a stateful set's pod should have when created                      |
@@ -158,6 +157,7 @@ Create a stateful set in a given [environment](#administration-environments).
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                        |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set        |
 
 Return value:


### PR DESCRIPTION
### Fixes [MC-11763](https://cloud-ops.atlassian.net/browse/MC-11763)

#### Changes made
<!-- Changes should match the template provided below -->
- Deamonset, Deployment, Pod, and statefulset api docs updated to include create method

#### Related PRs
- [This bad boi](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/95)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->