### PR TITLE
MC-11912:API-document-for-PVC

### DIFF
--- a/source/includes/azure/_k8_persistentvolumeclaims.md.erb
+++ b/source/includes/azure/_k8_persistentvolumeclaims.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_persistentvolumeclaims.md" %>

--- a/source/includes/gcp/_k8_persistentvolumeclaims.md.erb
+++ b/source/includes/gcp/_k8_persistentvolumeclaims.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_persistentvolumeclaims.md" %>

--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -1,0 +1,167 @@
+## Persistent Volume Claims
+
+<!-------------------- LIST Persistent volume claims -------------------->
+
+#### List persistent volume claims
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+   "data":[
+     {
+         "id":"cmc-staging-mysql/cmc-stg",
+         "metadata":{
+            "annotations":{
+               "pv.kubernetes.io/bind-completed":"yes",
+               "pv.kubernetes.io/bound-by-controller":"yes",
+               "volume.beta.kubernetes.io/storage-provisioner":"rook-ceph.rbd.csi.ceph.com"
+            },
+            "creationTimestamp":"2020-04-27T12:01:22.000-04:00",
+            "finalizers":[
+               "kubernetes.io/pvc-protection"
+            ],
+            "labels":{
+               "app":"cmc-staging-mysql",
+               "chart":"mysql-0.4.5",
+               "heritage":"Helm",
+               "release":"cmc-staging"
+            },
+            "name":"cmc-staging-mysql",
+            "namespace":"cmc-stg",
+            "resourceVersion":"111495311",
+            "selfLink":"/api/v1/namespaces/cmc-stg/persistentvolumeclaims/cmc-staging-mysql",
+            "uid":"ba115a65-e3c5-4e37-8548-e37ec395e79f"
+         },
+         "spec":{
+            "accessModes":[
+               "ReadWriteOnce"
+            ],
+            "resources":{
+               "requests":{
+                  "storage":"8Gi"
+               }
+            },
+            "storageClassName":"rook-ceph-block",
+            "volumeMode":"Filesystem",
+            "volumeName":"pvc-ba115a65-e3c5-4e37-8548-e37ec395e79f"
+         },
+         "status":{
+            "accessModes":[
+               "ReadWriteOnce"
+            ],
+            "capacity":{
+               "storage":"8Gi"
+            },
+            "phase":"Bound"
+         }
+      }
+   ],
+   "metadata":{
+      "recordCount":1
+   }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims</code>
+
+Retrieve a list of all persistent volumes in a given [environment](#administration-environments).
+
+| Attributes                            | &nbsp;                                                                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_ | The id of the persistent volume claim. This is the name of the resource. |
+| `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
+| `spec` <br/>_object_ | The specification of the persistent volume claim. |
+| `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
+| `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
+| `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
+| `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
+
+
+<!-------------------- GET A persistent volume -------------------->
+
+#### Get a persistent volume
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/cmc-staging-mysql/cmc-stg"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "cmc-staging-mysql/cmc-stg",
+    "apiVersion": "v1",
+    "kind": "PersistentVolumeClaim",
+    "metadata": {
+      "annotations": {
+        "pv.kubernetes.io/bind-completed": "yes",
+        "pv.kubernetes.io/bound-by-controller": "yes",
+        "volume.beta.kubernetes.io/storage-provisioner": "rook-ceph.rbd.csi.ceph.com"
+      },
+      "creationTimestamp": "2020-04-27T12:01:22.000-04:00",
+      "finalizers": [
+        "kubernetes.io/pvc-protection"
+      ],
+      "labels": {
+        "app": "cmc-staging-mysql",
+        "chart": "mysql-0.4.5",
+        "heritage": "Helm",
+        "release": "cmc-staging"
+      },
+      "name": "cmc-staging-mysql",
+      "namespace": "cmc-stg",
+      "resourceVersion": "111495311",
+      "selfLink": "/api/v1/namespaces/cmc-stg/persistentvolumeclaims/cmc-staging-mysql",
+      "uid": "ba115a65-e3c5-4e37-8548-e37ec395e79f"
+    },
+    "spec": {
+      "accessModes": [
+        "ReadWriteOnce"
+      ],
+      "resources": {
+        "requests": {
+          "storage": "8Gi"
+        }
+      },
+      "storageClassName": "rook-ceph-block",
+      "volumeMode": "Filesystem",
+      "volumeName": "pvc-ba115a65-e3c5-4e37-8548-e37ec395e79f"
+    },
+    "status": {
+      "accessModes": [
+        "ReadWriteOnce"
+      ],
+      "capacity": {
+        "storage": "8Gi"
+      },
+      "phase": "Bound"
+    }
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id</code>
+
+Retrieve a persistent volume and all its info in a given [environment](#administration-environments).
+
+| Attributes                            | &nbsp;                                                                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_ | The id of the persistent volume claim. This is the name of the resource. |
+| `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
+| `spec` <br/>_object_ | The specification of the persistent volume claim. |
+| `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
+| `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
+| `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
+| `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |

--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -71,11 +71,11 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims</code>
 
-Retrieve a list of all persistent volumes in a given [environment](#administration-environments).
+Retrieve a list of all persistent volume claims in a given [environment](#administration-environments).
 
 | Attributes                            | &nbsp;                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id` <br/>_string_ | The id of the persistent volume claim. This is the name of the resource. |
+| `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
 | `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
@@ -85,9 +85,9 @@ Retrieve a list of all persistent volumes in a given [environment](#administrati
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
 
 
-<!-------------------- GET A persistent volume -------------------->
+<!-------------------- GET A persistent volume claim-------------------->
 
-#### Get a persistent volume
+#### Get a persistent volume claim
 
 ```shell
 curl -X GET \
@@ -153,11 +153,11 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id</code>
 
-Retrieve a persistent volume and all its info in a given [environment](#administration-environments).
+Retrieve a persistent volume claim and all its info in a given [environment](#administration-environments).
 
 | Attributes                            | &nbsp;                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id` <br/>_string_ | The id of the persistent volume claim. This is the name of the resource. |
+| `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
 | `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |

--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -78,13 +78,14 @@ Retrieve a list of all persistent volume claims in a given [environment](#admini
 | `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
-| `spec.accessModes` <br/>_string_ | The requested accessMode for the persistent volume. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
-| `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
+| `spec.accessModes` <br/>_string_ | The requested access mode. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.resources.requests.storage` <br/>_string_ | The requested storage capacity of the persistent volume. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
-| `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
-| `status.accessModes` <br/>_string_ | Defined access mode of the persistent volume claimed. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
-| `status.capacity.phase` <br/>_string_ | Allocated storage capacity of the persistent volume. |
+| `status` <br/>_object_ | The status of the persistent volume claim. |
+| `status.phase` <br/>_string_ | The claim is in one of the following phases: `Pending`, `Bound`, `Lost` or `Terminating`. |
+| `status.accessModes` <br/>_string_ | The allocated access mode. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
+| `status.capacity.storage` <br/>_string_ | The allocated storage capacity. |
 
 
 
@@ -163,10 +164,11 @@ Retrieve a persistent volume claim and all its info in a given [environment](#ad
 | `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
-| `spec.accessModes` <br/>_string_ | The requested accessMode for the persistent volume. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
-| `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
+| `spec.accessModes` <br/>_string_ | The requested access mode. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.resources.requests.storage` <br/>_string_ | The requested storage capacity of the persistent volume. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
-| `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
-| `status.accessModes` <br/>_string_ | Defined access mode of the persistent volume claimed. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
-| `status.capacity.phase` <br/>_string_ | Allocated storage capacity of the persistent volume. |
+| `status` <br/>_object_ | The status of the persistent volume claim. |
+| `status.phase` <br/>_string_ | The claim is in one of the following phases: `Pending`, `Bound`, `Lost` or `Terminating`. |
+| `status.accessModes` <br/>_string_ | The allocated access mode. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
+| `status.capacity.storage` <br/>_string_ | The allocated storage capacity. |

--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -78,11 +78,14 @@ Retrieve a list of all persistent volume claims in a given [environment](#admini
 | `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
-| `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.accessModes` <br/>_string_ | The requested accessMode for the persistent volume. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
 | `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
+| `status.accessModes` <br/>_string_ | Defined access mode of the persistent volume claimed. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
+| `status.capacity.phase` <br/>_string_ | Allocated storage capacity of the persistent volume. |
+
 
 
 <!-------------------- GET A persistent volume claim-------------------->
@@ -160,8 +163,10 @@ Retrieve a persistent volume claim and all its info in a given [environment](#ad
 | `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
-| `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.accessModes` <br/>_string_ | The requested accessMode for the persistent volume. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
 | `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
+| `status.accessModes` <br/>_string_ | Defined access mode of the persistent volume claimed. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
+| `status.capacity.phase` <br/>_string_ | Allocated storage capacity of the persistent volume. |

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -1,0 +1,177 @@
+### Persistent Volume Claims
+
+<!-------------------- LIST Persistent volume claims -------------------->
+
+#### List persistent volume claims
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+   "data":[
+     {
+         "id":"cmc-staging-mysql/cmc-stg",
+         "metadata":{
+            "annotations":{
+               "pv.kubernetes.io/bind-completed":"yes",
+               "pv.kubernetes.io/bound-by-controller":"yes",
+               "volume.beta.kubernetes.io/storage-provisioner":"rook-ceph.rbd.csi.ceph.com"
+            },
+            "creationTimestamp":"2020-04-27T12:01:22.000-04:00",
+            "finalizers":[
+               "kubernetes.io/pvc-protection"
+            ],
+            "labels":{
+               "app":"cmc-staging-mysql",
+               "chart":"mysql-0.4.5",
+               "heritage":"Helm",
+               "release":"cmc-staging"
+            },
+            "name":"cmc-staging-mysql",
+            "namespace":"cmc-stg",
+            "resourceVersion":"111495311",
+            "selfLink":"/api/v1/namespaces/cmc-stg/persistentvolumeclaims/cmc-staging-mysql",
+            "uid":"ba115a65-e3c5-4e37-8548-e37ec395e79f"
+         },
+         "spec":{
+            "accessModes":[
+               "ReadWriteOnce"
+            ],
+            "resources":{
+               "requests":{
+                  "storage":"8Gi"
+               }
+            },
+            "storageClassName":"rook-ceph-block",
+            "volumeMode":"Filesystem",
+            "volumeName":"pvc-ba115a65-e3c5-4e37-8548-e37ec395e79f"
+         },
+         "status":{
+            "accessModes":[
+               "ReadWriteOnce"
+            ],
+            "capacity":{
+               "storage":"8Gi"
+            },
+            "phase":"Bound"
+         }
+      }
+   ],
+   "metadata":{
+      "recordCount":1
+   }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims?cluster_id=:cluster_id</code>
+
+Retrieve a list of all persistent volumes in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                                      |	
+| -------------------------- | ----------------------------------------------------------- |	
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the persistent volume claims. |	
+
+
+| Attributes                            | &nbsp;                                                                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_ | The id of the persistent volume claim. This is the name of the resource. |
+| `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
+| `spec` <br/>_object_ | The specification of the persistent volume claim. |
+| `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
+| `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
+| `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
+| `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
+
+
+<!-------------------- GET A persistent volume -------------------->
+
+#### Get a persistent volume
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/cmc-staging-mysql/cmc-stg"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "cmc-staging-mysql/cmc-stg",
+    "apiVersion": "v1",
+    "kind": "PersistentVolumeClaim",
+    "metadata": {
+      "annotations": {
+        "pv.kubernetes.io/bind-completed": "yes",
+        "pv.kubernetes.io/bound-by-controller": "yes",
+        "volume.beta.kubernetes.io/storage-provisioner": "rook-ceph.rbd.csi.ceph.com"
+      },
+      "creationTimestamp": "2020-04-27T12:01:22.000-04:00",
+      "finalizers": [
+        "kubernetes.io/pvc-protection"
+      ],
+      "labels": {
+        "app": "cmc-staging-mysql",
+        "chart": "mysql-0.4.5",
+        "heritage": "Helm",
+        "release": "cmc-staging"
+      },
+      "name": "cmc-staging-mysql",
+      "namespace": "cmc-stg",
+      "resourceVersion": "111495311",
+      "selfLink": "/api/v1/namespaces/cmc-stg/persistentvolumeclaims/cmc-staging-mysql",
+      "uid": "ba115a65-e3c5-4e37-8548-e37ec395e79f"
+    },
+    "spec": {
+      "accessModes": [
+        "ReadWriteOnce"
+      ],
+      "resources": {
+        "requests": {
+          "storage": "8Gi"
+        }
+      },
+      "storageClassName": "rook-ceph-block",
+      "volumeMode": "Filesystem",
+      "volumeName": "pvc-ba115a65-e3c5-4e37-8548-e37ec395e79f"
+    },
+    "status": {
+      "accessModes": [
+        "ReadWriteOnce"
+      ],
+      "capacity": {
+        "storage": "8Gi"
+      },
+      "phase": "Bound"
+    }
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id?cluster_id=:cluster_id</code>
+
+Retrieve a persistent volume and all its info in a given [environment](#administration-environments).
+
+		
+| Required                   | &nbsp;                                                      |	
+| -------------------------- | ----------------------------------------------------------- |	
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the persistent volume claim. |
+
+| Attributes                            | &nbsp;                                                                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_ | The id of the persistent volume claim. This is the name of the resource. |
+| `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
+| `spec` <br/>_object_ | The specification of the persistent volume claim. |
+| `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
+| `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
+| `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
+| `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -158,7 +158,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id?cluster_id=:cluster_id</code>
 
-Retrieve a persistent volume claims and all its info in a given [environment](#administration-environments).
+Retrieve a persistent volume claim and all its info in a given [environment](#administration-environments).
 
 		
 | Required                   | &nbsp;                                                      |	

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -83,12 +83,13 @@ Retrieve a list of all persistent volume claims in a given [environment](#admini
 | `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
-| `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.accessModes` <br/>_string_ | The requested accessMode for the persistent volume. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
 | `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
-
+| `status.accessModes` <br/>_string_ | Defined access mode of the persistent volume claimed. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
+| `status.capacity.phase` <br/>_string_ | Allocated storage capacity of the persistent volume. |
 
 <!-------------------- GET A persistent volume claim -------------------->
 
@@ -170,8 +171,10 @@ Retrieve a persistent volume claim and all its info in a given [environment](#ad
 | `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
-| `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.accessModes` <br/>_string_ | The requested accessMode for the persistent volume. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
 | `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
+| `status.accessModes` <br/>_string_ | Defined access mode of the persistent volume claimed. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
+| `status.capacity.phase` <br/>_string_ | Allocated storage capacity of the persistent volume. |

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -71,7 +71,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims?cluster_id=:cluster_id</code>
 
-Retrieve a list of all persistent volumes in a given [environment](#administration-environments).
+Retrieve a list of all persistent volume claims in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                                      |	
 | -------------------------- | ----------------------------------------------------------- |	
@@ -80,7 +80,7 @@ Retrieve a list of all persistent volumes in a given [environment](#administrati
 
 | Attributes                            | &nbsp;                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id` <br/>_string_ | The id of the persistent volume claim. This is the name of the resource. |
+| `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
 | `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
@@ -90,9 +90,9 @@ Retrieve a list of all persistent volumes in a given [environment](#administrati
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
 
 
-<!-------------------- GET A persistent volume -------------------->
+<!-------------------- GET A persistent volume claim -------------------->
 
-#### Get a persistent volume
+#### Get a persistent volume claim
 
 ```shell
 curl -X GET \
@@ -158,7 +158,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id?cluster_id=:cluster_id</code>
 
-Retrieve a persistent volume and all its info in a given [environment](#administration-environments).
+Retrieve a persistent volume claims and all its info in a given [environment](#administration-environments).
 
 		
 | Required                   | &nbsp;                                                      |	
@@ -167,7 +167,7 @@ Retrieve a persistent volume and all its info in a given [environment](#administ
 
 | Attributes                            | &nbsp;                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id` <br/>_string_ | The id of the persistent volume claim. This is the name of the resource. |
+| `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
 | `spec.accessModes` <br/>_string_ | The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -83,13 +83,14 @@ Retrieve a list of all persistent volume claims in a given [environment](#admini
 | `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
-| `spec.accessModes` <br/>_string_ | The requested accessMode for the persistent volume. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
-| `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
+| `spec.accessModes` <br/>_string_ | The requested access mode. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.resources.requests.storage` <br/>_string_ | The requested storage capacity of the persistent volume. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
-| `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
-| `status.accessModes` <br/>_string_ | Defined access mode of the persistent volume claimed. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
-| `status.capacity.phase` <br/>_string_ | Allocated storage capacity of the persistent volume. |
+| `status` <br/>_object_ | The status of the persistent volume claim. |
+| `status.phase` <br/>_string_ | The claim is in one of the following phases: `Pending`, `Bound`, `Lost` or `Terminating`. |
+| `status.accessModes` <br/>_string_ | The allocated access mode. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
+| `status.capacity.storage` <br/>_string_ | The allocated storage capacity. |
 
 <!-------------------- GET A persistent volume claim -------------------->
 
@@ -171,10 +172,11 @@ Retrieve a persistent volume claim and all its info in a given [environment](#ad
 | `id` <br/>_string_ | The id of the persistent volume claim. This is the name and namespace of the resource. |
 | `metadata` <br/>_object_ | The metadata of the persistent volume claim.|
 | `spec` <br/>_object_ | The specification of the persistent volume claim. |
-| `spec.accessModes` <br/>_string_ | The requested accessMode for the persistent volume. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
-| `spec.resources.requests.storage` <br/>_string_ | Requested storage capacity of the persistent volume. |
+| `spec.accessModes` <br/>_string_ | The requested access mode. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes). |
+| `spec.resources.requests.storage` <br/>_string_ | The requested storage capacity of the persistent volume. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
-| `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
-| `status.accessModes` <br/>_string_ | Defined access mode of the persistent volume claimed. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
-| `status.capacity.phase` <br/>_string_ | Allocated storage capacity of the persistent volume. |
+| `status` <br/>_object_ | The status of the persistent volume claim. |
+| `status.phase` <br/>_string_ | The claim is in one of the following phases: `Pending`, `Bound`, `Lost` or `Terminating`. |
+| `status.accessModes` <br/>_string_ | The allocated access mode. The volume can be mounted on a host in any way supported by the resource provider and will give the provider access to different capabilities. Value is one of `ReadWriteOnce` (by a single node), `ReadOnlyMany` (by many nodes) or `ReadWriteMany` (by many nodes).|
+| `status.capacity.storage` <br/>_string_ | The allocated storage capacity. |

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -103,6 +103,7 @@ includes:
   - gcp/k8_secrets
   - gcp/k8_storageclasses
   - gcp/k8_persistentvolumes
+  - gcp/k8_persistentvolumeclaims
   - gcp/k8_releases
   - gcp/k8_charts
   - gcp/images
@@ -119,6 +120,7 @@ includes:
   - kubernetes/k8_secrets
   - kubernetes/k8_storageclasses
   - kubernetes/k8_persistentvolumes
+  - kubernetes/k8_persistentvolumeclaims
   - kubernetes/k8_releases
   - kubernetes/k8_charts  
   - azure
@@ -146,6 +148,7 @@ includes:
   - azure/k8_secrets
   - azure/k8_storageclasses
   - azure/k8_persistentvolumes
+  - azure/k8_persistentvolumeclaims
   - masterportal
   - masterportal/applications
   - swift


### PR DESCRIPTION
### Fixes [MC-11912](https://cloud-ops.atlassian.net/browse/MC-11912)

#### Changes made
<!-- Changes should match the template provided below -->
- Added documentation on PVC

#### Related PRs
- PR https://github.com/cloudops/cloudmc-kubernetes-plugin/pull/36
- PR https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/114

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->