### PR TITLE
MC-12120: create storage class doc added

### DIFF
--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -130,6 +130,53 @@ Retrieve a storage class and all its info in a given [environment](#administrati
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
 
+<!-------------------- CREATE A storage class -------------------->
+#### Create a storage class
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses"
+  Content-Type: application/json 
+  {
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "local-storage-name"
+  },
+  "provisioner": "kubernetes.io/no-provisioner",
+  "volumeBindingMode": WaitForFirstConsumer
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses</code>
+
+Create a storage class in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                      |
+| ------------------------------------------ | ----------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the storage class.                    |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents      |
+| `metadata` <br/>_object_                   | The metadata of the storage class.                                          |
+| `metadata.name` <br/>_string_              | The name of the storage class.                                              |
+| `provisioner` <br/>_string_                | The provsioner for the storage class                                        |
+| `volumeBindingMode` <br/>_string_          | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                    |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `reclaimPolicy` <br/>_string_              | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.               |
+| `parameters` <br/>_object_                 | The parameters for the storage provisioner. These are storage provisioner specific and you will likely have to read external documentation. |
+| `allowVolumeExpansion` <br/>_boolean_      | Whether not the storage class allows for expandable volumes.              |
+
 <!-------------------- DELETE A storage class -------------------->
 #### Delete a storage class
 

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -145,7 +145,7 @@ curl -X POST \
     "name": "local-storage-name"
   },
   "provisioner": "kubernetes.io/no-provisioner",
-  "volumeBindingMode": WaitForFirstConsumer
+  "volumeBindingMode": "WaitForFirstConsumer"
 }
 ```
 
@@ -176,6 +176,13 @@ Create a storage class in a given [environment](#administration-environments).
 | `reclaimPolicy` <br/>_string_              | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.               |
 | `parameters` <br/>_object_                 | The parameters for the storage provisioner. These are storage provisioner specific and you will likely have to read external documentation. |
 | `allowVolumeExpansion` <br/>_boolean_      | Whether not the storage class allows for expandable volumes.              |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                |
+---------------------------- | ------------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the create stateful set task. |
+| `taskStatus` <br/>*string* | The status of the operation.                          |
 
 <!-------------------- DELETE A storage class -------------------->
 #### Delete a storage class

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -165,7 +165,7 @@ Create a storage class in a given [environment](#administration-environments).
 | Required Attributes                        | &nbsp;                                                                      |
 | ------------------------------------------ | ----------------------------------------------------------------------------|
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the storage class.                    |
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents      |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents.     |
 | `metadata` <br/>_object_                   | The metadata of the storage class.                                          |
 | `metadata.name` <br/>_string_              | The name of the storage class.                                              |
 | `provisioner` <br/>_string_                | The provsioner for the storage class                                        |

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -126,7 +126,7 @@ Retrieve a storage class and all its info in a given [environment](#administrati
 | `allowVolumeExpansion` <br/>_boolean_ | Whether not the storage class allows for expandable volumes.                                                                                |
 | `metadata` <br/>_object_              | The metadata of the storage class.                                                                                                          |
 | `parameters` <br/>_object_            | The parameters for the storage provisioner. These are storage provisioner specific and you will likely have to read external documentation. |
-| `provisioner` <br/>_string_           | The provsioner for the storage class                                                                                                        |
+| `provisioner` <br/>_string_           | The provisioner for the storage class                                                                                                        |
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
 
@@ -168,7 +168,7 @@ Create a storage class in a given [environment](#administration-environments).
 | `kind`<br/>_string_                        | The string value representing the REST resource this object represents.     |
 | `metadata` <br/>_object_                   | The metadata of the storage class.                                          |
 | `metadata.name` <br/>_string_              | The name of the storage class.                                              |
-| `provisioner` <br/>_string_                | The provsioner for the storage class                                        |
+| `provisioner` <br/>_string_                | The provisioner for the storage class                                        |
 | `volumeBindingMode` <br/>_string_          | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                    |
 
 | Optional Attributes                        | &nbsp;                                                                    |

--- a/source/includes/kubernetes_extension/_k8_storageclasses.md
+++ b/source/includes/kubernetes_extension/_k8_storageclasses.md
@@ -176,7 +176,7 @@ Create a storage class in a given [environment](#administration-environments).
 | `kind`<br/>_string_                        | The string value representing the REST resource this object represents.     |
 | `metadata` <br/>_object_                   | The metadata of the storage class.                                          |
 | `metadata.name` <br/>_string_              | The name of the storage class.                                              |
-| `provisioner` <br/>_string_                | The provsioner for the storage class                                        |
+| `provisioner` <br/>_string_                | The provisioner for the storage class                                        |
 | `volumeBindingMode` <br/>_string_          | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                    |
 
 | Optional Attributes                        | &nbsp;                                                                    |

--- a/source/includes/kubernetes_extension/_k8_storageclasses.md
+++ b/source/includes/kubernetes_extension/_k8_storageclasses.md
@@ -138,6 +138,60 @@ Retrieve a storage class and all its info in a given [environment](#administrati
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
 
+<!-------------------- CREATE A storage class -------------------->
+##### Create a storage class
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses?cluster_id=a_cluster_id"
+  Content-Type: application/json 
+  {
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "local-storage-name"
+  },
+  "provisioner": "kubernetes.io/no-provisioner",
+  "volumeBindingMode": "WaitForFirstConsumer"
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses?cluster_id=:cluster_id</code>
+
+Create a storage class in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                      |
+| ------------------------------------------ | ----------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the storage class.                    |
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents.     |
+| `metadata` <br/>_object_                   | The metadata of the storage class.                                          |
+| `metadata.name` <br/>_string_              | The name of the storage class.                                              |
+| `provisioner` <br/>_string_                | The provsioner for the storage class                                        |
+| `volumeBindingMode` <br/>_string_          | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                    |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `reclaimPolicy` <br/>_string_              | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.               |
+| `parameters` <br/>_object_                 | The parameters for the storage provisioner. These are storage provisioner specific and you will likely have to read external documentation. |
+| `allowVolumeExpansion` <br/>_boolean_      | Whether not the storage class allows for expandable volumes.   
+
+Return value:
+
+| Attributes                 | &nbsp;                                                |
+---------------------------- | ------------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the create stateful set task. |
+| `taskStatus` <br/>*string* | The status of the operation.                          |
+
 <!-------------------- DELETE A storage class -------------------->
 ##### Delete a storage class
 


### PR DESCRIPTION
### Fixes [MC-12120](https://cloud-ops.atlassian.net/browse/MC-12120)

#### Changes made
<img width="1440" alt="Screen Shot 2020-08-03 at 2 26 58 PM" src="https://user-images.githubusercontent.com/35710207/89215514-ca0ece00-d596-11ea-81fb-f1b8cb5feb4a.png">

#### Related PRs
- https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/136

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->