### PR TITLE
MC-11750:Add rank

### DIFF
--- a/source/includes/administration/_identity_providers.md
+++ b/source/includes/administration/_identity_providers.md
@@ -67,7 +67,7 @@ Attributes | &nbsp;
 `connectionName`<br/>*string* | The connection name of the identity provider.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider.
-`rank`<br/>*int* | If provided, it sorts the of identity providers in decending order starting from 1.
+`rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.
 
 
 <!-------------------- CREATE IDPS -------------------->
@@ -148,7 +148,7 @@ Required | &nbsp;
 `logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider. The issuerURL will be set if of a default provider type.
-`rank`<br/>*int* | If provided, it sorts the of identity providers in decending order starting from 1.
+`rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.
 
 
 Optional | &nbsp;

--- a/source/includes/administration/_identity_providers.md
+++ b/source/includes/administration/_identity_providers.md
@@ -33,6 +33,7 @@ curl "https://cloudmc_endpoint/v1/identity_providers" \
       "id": "02b3cbd5-9286-4cd7-b47e-22b2fb9ceae5",
       "connectionName": "Google",
       "type": "OIDC",
+      "rank": "1",
       "parameters": [
         {
           "parameter": "issuerURL",
@@ -66,6 +67,8 @@ Attributes | &nbsp;
 `connectionName`<br/>*string* | The connection name of the identity provider.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider.
+`rank`<br/>*int* | If provided, it sorts the of identity providers in decending order starting from 1.
+
 
 <!-------------------- CREATE IDPS -------------------->
 
@@ -114,6 +117,7 @@ curl -X POST "https://cloudmc_endpoint/rest/identity_providers" \
     "displayName": "Google",
     "connectionName": "CloudMC Google",
     "type": "OIDC",
+    "rank": "1",
     "parameters": [
       {
         "parameter": "issuerURL",
@@ -144,6 +148,8 @@ Required | &nbsp;
 `logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider. The issuerURL will be set if of a default provider type.
+`rank`<br/>*int* | If provided, it sorts the of identity providers in decending order starting from 1.
+
 
 Optional | &nbsp;
 ---------- | -----------
@@ -198,6 +204,7 @@ curl -X PUT "https://cloudmc_endpoint/rest/identity_providers/c84cfe41-929b-47c9
     "id": "da33bf85-6ba3-4214-a258-9442de149eff",
     "connectionName": "CloudMC Google",
     "type": "OIDC",
+    "rank": "1",
     "parameters": [
       {
         "parameter": "issuerURL",
@@ -228,6 +235,8 @@ Required | &nbsp;
 `logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider. The issuerURL will be set if of a default provider type.
+`rank`<br/>*int* | If provided, it sorts the of identity providers in decending order starting from 1.
+
 
 Optional | &nbsp;
 ---------- | -----------

--- a/source/includes/administration/_identity_providers.md
+++ b/source/includes/administration/_identity_providers.md
@@ -148,7 +148,7 @@ Required | &nbsp;
 `logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider. The issuerURL will be set if of a default provider type.
-`rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.rank
+`rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.
 
 
 Optional | &nbsp;

--- a/source/includes/administration/_identity_providers.md
+++ b/source/includes/administration/_identity_providers.md
@@ -148,7 +148,7 @@ Required | &nbsp;
 `logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider. The issuerURL will be set if of a default provider type.
-`rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.
+`rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.rank
 
 
 Optional | &nbsp;
@@ -235,7 +235,7 @@ Required | &nbsp;
 `logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider. The issuerURL will be set if of a default provider type.
-`rank`<br/>*int* | If provided, it sorts the of identity providers in decending order starting from 1.
+`rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.
 
 
 Optional | &nbsp;


### PR DESCRIPTION
### Fixes [MC-11750](https://cloud-ops.atlassian.net/browse/MC-11750)

#### Changes made
<!-- Changes should match the template provided below -->
- Added rank field

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->