### PR TITLE
MC-11761 Adds delete workload documentation

### DIFF
--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -175,9 +175,9 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
 
-Delete a daemon sets from a given [environment](#administration-environments).
+Delete a daemon set from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                       |
-| -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                 |
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete daemon set task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -153,3 +153,31 @@ Return value:
 ---------------------------- | ----------------------------------------------------|
 | `taskId` <br/>*string*     | The id corresponding to the create daemon set task. |
 | `taskStatus` <br/>*string* | The status of the operation.                        |
+
+<!-------------------- DELETE DAEMON SET -------------------->
+
+### Delete a daemon set
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/daemonsets/nginx-ingress-controller/ingress-nginx"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
+
+Delete a daemon sets from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -185,7 +185,7 @@ curl -X DELETE \
 
 Delete a deployment from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                       |
-| -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                 |
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete deployment task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -161,3 +161,31 @@ Return value:
 ---------------------------- | ----------------------------------------------------- |
 | `taskId` <br/>*string*     | The id corresponding to the create deployment task.   |
 | `taskStatus` <br/>*string* | The status of the operation.                          |
+
+<!-------------------- DELETE DEPLOYMENT -------------------->
+
+### Delete a deployment
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/deployments/dex/auth"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id</code>
+
+Delete a deployment from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -162,3 +162,31 @@ Return value:
 ---------------------------- | ------------------------------------------------------|
 | `taskId` <br/>*string*     | The id corresponding to the create stateful set task. |
 | `taskStatus` <br/>*string* | The status of the operation.                          |
+
+<!-------------------- DELETE STATEFUL SET -------------------->
+
+### Delete a stateful set
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets/my-aerospike/default"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id</code>
+
+Delete a stateful set from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -186,7 +186,7 @@ curl -X DELETE \
 
 Delete a stateful set from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                       |
-| -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                 |
+| Attributes                 | &nbsp;                                                |
+| -------------------------- | ----------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete stateful set task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                          |

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -185,9 +185,9 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id?cluster_id=:cluster_id</code>
 
-Delete a daemon sets from a given [environment](#administration-environments).
+Delete a daemon set from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                       |
-| -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                 |
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete daemon set task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -162,4 +162,32 @@ Return value:
 | Attributes                 | &nbsp;                                              |
 ---------------------------- | ----------------------------------------------------|
 | `taskId` <br/>*string*     | The id corresponding to the create daemon set task. |
-| `taskStatus` <br/>*string* | The status of the operation.                        |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |
+
+<!-------------------- DELETE DAEMON SET -------------------->
+
+#### Delete a daemon set
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/daemonsets/nginx-ingress-controller/ingress-nginx?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id?cluster_id=:cluster_id</code>
+
+Delete a daemon sets from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -194,7 +194,7 @@ curl -X DELETE \
 
 Delete a deployment from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                       |
-| -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                 |
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete deployment task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -169,4 +169,32 @@ Return value:
 | Attributes                 | &nbsp;                                                |
 ---------------------------- | ----------------------------------------------------- |
 | `taskId` <br/>*string*     | The id corresponding to the create deployment task.   |
-| `taskStatus` <br/>*string* | The status of the operation.                          |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |
+
+<!-------------------- DELETE DEPLOYMENT -------------------->
+
+#### Delete a deployment
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/deployments/dex/auth?cluster_id=a_cluster_id?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id?cluster_id=:cluster_id</code>
+
+Delete a deployment from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -166,3 +166,31 @@ Return value:
 ---------------------------- | ------------------------------------------------------|
 | `taskId` <br/>*string*     | The id corresponding to the create stateful set task. |
 | `taskStatus` <br/>*string* | The status of the operation.                          |
+
+<!-------------------- DELETE STATEFUL SET -------------------->
+
+#### Delete a stateful set
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets/my-aerospike/default"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id?cluster_id=:cluster_id</code>
+
+Delete a stateful set from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -190,7 +190,7 @@ curl -X DELETE \
 
 Delete a stateful set from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                       |
-| -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                 |
+| Attributes                 | &nbsp;                                                |
+| -------------------------- | ----------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete stateful set task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                          |


### PR DESCRIPTION
### Fixes [MC-11761 ](https://cloud-ops.atlassian.net/browse/MC-11761)

#### Changes made
<!-- Changes should match the template provided below -->

- Adds delete workload (daemon sets, deployments and stateful sets) documentation
- Use tool to auto-format documents