### PR TITLE
MC-12119: Delete storage classes, pvs and pvcs

### DIFF
--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -236,3 +236,30 @@ Return value:
 | -------------------------- | ---------------------------------------------------------------- |
 | `taskId` <br/>_string_     | The id corresponding to the create persistent volume claim task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                                     |
+
+<!-------------------- DELETE a persistent volume claim  -------------------->
+#### Delete a persistent volume claim
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/cmc-staging-mysql/cmc-stg"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id</code>
+
+Delete a perstent volume claim from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete persistent volume claim task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -177,3 +177,31 @@ Retrieve a persistent volume and all its info in a given [environment](#administ
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
+
+<!-------------------- DELETE a persistent volume  -------------------->
+#### Delete a persistent volume
+
+<!-- TODO is cluster_id required -->
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes/pvc-05097a93-120d-45d2?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumes/:id</code>
+
+Delete a perstent volume from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete persistent volume task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -100,7 +100,7 @@ Retrieve a list of all persistent volumes in a given [environment](#administrati
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes/pvc-05097a93-120d-45d2?cluster_id=a_cluster_id"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes/pvc-05097a93-120d-45d2"
 ```
 
 > The above command returns a JSON structured like this:
@@ -181,11 +181,10 @@ Retrieve a persistent volume and all its info in a given [environment](#administ
 <!-------------------- DELETE a persistent volume  -------------------->
 #### Delete a persistent volume
 
-<!-- TODO is cluster_id required -->
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes/pvc-05097a93-120d-45d2?cluster_id=a_cluster_id"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes/pvc-05097a93-120d-45d2"
 ```
 
 > The above command returns a JSON structured like this:

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -7,7 +7,7 @@
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses?cluster_id=a_cluster_id"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses"
 ```
 
 > The above command returns a JSON structured like this:
@@ -74,7 +74,7 @@ Retrieve a list of all storage classes in a given [environment](#administration-
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses/rook-ceph-block?cluster_id=a_cluster_id"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses/rook-ceph-block"
 ```
 
 > The above command returns a JSON structured like this:
@@ -133,11 +133,10 @@ Retrieve a storage class and all its info in a given [environment](#administrati
 <!-------------------- DELETE A storage class -------------------->
 #### Delete a storage class
 
-<!-- TODO is cluster_id required -->
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses/rook-ceph-block?cluster_id=a_cluster_id"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses/rook-ceph-block
 ```
 
 > The above command returns a JSON structured like this:

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -129,3 +129,31 @@ Retrieve a storage class and all its info in a given [environment](#administrati
 | `provisioner` <br/>_string_           | The provsioner for the storage class                                                                                                        |
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
+
+<!-------------------- DELETE A storage class -------------------->
+#### Delete a storage class
+
+<!-- TODO is cluster_id required -->
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses/rook-ceph-block?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses/:id</code>
+
+Delete a storage class from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete storage class task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -141,7 +141,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingress/:id??cluster_id=:cluster_id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingress/:id?cluster_id=:cluster_id</code>
 
 Retrieve an ingress and all its info in a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -247,3 +247,30 @@ Return value:
 | -------------------------- | -------------------------------------------- |
 | `taskId` <br/>_string_     | The id corresponding to the create persistent volume claim task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
+
+<!-------------------- DELETE a persistent volume claim  -------------------->
+##### Delete a persistent volume claim
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/cmc-staging-mysql/cmc-stg"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id</code>
+
+Delete a perstent volume claim from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete persistent volume claim task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -99,7 +99,7 @@ Retrieve a list of all persistent volume claims in a given [environment](#admini
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/cmc-staging-mysql/cmc-stg"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/cmc-staging-mysql/cmc-stg?cluster_id=:cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -254,7 +254,7 @@ Return value:
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/cmc-staging-mysql/cmc-stg"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/cmc-staging-mysql/cmc-stg?cluster_id=:cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -266,7 +266,7 @@ curl -X GET \
 }
 ```
 
-<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id</code>
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id?cluster_id=:cluster_id</code>
 
 Delete a perstent volume claim from a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -189,7 +189,6 @@ Retrieve a persistent volume and all its info in a given [environment](#administ
 <!-------------------- DELETE a persistent volume  -------------------->
 ##### Delete a persistent volume
 
-<!-- TODO is cluster_id required -->
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
@@ -205,7 +204,7 @@ curl -X DELETE \
 }
 ```
 
-<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumes/:id</code>
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumes/:id?cluster_id=:cluster_id</code>
 
 Delete a perstent volume from a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -185,3 +185,31 @@ Retrieve a persistent volume and all its info in a given [environment](#administ
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume. |
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
+
+<!-------------------- DELETE a persistent volume  -------------------->
+##### Delete a persistent volume
+
+<!-- TODO is cluster_id required -->
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes/pvc-05097a93-120d-45d2?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumes/:id</code>
+
+Delete a perstent volume from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete persistent volume task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |

--- a/source/includes/kubernetes_extension/_k8_storageclasses.md
+++ b/source/includes/kubernetes_extension/_k8_storageclasses.md
@@ -141,7 +141,6 @@ Retrieve a storage class and all its info in a given [environment](#administrati
 <!-------------------- DELETE A storage class -------------------->
 ##### Delete a storage class
 
-<!-- TODO is cluster_id required -->
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
@@ -157,7 +156,7 @@ curl -X DELETE \
 }
 ```
 
-<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses/:id</code>
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses/:id?cluster_id=:cluster_id</code>
 
 Delete a storage class from a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes_extension/_k8_storageclasses.md
+++ b/source/includes/kubernetes_extension/_k8_storageclasses.md
@@ -137,3 +137,31 @@ Retrieve a storage class and all its info in a given [environment](#administrati
 | `provisioner` <br/>_string_           | The provisioner for the storage class                                                                                                       |
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
+
+<!-------------------- DELETE A storage class -------------------->
+##### Delete a storage class
+
+<!-- TODO is cluster_id required -->
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses/rook-ceph-block?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses/:id</code>
+
+Delete a storage class from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete storage class task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |


### PR DESCRIPTION
### Fixes [MC-12119](https://cloud-ops.atlassian.net/browse/MC-12119)

#### Changes made
Document deletion of
- storage classes
- persistent volumes
- persistent volume claims

#### Related PRs
- [cloudmc-kubernetes-sdk](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/133)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->