### PR TITLE
Updates required fields to include id for get/delete requests

### DIFF
--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -1,6 +1,6 @@
 ### ConfigMaps
 
-<!-------------------- LIST CONFIG MAPS -------------------->
+<!-------------------- LIST CONFIGMAPS -------------------->
 
 #### List configmaps
 
@@ -31,14 +31,17 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps</code>
 
-Retrieve a list of all config maps in a given [environment](#administration-environments).
+Retrieve a list of all configmaps in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                  |
-| ------------------------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the config map                                |
-| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
-| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
-| `metadata` <br/>_object_                   | The metadata of the config map                          |
+| Required           | &nbsp;                   |
+| ------------------ | ------------------------ |
+| `id` <br/>_string_ | The id of the configmap. |
+
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `apiVersion` <br/>_string_ | The API version used to retrieve this configmap.  |
+| `kind` <br/>_string_       | The type of the returned resource. ie, ConfigMap. |
+| `metadata` <br/>_object_   | The metadata of the configmap.                    |
 
 <!-------------------- GET A configmap -------------------->
 
@@ -67,9 +70,12 @@ curl -X GET \
 
 Retrieve a configmap and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                  |
-| ------------------------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the config map                                |
-| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map        |
-| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap        |
-| `metadata` <br/>_object_                   | The metadata of the config map                          |
+| Required Attributes | &nbsp;                   |
+| ------------------- | ------------------------ |
+| `id` <br/>_string_  | The id of the configmap. |
+
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `apiVersion` <br/>_string_ | The API version used to retrieve this configmap.  |
+| `kind` <br/>_string_       | The type of the returned resource. ie, ConfigMap. |
+| `metadata` <br/>_object_   | The metadata of the configmap.                    |

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -1,8 +1,8 @@
-### Daemon Sets
+### DaemonSets
 
-<!-------------------- LIST DAEMON SETS -------------------->
+<!-------------------- LIST DAEMONSETS -------------------->
 
-#### List daemon sets
+#### List daemonsets
 
 ```shell
 curl -X GET \
@@ -30,20 +30,20 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets</code>
 
-Retrieve a list of all daemon sets in a given [environment](#administration-environments).
+Retrieve a list of all daemonsets in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                  |
-| ------------------------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the daemon set                                |
-| `metadata` <br/>_object_                   | The metadata of the daemon set                          |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set |
-| `status`<br/>_object_                      | The status information of the daemon set                |
+| Attributes               | &nbsp;                                                  |
+| ------------------------ | ------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the daemonset.                                |
+| `metadata` <br/>_object_ | The metadata of the daemonset.                          |
+| `spec`<br/>_object_      | The specification used to create and run the daemonset. |
+| `status`<br/>_object_    | The status information of the daemonset.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- GET A DAEMON SET -------------------->
+<!-------------------- GET A DAEMONSET -------------------->
 
-#### Get a daemon set
+#### Get a daemonset
 
 ```shell
 curl -X GET \
@@ -55,31 +55,36 @@ curl -X GET \
 
 ```json
 {
-    "data": {
-        "id": "canal/kube-system",
-        "metadata": {},
-        "spec": {},
-        "status": {}
-    }
+  "data": {
+    "id": "canal/kube-system",
+    "metadata": {},
+    "spec": {},
+    "status": {}
+  }
 }
 ```
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
 
-Retrieve a daemon set and all its info in a given [environment](#administration-environments).
+Retrieve a daemonset and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the daemon set                                        |
-| `metadata` <br/>_object_                   | The metadata of the daemon set                                  |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set         |
-| `status`<br/>_object_                      | The status information of the daemon set                        |
+| Required           | &nbsp;                   |
+| ------------------ | ------------------------ |
+| `id` <br/>_string_ | The id of the daemonset. |
+
+
+| Attributes               | &nbsp;                                                  |
+| ------------------------ | ------------------------------------------------------- |
+| `metadata` <br/>_object_ | The metadata of the daemonset.                          |
+| `spec`<br/>_object_      | The specification used to create and run the daemonset. |
+| `status`<br/>_object_    | The status information of the daemonset.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- CREATE DAEMON SET -------------------->
+<!-------------------- CREATE A DAEMONSET -------------------->
 
-#### Create a daemon set
+#### Create a daemonset
+
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
@@ -128,35 +133,34 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets</code>
 
-Create a daemon set in a given [environment](#administration-environments).
+Create a daemonset in a given [environment](#administration-environments).
 
-| Required Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | --------------------------------------------------------------------------|
-| `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set                      |
-| `metadata` <br/>_object_                   | The metadata of the daemon set                                            |
-| `metadata.name` <br/>_string_              | The name of the daemon set                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set                   |
-| `spec.selector`<br/>_object_               | The label query over the daemon set's resources                           |
-| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created                      |
-| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set |
+| Required Attributes           | &nbsp;                                                                    |
+| ----------------------------- | ------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the daemonset.                      |
+| `metadata` <br/>_object_      | The metadata of the daemonset.                                            |
+| `metadata.name` <br/>_string_ | The name of the daemonset.                                                |
+| `spec`<br/>_object_           | The specification used to create and run the daemonset.                   |
+| `spec.selector`<br/>_object_  | The label query over the daemonset's resources.                           |
+| `spec.template`<br/>_object_  | The data a daemonset's pod should have when created.                      |
+| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the daemonset. |
 
-
-| Optional Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
+| Optional Attributes                      | &nbsp;                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                      | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_       | The namespace in which the daemonset is created.                        |
+| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a daemonset.        |
 
 Return value:
 
-| Attributes                 | &nbsp;                                              |
----------------------------- | ----------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the create daemon set task. |
-| `taskStatus` <br/>*string* | The status of the operation.                        |
+| Attributes                 | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create daemonset task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                       |
 
-<!-------------------- DELETE DAEMON SET -------------------->
+<!-------------------- DELETE A DAEMONSET -------------------->
 
-#### Delete a daemon set
+#### Delete a daemonset
 
 ```shell
 curl -X DELETE \
@@ -175,9 +179,15 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
 
-Delete a daemon set from a given [environment](#administration-environments).
+Delete a daemonset from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                              |
-| -------------------------- | --------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete daemon set task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                        |
+| Required           | &nbsp;                   |
+| ------------------ | ------------------------ |
+| `id` <br/>_string_ | The id of the daemonset. |
+
+Return value:
+
+| Attributes                 | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete daemonset task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                       |

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -23,7 +23,7 @@ curl -X GET \
       "spec": {},
       "status": {}
     }
-  ],  
+  ],
   "metadata": {
     "recordCount": 9
   }
@@ -34,16 +34,16 @@ curl -X GET \
 
 Retrieve a list of all deployments in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the deployment                                        |
-| `metadata` <br/>_object_                   | The metadata of the deployment                                  |
-| `metadata.name` <br/>_string_              | The name of the deployment                                      |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                |
-| `metadata.uid` <br/>_object_               | The UUID of the deployment                                      |
-| `images` <br/>_object_                     | The container images within a deployment                        |
-| `spec`<br/>_object_                        | The specification used to create and run the deployment         |
-| `status`<br/>_object_                      | The status information of the deployment                        |
+| Attributes                         | &nbsp;                                                   |
+| ---------------------------------- | -------------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the deployment.                                |
+| `metadata` <br/>_object_           | The metadata of the deployment.                          |
+| `metadata.name` <br/>_string_      | The name of the deployment.                              |
+| `metadata.namespace` <br/>_string_ | The namespace in which the deployment is created.        |
+| `metadata.uid` <br/>_object_       | The UUID of the deployment.                              |
+| `images` <br/>_object_             | The container images within a deployment.                |
+| `spec`<br/>_object_                | The specification used to create and run the deployment. |
+| `status`<br/>_object_              | The status information of the deployment.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -61,14 +61,14 @@ curl -X GET \
 
 ```json
 {
-    "data": {
-      "id": "apm-server-1585600296-apm-server/monitoring",
-      "deploymentStatus": "Available",
-      "readyRatio": "1/1",
-      "metadata": {},
-      "spec": {},
-      "status": {}
-    }
+  "data": {
+    "id": "apm-server-1585600296-apm-server/monitoring",
+    "deploymentStatus": "Available",
+    "readyRatio": "1/1",
+    "metadata": {},
+    "spec": {},
+    "status": {}
+  }
 }
 ```
 
@@ -76,19 +76,23 @@ curl -X GET \
 
 Retrieve a deployment and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                            |
-| ------------------------------------------ | ----------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the deployment                                          |
-| `deplomentStatus`<br/>_object_             | The status information of the deployment                          |
-| `readyRatio` <br/>_object_                 | The ready replicas to total replicas ratio of this deployment set |
-| `metadata` <br/>_object_                   | The metadata of the deployment                                    |
-| `spec`<br/>_object_                        | The specification used to create and run the deployment           |
+| Required           | &nbsp;                    |
+| ------------------ | ------------------------- |
+| `id` <br/>_string_ | The id of the deployment. |
+
+| Attributes                     | &nbsp;                                                             |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `deplomentStatus`<br/>_object_ | The status information of the deployment.                          |
+| `readyRatio` <br/>_object_     | The ready replicas to total replicas ratio of this deployment set. |
+| `metadata` <br/>_object_       | The metadata of the deployment.                                    |
+| `spec`<br/>_object_            | The specification used to create and run the deployment.           |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
 <!-------------------- CREATE DEPLOYMENT -------------------->
 
 #### Create a deployment
+
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
@@ -139,28 +143,28 @@ curl -X POST \
 
 Create a deployment in a given [environment](#administration-environments).
 
-| Required Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment                      |
-| `metadata` <br/>_object_                   | The metadata of the deployment                                            |
-| `metadata.name` <br/>_string_              | The name of the deployment                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the deployment                   |
-| `spec.selector`<br/>_object_               | The label query over the deployment's set of resources                    |
-| `spec.template`<br/>_object_               | The data a deployment's pod should have when created                      |
-| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment |
+| Required Attributes           | &nbsp;                                                                     |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the deployment.                      |
+| `metadata` <br/>_object_      | The metadata of the deployment.                                            |
+| `metadata.name` <br/>_string_ | The name of the deployment.                                                |
+| `spec`<br/>_object_           | The specification used to create and run the deployment.                   |
+| `spec.selector`<br/>_object_  | The label query over the deployment's set of resources.                    |
+| `spec.template`<br/>_object_  | The data a deployment's pod should have when created.                      |
+| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the deployment. |
 
-| Optional Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
+| Optional Attributes                      | &nbsp;                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                      | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_       | The namespace in which the deployment is created.                       |
+| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a deployment.       |
 
 Return value:
 
-| Attributes                 | &nbsp;                                                |
----------------------------- | ----------------------------------------------------- |
-| `taskId` <br/>*string*     | The id corresponding to the create deployment task.   |
-| `taskStatus` <br/>*string* | The status of the operation.                          |
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create deployment task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |
 
 <!-------------------- DELETE DEPLOYMENT -------------------->
 
@@ -184,6 +188,12 @@ curl -X DELETE \
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id</code>
 
 Delete a deployment from a given [environment](#administration-environments).
+
+| Required           | &nbsp;                    |
+| ------------------ | ------------------------- |
+| `id` <br/>_string_ | The id of the deployment. |
+
+Return value:
 
 | Attributes                 | &nbsp;                                              |
 | -------------------------- | --------------------------------------------------- |

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -64,8 +64,8 @@ curl -X GET \
         "selfLink": "/apis/extensions/v1beta1/namespaces/auth/ingresses/cm-acme-http-solver-75png",
         "uid": "48720f48-f2bc-45fc-95c5-60cae8ffe11e"
       },
-      "spec":{
-        "rules":[]
+      "spec": {
+        "rules": []
       },
       "status": {
         "loadBalancer": {}
@@ -79,19 +79,19 @@ curl -X GET \
 
 Retrieve a list of all ingresses in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the ingress                                           |
-| `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
-| `service` <br/>_object_                    | The service associated with the ingress                         |
-| `service.port` <br/>_string_               | The port of the service associated with the ingress             |
-| `service.name` <br/>_string_               | The name of the service associated with the ingress             |
-| `metadata` <br/>_object_                   | The metadata of the ingress                                     |
-| `metadata.name` <br/>_string_              | The name of the ingress                                         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
-| `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
-| `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
+| Attributes                         | &nbsp;                                               |
+| ---------------------------------- | ---------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the ingress.                               |
+| `endpoint` <br/>_string_           | The endpoint of the ingress.                         |
+| `service` <br/>_object_            | The service associated with the ingress.             |
+| `service.port` <br/>_string_       | The port of the service associated with the ingress. |
+| `service.name` <br/>_string_       | The name of the service associated with the ingress. |
+| `metadata` <br/>_object_           | The metadata of the ingress.                         |
+| `metadata.name` <br/>_string_      | The name of the ingress.                             |
+| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created.       |
+| `metadata.labels` <br/>_object_    | The labels associated with the ingress.              |
+| `metadata.uid` <br/>_object_       | The UUID of the ingress.                             |
+| `spec`<br/>_object_                | The attributes that a user specifies for an ingress. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -141,18 +141,21 @@ curl -X GET \
 
 Retrieve an ingress and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the ingress                                           |
-| `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
-| `service` <br/>_object_                    | The service associated with the ingress                         |
-| `service.port` <br/>_string_               | The port of the service associated with the ingress             |
-| `service.name` <br/>_string_               | The name of the service associated with the ingress             |
-| `metadata` <br/>_object_                   | The metadata of the ingress                                     |
-| `metadata.name` <br/>_string_              | The name of the ingress                                         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
-| `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
-| `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
+| Required           | &nbsp;                 |
+| ------------------ | ---------------------- |
+| `id` <br/>_string_ | The id of the ingress. |
+
+| Attributes                         | &nbsp;                                               |
+| ---------------------------------- | ---------------------------------------------------- |
+| `endpoint` <br/>_string_           | The endpoint of the ingress.                         |
+| `service` <br/>_object_            | The service associated with the ingress.             |
+| `service.port` <br/>_string_       | The port of the service associated with the ingress. |
+| `service.name` <br/>_string_       | The name of the service associated with the ingress. |
+| `metadata` <br/>_object_           | The metadata of the ingress.                         |
+| `metadata.name` <br/>_string_      | The name of the ingress.                             |
+| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created.       |
+| `metadata.labels` <br/>_object_    | The labels associated with the ingress.              |
+| `metadata.uid` <br/>_object_       | The UUID of the ingress.                             |
+| `spec`<br/>_object_                | The attributes that a user specifies for an ingress. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes/_k8_namespaces.md
+++ b/source/includes/kubernetes/_k8_namespaces.md
@@ -32,12 +32,12 @@ curl -X GET \
 
 Retrieve a list of all namespaces in a given [environment](#administration-environments).
 
-| Attributes                     | &nbsp;                                                                                    |
-| ------------------------------ | ----------------------------------------------------------------------------------------- |
-| `id` <br/>_string_             | The id of the namespace.                                                                  |
-| `metadata` <br/>_object_       | The metadata of the namespace                                                             |
-| `spec`<br/>_object_            | The specification describes the attributes on a namespace.                                |
-| `status`<br/>_object_          | The status information of the namespace                                                   |
+| Attributes               | &nbsp;                                                     |
+| ------------------------ | ---------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the namespace.                                   |
+| `metadata` <br/>_object_ | The metadata of the namespace.                             |
+| `spec`<br/>_object_      | The specification describes the attributes on a namespace. |
+| `status`<br/>_object_    | The status information of the namespace.                   |
 
 <!-------------------- GET A NAMESPACE -------------------->
 
@@ -68,11 +68,14 @@ curl -X GET \
 
 Retrieve a namespace and all its info in a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                                                               |
-| -------------------------- | ------------------------------------------------------------------------------------ |
-| `id` <br/>_string_         | The id of the namespace.                                                             |
-| `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object |
-| `kind` <br/>_string_       | A string value representing the REST resource this object represents                 |
-| `metadata` <br/>_object_   | The metadata of the namespace                                                        |
-| `spec`<br/>_object_        | The specification describes the attributes on a namespace.                           |
-| `status`<br/>_object_      | The status information of the namespace                                              |
+| Required           | &nbsp;                   |
+| ------------------ | ------------------------ |
+| `id` <br/>_string_ | The id of the namespace. |
+
+| Attributes                 | &nbsp;                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object. |
+| `kind` <br/>_string_       | A string value representing the REST resource this object represents.                 |
+| `metadata` <br/>_object_   | The metadata of the namespace.                                                        |
+| `spec`<br/>_object_        | The specification describes the attributes on a namespace.                            |
+| `status`<br/>_object_      | The status information of the namespace.                                              |

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -1,6 +1,5 @@
 ### Pods
 
-
 <!-------------------- LIST PODS -------------------->
 
 #### List pods
@@ -10,6 +9,7 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -204,31 +204,26 @@ curl -X GET \
 }
 ```
 
-
-
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods</code>
 
 Retrieve a list of all pods in a given [environment](#administration-environments).
 
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id of the pod.
-`metadata` <br/>*object* | The metadata of the pod
-`metadata.annotations` <br/>*map* | The annotations of the pod
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string
-`metadata.labels` <br/>*map* | The labels associated to the pod
-`metadata.name` <br/>*string* | The name of the pod
-`metadata.namespace` <br/>*string* | The namespace in which the pod is created
-`metadata.uid` <br/>*object* | The UUID of the pod
-`spec`<br/>*object* | The specification used to create and run the pod
-`spec.container`<br/>*string* | The name of the container running
-`status`<br/>*object* | The status information of the pod
-`status.phase`<br/>*string* | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed
-
+| Attributes                                 | &nbsp;                                                                                        |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the pod.                                                                            |
+| `metadata` <br/>_object_                   | The metadata of the pod.                                                                      |
+| `metadata.annotations` <br/>_map_          | The annotations of the pod.                                                                   |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the pod as a string.                                                  |
+| `metadata.labels` <br/>_map_               | The labels associated to the pod.                                                             |
+| `metadata.name` <br/>_string_              | The name of the pod.                                                                          |
+| `metadata.namespace` <br/>_string_         | The namespace in which the pod is created.                                                    |
+| `metadata.uid` <br/>_object_               | The UUID of the pod.                                                                          |
+| `spec`<br/>_object_                        | The specification used to create and run the pod.                                             |
+| `spec.container`<br/>_string_              | The name of the container running.                                                            |
+| `status`<br/>_object_                      | The status information of the pod.                                                            |
+| `status.phase`<br/>_string_                | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
-
-
 
 <!-------------------- GET A POD -------------------->
 
@@ -239,6 +234,7 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods/my-aerospike-0/default"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -433,33 +429,34 @@ curl -X GET \
 }
 ```
 
-
-
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id</code>
 
 Retrieve a pod and all its info in a given [environment](#administration-environments).
 
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id of the pod.
-`metadata` <br/>*object* | The metadata of the pod
-`metadata.annotations` <br/>*map* | The annotations of the pod
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string
-`metadata.labels` <br/>*map* | The labels associated to the pod
-`metadata.name` <br/>*string* | The name of the pod
-`metadata.namespace` <br/>*string* | The namespace in which the pod is created
-`metadata.uid` <br/>*object* | The UUID of the pod
-`spec`<br/>*object* | The specification used to create and run the pod
-`spec.container`<br/>*string* | The name of the container running
-`status`<br/>*object* | The status information of the pod
-`status.phase`<br/>*string* | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed
+| Required           | &nbsp;             |
+| ------------------ | ------------------ |
+| `id` <br/>_string_ | The id of the pod. |
 
+| Attributes                                 | &nbsp;                                                                                        |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `metadata` <br/>_object_                   | The metadata of the pod.                                                                      |
+| `metadata.annotations` <br/>_map_          | The annotations of the pod.                                                                   |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the pod as a string.                                                  |
+| `metadata.labels` <br/>_map_               | The labels associated to the pod.                                                             |
+| `metadata.name` <br/>_string_              | The name of the pod.                                                                          |
+| `metadata.namespace` <br/>_string_         | The namespace in which the pod is created.                                                    |
+| `metadata.uid` <br/>_object_               | The UUID of the pod.                                                                          |
+| `spec`<br/>_object_                        | The specification used to create and run the pod.                                             |
+| `spec.container`<br/>_string_              | The name of the container running.                                                            |
+| `status`<br/>_object_                      | The status information of the pod.                                                            |
+| `status.phase`<br/>_string_                | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
 <!-------------------- CREATE POD -------------------->
 
 #### Create a pod
+
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
@@ -496,27 +493,26 @@ curl -X POST \
 
 Create a pod in a given [environment](#administration-environments).
 
-Required Attributes                 | &nbsp;
------------------------------------ | ------------------------------------------------------------
-`apiVersion` <br/>*string*          | The api version (versioned schema) of the pod
-`metadata` <br/>*object*            | The metadata of the pod
-`metadata.name` <br/>*string*       | The name of the pod
-`spec`<br/>*object*                 | The specification used to create and run the pod
-`spec.container.image`<br/>*string* | The docker image name
-`spec.container.name`<br/>*string*  | The (unique) name of the container specified as a DNS_LABEL
+| Required Attributes                 | &nbsp;                                                       |
+| ----------------------------------- | ------------------------------------------------------------ |
+| `apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.               |
+| `metadata` <br/>_object_            | The metadata of the pod.                                     |
+| `metadata.name` <br/>_string_       | The name of the pod.                                         |
+| `spec`<br/>_object_                 | The specification used to create and run the pod.            |
+| `spec.container.image`<br/>_string_ | The docker image name.                                       |
+| `spec.container.name`<br/>_string_  | The (unique) name of the container specified as a DNS_LABEL. |
 
-| Optional Attributes                       | &nbsp;                                                                  |
-| ----------------------------------------- | ----------------------------------------------------------------------- |
-| `kind`<br/>_string_                       | The string value representing the REST resource this object represents  |
-| `metadata.namespace` <br/>*string*        | The namespace in which the pod is created                               |
+| Optional Attributes                | &nbsp;                                                                  |
+| ---------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_ | The namespace in which the pod is created.                              |
 
 Return value:
 
 | Attributes                 | &nbsp;                                       |
----------------------------- | ---------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the create pod task. |
-| `taskStatus` <br/>*string* | The status of the operation.                 |
-
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE POD -------------------->
 
@@ -527,6 +523,7 @@ curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods/my-aerospike-0/default"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -536,13 +533,17 @@ curl -X DELETE \
 }
 ```
 
-
-
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id</code>
 
 Delete a pod from a given [environment](#administration-environments).
 
+| Required           | &nbsp;             |
+| ------------------ | ------------------ |
+| `id` <br/>_string_ | The id of the pod. |
+
+Return value:
+
 | Attributes                 | &nbsp;                                       |
----------------------------- | ---------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the delete pod task. |
-| `taskStatus` <br/>*string* | The status of the operation.                 |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes/_k8_secrets.md
+++ b/source/includes/kubernetes/_k8_secrets.md
@@ -19,9 +19,9 @@ curl -X GET \
       "id": "default-token-xxxmt/default",
       "apiVersion": "v1",
       "data": {
-            "ca.crt": [],
-            "namespace": [],
-            "token": []
+        "ca.crt": [],
+        "namespace": [],
+        "token": []
       },
       "kind": "Secret",
       "metadata": {},
@@ -39,7 +39,7 @@ curl -X GET \
 Retrieve a list of all secrets in a given [environment](#administration-environments).
 
 | Attributes                 | &nbsp;                                                                     |
-| -------------------------- | ---------------------------------------------------------------------------|
+| -------------------------- | -------------------------------------------------------------------------- |
 | `id` <br/>_string_         | The id of the secret.                                                      |
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `data` <br/>_string_       | The data that the secret contains.                                         |
@@ -61,18 +61,18 @@ curl -X GET \
 
 ```json
 {
+  "data": {
+    "id": "default-token-xxxmt/default",
+    "apiVersion": "v1",
     "data": {
-        "id": "default-token-xxxmt/default",
-        "apiVersion": "v1",
-        "data": {
-            "ca.crt": [],
-            "namespace": [],
-            "token": []
-        },
-        "kind": "Secret",
-        "metadata": {},
-        "type": "kubernetes.io/service-account-token"
-    }
+      "ca.crt": [],
+      "namespace": [],
+      "token": []
+    },
+    "kind": "Secret",
+    "metadata": {},
+    "type": "kubernetes.io/service-account-token"
+  }
 }
 ```
 
@@ -80,9 +80,12 @@ curl -X GET \
 
 Retrieve a secret and all its info in a given [environment](#administration-environments).
 
+| Required           | &nbsp;                |
+| ------------------ | --------------------- |
+| `id` <br/>_string_ | The id of the secret. |
+
 | Attributes                 | &nbsp;                                                                     |
-| -------------------------- | ---------------------------------------------------------------------------|
-| `id` <br/>_string_         | The id of the secret.                                                      |
+| -------------------------- | -------------------------------------------------------------------------- |
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `data` <br/>_string_       | The data that the secret contains.                                         |
 | `metadata` <br/>_object_   | The metadata of the secret.                                                |

--- a/source/includes/kubernetes/_k8_services.md
+++ b/source/includes/kubernetes/_k8_services.md
@@ -17,10 +17,7 @@ curl -X GET \
   "data": [
     {
       "id": "alaintest-aerospike/default",
-      "ports": [
-        "3000/TCP",
-        "3002/TCP"
-      ],
+      "ports": ["3000/TCP", "3002/TCP"],
       "type": "ClusterIP",
       "metadata": {},
       "spec": {},
@@ -30,22 +27,18 @@ curl -X GET \
     },
     {
       "id": "alertmanager-operated/monitoring",
-      "ports": [
-        "9093/TCP",
-        "9094/TCP",
-        "9094/UDP"
-      ],
+      "ports": ["9093/TCP", "9094/TCP", "9094/UDP"],
       "type": "NodePort",
       "apiVersion": "v1",
       "kind": "Service",
       "metadata": {},
       "spec": {},
       "status": {
-       "loadBalancer": {}
+        "loadBalancer": {}
       }
     }
   ],
-    "metadata": {
+  "metadata": {
     "recordCount": 2
   }
 }
@@ -55,17 +48,17 @@ curl -X GET \
 
 Retrieve a list of all services in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the service                                           |
-| `metadata` <br/>_object_                   | The metadata of the service                                     |
-| `metadata.name` <br/>_string_              | The name of the service                                         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the service is created                   |
-| `metadata.uid` <br/>_object_               | The UUID of the service                                         |
-| `type` <br/>_object_                       | The container images within a service                           |
-| `ports`<br/>_object_                       | The list of ports that are exposed by this service              |
-| `spec`<br/>_object_                        | The attributes that a user creates on a service                 |
-| `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
+| Attributes                         | &nbsp;                                                                                                   |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the service.                                                                                   |
+| `metadata` <br/>_object_           | The metadata of the service.                                                                             |
+| `metadata.name` <br/>_string_      | The name of the service.                                                                                 |
+| `metadata.namespace` <br/>_string_ | The namespace in which the service is created.                                                           |
+| `metadata.uid` <br/>_object_       | The UUID of the service.                                                                                 |
+| `type` <br/>_object_               | The container images within a service.                                                                   |
+| `ports`<br/>_object_               | The list of ports that are exposed by this service.                                                      |
+| `spec`<br/>_object_                | The attributes that a user creates on a service.                                                         |
+| `spec.selector`<br/>_object_       | The keys and values corresponding to pod labels, used to determine where service traffic will be routed. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -85,10 +78,7 @@ curl -X GET \
 {
   "data": {
     "id": "test-aerospike/auth",
-    "ports": [
-      "3000/TCP",
-      "3002/TCP"
-    ],
+    "ports": ["3000/TCP", "3002/TCP"],
     "type": "ClusterIP",
     "apiVersion": "v1",
     "kind": "Service",
@@ -105,16 +95,19 @@ curl -X GET \
 
 Retrieve a service and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the service                                           |
-| `metadata` <br/>_object_                   | The metadata of the service                                     |
-| `metadata.name` <br/>_string_              | The name of the service                                         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the service is created                   |
-| `metadata.uid` <br/>_object_               | The UUID of the service                                         |
-| `type` <br/>_object_                       | The container images within a service                           |
-| `ports`<br/>_object_                       | The list of ports that are exposed by this service              |
-| `spec`<br/>_object_                        | The attributes that a user creates on a service                 |
-| `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
+| Required           | &nbsp;                 |
+| ------------------ | ---------------------- |
+| `id` <br/>_string_ | The id of the service. |
+
+| Attributes                         | &nbsp;                                                                                                   |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `metadata` <br/>_object_           | The metadata of the service.                                                                             |
+| `metadata.name` <br/>_string_      | The name of the service.                                                                                 |
+| `metadata.namespace` <br/>_string_ | The namespace in which the service is created.                                                           |
+| `metadata.uid` <br/>_object_       | The UUID of the service.                                                                                 |
+| `type` <br/>_object_               | The container images within a service.                                                                   |
+| `ports`<br/>_object_               | The list of ports that are exposed by this service.                                                      |
+| `spec`<br/>_object_                | The attributes that a user creates on a service.                                                         |
+| `spec.selector`<br/>_object_       | The keys and values corresponding to pod labels, used to determine where service traffic will be routed. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -1,8 +1,8 @@
-### Stateful Sets
+### StatefulSets
 
 <!-------------------- LIST STATEFUL SETS -------------------->
 
-#### List stateful sets
+#### List statefulsets
 
 ```shell
 curl -X GET \
@@ -17,9 +17,7 @@ curl -X GET \
   "data": [
     {
       "id": "test-aerospike/auth",
-      "images": [
-        "aerospike/aerospike-server:4.5.0.5"
-      ],
+      "images": ["aerospike/aerospike-server:4.5.0.5"],
       "metadata": {},
       "spec": {},
       "status": {}
@@ -33,20 +31,20 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets</code>
 
-Retrieve a list of all stateful sets in a given [environment](#administration-environments).
+Retrieve a list of all statefulsets in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>*string*                         | The id of the stateful set                                      |
-| `metadata` <br/>*object*                   | The metadata of the stateful set                                |
-| `spec`<br/>*object*                        | The specification used to create and run the stateful set       |
-| `status`<br/>*object*                      | The status information of the stateful set                      |
+| Attributes               | &nbsp;                                                    |
+| ------------------------ | --------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the statefulset.                                |
+| `metadata` <br/>_object_ | The metadata of the statefulset.                          |
+| `spec`<br/>_object_      | The specification used to create and run the statefulset. |
+| `status`<br/>_object_    | The status information of the statefulset.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
 <!-------------------- GET A STATEFUL SET -------------------->
 
-#### Get a stateful set
+#### Get a statefulset
 
 ```shell
 curl -X GET \
@@ -61,9 +59,7 @@ curl -X GET \
   "data": {
     "id": "test-aerospike/auth",
     "replicaRatio": "1 / 1",
-    "images": [
-      "aerospike/aerospike-server:4.5.0.5"
-    ],
+    "images": ["aerospike/aerospike-server:4.5.0.5"],
     "apiVersion": "apps/v1",
     "kind": "StatefulSet",
     "metadata": {},
@@ -75,20 +71,21 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id</code>
 
-Retrieve a stateful set and all its info in a given [environment](#administration-environments).
+Retrieve a statefulset and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>*string*                         | The id of the stateful set                                      |
-| `metadata` <br/>*object*                   | The metadata of the stateful set                                |
-| `spec`<br/>*object*                        | The specification used to create and run the stateful set       |
-| `status`<br/>*object*                      | The status information of the stateful set                      |
+| Attributes               | &nbsp;                                                    |
+| ------------------------ | --------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the statefulset.                                |
+| `metadata` <br/>_object_ | The metadata of the statefulset.                          |
+| `spec`<br/>_object_      | The specification used to create and run the statefulset. |
+| `status`<br/>_object_    | The status information of the statefulset.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
 <!-------------------- CREATE A STATEFUL SET -------------------->
 
-#### Create a stateful set
+#### Create a statefulset
+
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
@@ -137,35 +134,34 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets</code>
 
+Create a statefulset in a given [environment](#administration-environments).
 
-Create a stateful set in a given [environment](#administration-environments).
+| Required Attributes           | &nbsp;                                                                      |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the statefulset.                      |
+| `metadata` <br/>_object_      | The metadata of the statefulset.                                            |
+| `metadata.name` <br/>_string_ | The name of the statefulset.                                                |
+| `spec`<br/>_object_           | The specification used to create and run the statefulset.                   |
+| `spec.selector`<br/>_object_  | The label query over the statefulset's of resources.                        |
+| `spec.template`<br/>_object_  | The data a statefulset's pod should have when created.                      |
+| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the statefulset. |
 
-| Required Attributes                        | &nbsp;                                                                      |
-| ------------------------------------------ | ----------------------------------------------------------------------------|
-| `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set                      |
-| `metadata` <br/>_object_                   | The metadata of the stateful set                                            |
-| `metadata.name` <br/>_string_              | The name of the stateful set                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the stateful set                   |
-| `spec.selector`<br/>_object_               | The label query over the stateful set's of resources                        |
-| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created                      |
-| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the stateful set |
-
-| Optional Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
-| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                        |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set        |
+| Optional Attributes                      | &nbsp;                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                      | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_       | The namespace in which the statefulset is created.                      |
+| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a statefulset.      |
 
 Return value:
 
-| Attributes                 | &nbsp;                                                |
----------------------------- | ------------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the create stateful set task. |
-| `taskStatus` <br/>*string* | The status of the operation.                          |
+| Attributes                 | &nbsp;                                               |
+| -------------------------- | ---------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create statefulset task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                         |
 
 <!-------------------- DELETE STATEFUL SET -------------------->
 
-#### Delete a stateful set
+#### Delete a statefulset
 
 ```shell
 curl -X DELETE \
@@ -184,9 +180,15 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id</code>
 
-Delete a stateful set from a given [environment](#administration-environments).
+Delete a statefulset from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                                |
-| -------------------------- | ----------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete stateful set task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                          |
+| Required           | &nbsp;                     |
+| ------------------ | -------------------------- |
+| `id` <br/>_string_ | The id of the statefulset. |
+
+Return value:
+
+| Attributes                 | &nbsp;                                               |
+| -------------------------- | ---------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete statefulset task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                         |

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -67,6 +67,7 @@ Retrieve a list of all storage classes in a given [environment](#administration-
 | `provisioner` <br/>_string_           | The provisioner for the storage class.                                                                                                      |
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
+
 <!-------------------- GET A storage class -------------------->
 
 #### Get a storage class
@@ -81,37 +82,37 @@ curl -X GET \
 
 ```json
 {
-    "data": {
-      "id": "rook-ceph-block",
-      "isDefault": true,
-      "allowVolumeExpansion": true,
-      "metadata": {
-        "annotations": {
-          "storageclass.kubernetes.io/is-default-class": "true"
-        },
-        "creationTimestamp": "2020-04-20T16:08:54.000-04:00",
-        "name": "rook-ceph-block",
-        "resourceVersion": "107033002",
-        "selfLink": "/apis/storage.k8s.io/v1/storageclasses/rook-ceph-block",
-        "uid": "f289c0e6-3f20-4274-8cb8-5db8b34dece6"
+  "data": {
+    "id": "rook-ceph-block",
+    "isDefault": true,
+    "allowVolumeExpansion": true,
+    "metadata": {
+      "annotations": {
+        "storageclass.kubernetes.io/is-default-class": "true"
       },
-      "parameters": {
-        "clusterID": "rook-ceph",
-        "csi.storage.k8s.io/controller-expand-secret-name": "rook-csi-rbd-provisioner",
-        "csi.storage.k8s.io/controller-expand-secret-namespace": "rook-ceph",
-        "csi.storage.k8s.io/fstype": "ext4",
-        "csi.storage.k8s.io/node-stage-secret-name": "rook-csi-rbd-node",
-        "csi.storage.k8s.io/node-stage-secret-namespace": "rook-ceph",
-        "csi.storage.k8s.io/provisioner-secret-name": "rook-csi-rbd-provisioner",
-        "csi.storage.k8s.io/provisioner-secret-namespace": "rook-ceph",
-        "imageFeatures": "layering",
-        "imageFormat": "2",
-        "pool": "replicapool"
-      },
-      "provisioner": "rook-ceph.rbd.csi.ceph.com",
-      "reclaimPolicy": "Delete",
-      "volumeBindingMode": "Immediate"
-    }
+      "creationTimestamp": "2020-04-20T16:08:54.000-04:00",
+      "name": "rook-ceph-block",
+      "resourceVersion": "107033002",
+      "selfLink": "/apis/storage.k8s.io/v1/storageclasses/rook-ceph-block",
+      "uid": "f289c0e6-3f20-4274-8cb8-5db8b34dece6"
+    },
+    "parameters": {
+      "clusterID": "rook-ceph",
+      "csi.storage.k8s.io/controller-expand-secret-name": "rook-csi-rbd-provisioner",
+      "csi.storage.k8s.io/controller-expand-secret-namespace": "rook-ceph",
+      "csi.storage.k8s.io/fstype": "ext4",
+      "csi.storage.k8s.io/node-stage-secret-name": "rook-csi-rbd-node",
+      "csi.storage.k8s.io/node-stage-secret-namespace": "rook-ceph",
+      "csi.storage.k8s.io/provisioner-secret-name": "rook-csi-rbd-provisioner",
+      "csi.storage.k8s.io/provisioner-secret-namespace": "rook-ceph",
+      "imageFeatures": "layering",
+      "imageFormat": "2",
+      "pool": "replicapool"
+    },
+    "provisioner": "rook-ceph.rbd.csi.ceph.com",
+    "reclaimPolicy": "Delete",
+    "volumeBindingMode": "Immediate"
+  }
 }
 ```
 
@@ -119,18 +120,22 @@ curl -X GET \
 
 Retrieve a storage class and all its info in a given [environment](#administration-environments).
 
+| Required           | &nbsp;                                                         |
+| ------------------ | -------------------------------------------------------------- |
+| `id` <br/>_string_ | The id of the storage class. This is the name of the resource. |
+
 | Attributes                            | &nbsp;                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id` <br/>_string_                    | The id of the storage class. This is the name of the resource                                                                               |
-| `isDefault` <br/>_boolean_            | Whether or not the storage class is the default one                                                                                         |
+| `isDefault` <br/>_boolean_            | Whether or not the storage class is the default one.                                                                                        |
 | `allowVolumeExpansion` <br/>_boolean_ | Whether not the storage class allows for expandable volumes.                                                                                |
 | `metadata` <br/>_object_              | The metadata of the storage class.                                                                                                          |
 | `parameters` <br/>_object_            | The parameters for the storage provisioner. These are storage provisioner specific and you will likely have to read external documentation. |
-| `provisioner` <br/>_string_           | The provsioner for the storage class                                                                                                        |
+| `provisioner` <br/>_string_           | The provsioner for the storage class.                                                                                                       |
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
 
 <!-------------------- DELETE A storage class -------------------->
+
 #### Delete a storage class
 
 ```shell
@@ -152,7 +157,13 @@ curl -X DELETE \
 
 Delete a storage class from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                              |
-| -------------------------- | --------------------------------------------------- |
+| Required           | &nbsp;                       |
+| ------------------ | ---------------------------- |
+| `id` <br/>_string_ | The id of the storage class. |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                 |
+| -------------------------- | ------------------------------------------------------ |
 | `taskId` <br/>_string_     | The id corresponding to the delete storage class task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                        |
+| `taskStatus` <br/>_string_ | The status of the operation.                           |

--- a/source/includes/kubernetes_extension/_k8_configmaps.md
+++ b/source/includes/kubernetes_extension/_k8_configmaps.md
@@ -33,18 +33,18 @@ curl -X GET \
 
 Retrieve a list of all config maps in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                  |
-| -------------------------- | ------------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to list the config maps. |
+| Required                   | &nbsp;                                                 |
+| -------------------------- | ------------------------------------------------------ |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the configmaps. |
 
-| Attributes                                 | &nbsp;                                             |
-| ------------------------------------------ | -------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the config map                           |
-| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map   |
-| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap   |
-| `metadata` <br/>_object_                   | The metadata of the config map                     |
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `id` <br/>_string_         | The id of the configmap.                          |
+| `apiVersion` <br/>_string_ | The API version used to retrieve this configmap.  |
+| `kind` <br/>_string_       | The type of the returned resource. ie, ConfigMap. |
+| `metadata` <br/>_object_   | The metadata of the configmap.                    |
 
-<!-------------------- GET A configmap -------------------->
+<!-------------------- GET A CONFIGMAP -------------------->
 
 ##### Get a configmap
 
@@ -74,13 +74,13 @@ curl -X GET \
 
 Retrieve a configmap and all its info in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                |
-| -------------------------- | ----------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to get the config map. |
+| Required                   | &nbsp;                                               |
+| -------------------------- | ---------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the configmap. |
+| `id` <br/>_string_         | The id of the configmap.                             |
 
-| Attributes                                 | &nbsp;                                             |
-| ------------------------------------------ | -------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the config map                           |
-| `apiVersion` <br/>_string_                 | The API version used to retrieve this config map   |
-| `kind` <br/>_string_                       | The type of the returned resource. ie, ConfigMap   |
-| `metadata` <br/>_object_                   | The metadata of the config map                     |
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `apiVersion` <br/>_string_ | The API version used to retrieve this configmap.  |
+| `kind` <br/>_string_       | The type of the returned resource. ie, ConfigMap. |
+| `metadata` <br/>_object_   | The metadata of the configmap.                    |

--- a/source/includes/kubernetes_extension/_k8_configmaps.md
+++ b/source/includes/kubernetes_extension/_k8_configmaps.md
@@ -1,6 +1,6 @@
 #### ConfigMaps
 
-<!-------------------- LIST CONFIG MAPS -------------------->
+<!-------------------- LIST CONFIGMAPS -------------------->
 
 ##### List configmaps
 

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -1,8 +1,8 @@
-#### Daemon Sets
+#### daemonsets
 
-<!-------------------- LIST DAEMON SETS -------------------->
+<!-------------------- LIST daemonsetS -------------------->
 
-##### List daemon sets
+##### List daemonsets
 
 ```shell
 curl -X GET \
@@ -31,24 +31,24 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets?cluster_id=:cluster_id</code>
 
-Retrieve a list of all daemon sets in a given [environment](#administration-environments).
+Retrieve a list of all daemonsets in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                  |
-| -------------------------- | ------------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to list the daemon sets. |
+| Required                   | &nbsp;                                                 |
+| -------------------------- | ------------------------------------------------------ |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the daemonsets. |
+| `id` <br/>_string_         | The id of the daemonset.                               |
 
 | Attributes               | &nbsp;                                                  |
 | ------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_       | The id of the daemon set                                |
-| `metadata` <br/>_object_ | The metadata of the daemon set                          |
-| `spec`<br/>_object_      | The specification used to create and run the daemon set |
-| `status`<br/>_object_    | The status information of the daemon set                |
+| `metadata` <br/>_object_ | The metadata of the daemonset.                          |
+| `spec`<br/>_object_      | The specification used to create and run the daemonset. |
+| `status`<br/>_object_    | The status information of the daemonset.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- GET A DAEMON SET -------------------->
+<!-------------------- GET A daemonset -------------------->
 
-##### Get a daemon set
+##### Get a daemonset
 
 ```shell
 curl -X GET \
@@ -74,24 +74,25 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id?cluster_id=:cluster_id</code>
 
-Retrieve a daemon set and all its info in a given [environment](#administration-environments).
+Retrieve a daemonset and all its info in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                |
-| -------------------------- | ----------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to get the daemon set. |
+| Required                   | &nbsp;                                                 |
+| -------------------------- | ------------------------------------------------------ |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the daemonsets. |
+| `id` <br/>_string_         | The id of the daemonset.                               |
 
 | Attributes               | &nbsp;                                                  |
 | ------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_       | The id of the daemon set                                |
-| `metadata` <br/>_object_ | The metadata of the daemon set                          |
-| `spec`<br/>_object_      | The specification used to create and run the daemon set |
-| `status`<br/>_object_    | The status information of the daemon set                |
+| `metadata` <br/>_object_ | The metadata of the daemonset.                          |
+| `spec`<br/>_object_      | The specification used to create and run the daemonset. |
+| `status`<br/>_object_    | The status information of the daemonset.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- CREATE DAEMON SET -------------------->
+<!-------------------- CREATE daemonset -------------------->
 
-##### Create a daemon set
+##### Create a daemonset
+
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
@@ -139,34 +140,35 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets?cluster_id=:cluster_id</code>
 
-Create a daemon set in a given [environment](#administration-environments).
+Create a daemonset in a given [environment](#administration-environments).
 
-| Required Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | --------------------------------------------------------------------------|
-| `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set                      |
-| `metadata` <br/>_object_                   | The metadata of the daemon set                                            |
-| `metadata.name` <br/>_string_              | The name of the daemon set                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set                   |
-| `spec.selector`<br/>_object_               | The label query over the daemon set's resources                           |
-| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created                      |
-| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set |
+| Required Attributes           | &nbsp;                                                                    |
+| ----------------------------- | ------------------------------------------------------------------------- |
+| `cluster_id` <br/>_string_    | The id of the cluster in which to list the daemonsets.                    |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the daemonset.                      |
+| `metadata` <br/>_object_      | The metadata of the daemonset.                                            |
+| `metadata.name` <br/>_string_ | The name of the daemonset.                                                |
+| `spec`<br/>_object_           | The specification used to create and run the daemonset.                   |
+| `spec.selector`<br/>_object_  | The label query over the daemonset's resources.                           |
+| `spec.template`<br/>_object_  | The data a daemonset's pod should have when created.                      |
+| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the daemonset. |
 
-| Optional Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created                          |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set          |
+| Optional Attributes                      | &nbsp;                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                      | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_       | The namespace in which the daemonset is created.                        |
+| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a daemonset.        |
 
 Return value:
 
-| Attributes                 | &nbsp;                                              |
----------------------------- | ----------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the create daemon set task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                        |
+| Attributes                 | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create daemonset task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                       |
 
-<!-------------------- DELETE DAEMON SET -------------------->
+<!-------------------- DELETE daemonset -------------------->
 
-##### Delete a daemon set
+##### Delete a daemonset
 
 ```shell
 curl -X DELETE \
@@ -185,9 +187,16 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id?cluster_id=:cluster_id</code>
 
-Delete a daemon set from a given [environment](#administration-environments).
+Delete a daemonset from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                              |
-| -------------------------- | --------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete daemon set task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                        |
+| Required                   | &nbsp;                                                  |
+| -------------------------- | ------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to delete the daemonset. |
+| `id` <br/>_string_         | The id of the daemonset.                                |
+
+Return value:
+
+| Attributes                 | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete daemonset task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                       |

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -1,6 +1,6 @@
-#### daemonsets
+#### DaemonSets
 
-<!-------------------- LIST daemonsetS -------------------->
+<!-------------------- LIST DAEMONSETS -------------------->
 
 ##### List daemonsets
 
@@ -46,7 +46,7 @@ Retrieve a list of all daemonsets in a given [environment](#administration-envir
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- GET A daemonset -------------------->
+<!-------------------- GET A DAEMONSET -------------------->
 
 ##### Get a daemonset
 
@@ -89,7 +89,7 @@ Retrieve a daemonset and all its info in a given [environment](#administration-e
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- CREATE daemonset -------------------->
+<!-------------------- CREATE DAEMONSET -------------------->
 
 ##### Create a daemonset
 
@@ -166,7 +166,7 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create daemonset task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                       |
 
-<!-------------------- DELETE daemonset -------------------->
+<!-------------------- DELETE A DAEMONSET -------------------->
 
 ##### Delete a daemonset
 

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -34,18 +34,18 @@ curl -X GET \
 
 Retrieve a list of all deployments in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                  |
-| -------------------------- | ------------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to list the deployments. |
+| Required                   | &nbsp;                                                 |
+| -------------------------- | ------------------------------------------------------ |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the deployments |
+| `id` <br/>_string_         | The id of the deployment                               |
 
-| Attributes                         | &nbsp;                                                            |
-| ---------------------------------- | ----------------------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the deployment                                          |
-| `metadata` <br/>_object_           | The metadata of the deployment                                    |
-| `images` <br/>_object_             | The container images within a deployment                          |
-| `spec`<br/>_object_                | The specification used to create and run the deployment           |
-| `readyRatio` <br/>_object_         | The ready replicas to total replicas ratio of this deployment set |
-| `deploymentStatus`<br/>_object_    | The status information of the deployment                          |
+| Attributes                      | &nbsp;                                                            |
+| ------------------------------- | ----------------------------------------------------------------- |
+| `metadata` <br/>_object_        | The metadata of the deployment                                    |
+| `images` <br/>_object_          | The container images within a deployment                          |
+| `spec`<br/>_object_             | The specification used to create and run the deployment           |
+| `readyRatio` <br/>_object_      | The ready replicas to total replicas ratio of this deployment set |
+| `deploymentStatus`<br/>_object_ | The status information of the deployment                          |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -83,21 +83,23 @@ Retrieve a deployment and all its info in a given [environment](#administration-
 | Required                   | &nbsp;                                                |
 | -------------------------- | ----------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to get the deployment. |
+| `id` <br/>_string_         | The id of the deployment.                             |
 
-| Attributes                         | &nbsp;                                                            |
-| ---------------------------------- | ----------------------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the deployment                                          |
-| `metadata` <br/>_object_           | The metadata of the deployment                                    |
-| `images` <br/>_object_             | The container images within a deployment                          |
-| `spec`<br/>_object_                | The specification used to create and run the deployment           |
-| `readyRatio` <br/>_object_         | The ready replicas to total replicas ratio of this deployment set |
-| `deploymentStatus`<br/>_object_    | The status information of the deployment                          |
+| Attributes                      | &nbsp;                                                         |
+| ------------------------------- | -------------------------------------------------------------- |
+| `id` <br/>_string_              | The id of the deployment.                                      |
+| `metadata` <br/>_object_        | The metadata of the deployment.                                |
+| `images` <br/>_object_          | The container images within a deployment.                      |
+| `spec`<br/>_object_             | The specification used to create and run the deployment.       |
+| `readyRatio` <br/>_object_      | The ready replicas to total replicas ratio of this deployment. |
+| `deploymentStatus`<br/>_object_ | The status information of the deployment.                      |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
 <!-------------------- CREATE DEPLOYMENT -------------------->
 
 ##### Create a deployment
+
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
@@ -148,27 +150,28 @@ curl -X POST \
 
 Create a deployment in a given [environment](#administration-environments).
 
-| Required Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment                      |
-| `metadata` <br/>_object_                   | The metadata of the deployment                                            |
-| `metadata.name` <br/>_string_              | The name of the deployment                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the deployment                   |
-| `spec.selector`<br/>_object_               | The label query over the deployment's set of resources                    |
-| `spec.template`<br/>_object_               | The data a deployment's pod should have when created                      |
-| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment |
+| Required Attributes           | &nbsp;                                                                     |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| `cluster_id` <br/>_string_    | The id of the cluster in which to get the deployment.                      |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the deployment.                      |
+| `metadata` <br/>_object_      | The metadata of the deployment.                                            |
+| `metadata.name` <br/>_string_ | The name of the deployment.                                                |
+| `spec`<br/>_object_           | The specification used to create and run the deployment.                   |
+| `spec.selector`<br/>_object_  | The label query over the deployment's set of resources.                    |
+| `spec.template`<br/>_object_  | The data a deployment's pod should have when created.                      |
+| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the deployment. |
 
-| Optional Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created                          |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment          |
+| Optional Attributes                      | &nbsp;                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                      | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_       | The namespace in which the deployment is created.                       |
+| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a deployment.       |
 
 Return value:
 
-| Attributes                 | &nbsp;                                                |
----------------------------- | ----------------------------------------------------- |
-| `taskId` <br/>*string*     | The id corresponding to the create deployment task.   |
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create deployment task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
 <!-------------------- DELETE DEPLOYMENT -------------------->
@@ -193,6 +196,13 @@ curl -X DELETE \
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id?cluster_id=:cluster_id</code>
 
 Delete a deployment from a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                                |
+| -------------------------- | ----------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the deployment. |
+| `id` <br/>_string_         | The id of the deployment.                             |
+
+Return value:
 
 | Attributes                 | &nbsp;                                              |
 | -------------------------- | --------------------------------------------------- |

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -64,8 +64,8 @@ curl -X GET \
         "selfLink": "/apis/extensions/v1beta1/namespaces/auth/ingresses/cm-acme-http-solver-75png",
         "uid": "48720f48-f2bc-45fc-95c5-60cae8ffe11e"
       },
-      "spec":{
-        "rules":[]
+      "spec": {
+        "rules": []
       },
       "status": {
         "loadBalancer": {}
@@ -83,19 +83,19 @@ Retrieve a list of all ingresses in a given [environment](#administration-enviro
 | -------------------------- | -------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the ingress                                           |
-| `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
-| `service` <br/>_object_                    | The service associated with the ingress                         |
-| `service.port` <br/>_string_               | The port of the service associated with the ingress             |
-| `service.name` <br/>_string_               | The name of the service associated with the ingress             |
-| `metadata` <br/>_object_                   | The metadata of the ingress                                     |
-| `metadata.name` <br/>_string_              | The name of the ingress                                         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
-| `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
-| `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
+| Attributes                         | &nbsp;                                               |
+| ---------------------------------- | ---------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the ingress.                               |
+| `endpoint` <br/>_string_           | The endpoint of the ingress.                         |
+| `service` <br/>_object_            | The service associated with the ingress.             |
+| `service.port` <br/>_string_       | The port of the service associated with the ingress. |
+| `service.name` <br/>_string_       | The name of the service associated with the ingress. |
+| `metadata` <br/>_object_           | The metadata of the ingress.                         |
+| `metadata.name` <br/>_string_      | The name of the ingress.                             |
+| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created.       |
+| `metadata.labels` <br/>_object_    | The labels associated with the ingress.              |
+| `metadata.uid` <br/>_object_       | The UUID of the ingress.                             |
+| `spec`<br/>_object_                | The attributes that a user specifies for an ingress. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -148,19 +148,19 @@ Retrieve an ingress and all its info in a given [environment](#administration-en
 | Required                   | &nbsp;                                             |
 | -------------------------- | -------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
+| `id` <br/>_string_         | The id of the ingress.                             |
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the ingress                                           |
-| `endpoint` <br/>_string_                   | The endpoint of the ingress                                     |
-| `service` <br/>_object_                    | The service associated with the ingress                         |
-| `service.port` <br/>_string_               | The port of the service associated with the ingress             |
-| `service.name` <br/>_string_               | The name of the service associated with the ingress             |
-| `metadata` <br/>_object_                   | The metadata of the ingress                                     |
-| `metadata.name` <br/>_string_              | The name of the ingress                                         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created                   |
-| `metadata.labels` <br/>_object_            | The labels associated with the ingress                          |
-| `metadata.uid` <br/>_object_               | The UUID of the ingress                                         |
-| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
+| Attributes                         | &nbsp;                                               |
+| ---------------------------------- | ---------------------------------------------------- |
+| `endpoint` <br/>_string_           | The endpoint of the ingress.                         |
+| `service` <br/>_object_            | The service associated with the ingress.             |
+| `service.port` <br/>_string_       | The port of the service associated with the ingress. |
+| `service.name` <br/>_string_       | The name of the service associated with the ingress. |
+| `metadata` <br/>_object_           | The metadata of the ingress.                         |
+| `metadata.name` <br/>_string_      | The name of the ingress.                             |
+| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created.       |
+| `metadata.labels` <br/>_object_    | The labels associated with the ingress.              |
+| `metadata.uid` <br/>_object_       | The UUID of the ingress.                             |
+| `spec`<br/>_object_                | The attributes that a user specifies for an ingress. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_namespaces.md
+++ b/source/includes/kubernetes_extension/_k8_namespaces.md
@@ -36,14 +36,14 @@ Retrieve a list of all namespaces in a given [environment](#administration-envir
 | -------------------------- | ------------------------------------------------------ |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to list the namespaces. |
 
-| Attributes                                 | &nbsp;                                                                                    |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the namespace.                                                                  |
-| `apiVersion` <br/>_string_                 | APIVersion defines the versioned schema of this representation of a namespace object      |
-| `kind` <br/>_string_                       | A string value representing the REST resource this object represents                      |
-| `metadata` <br/>_object_                   | The metadata of the namespace                                                             |
-| `spec`<br/>_object_                        | The specification describes the attributes on a namespace.                                |
-| `status`<br/>_object_                      | The status information of the namespace                                                   |
+| Attributes                 | &nbsp;                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| `id` <br/>_string_         | The id of the namespace.                                                              |
+| `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object. |
+| `kind` <br/>_string_       | A string value representing the REST resource this object represents.                 |
+| `metadata` <br/>_object_   | The metadata of the namespace.                                                        |
+| `spec`<br/>_object_        | The specification describes the attributes on a namespace.                            |
+| `status`<br/>_object_      | The status information of the namespace.                                              |
 
 <!-------------------- GET A NAMESPACE -------------------->
 
@@ -77,12 +77,12 @@ Retrieve a namespace and all its info in a given [environment](#administration-e
 | Required                   | &nbsp;                                               |
 | -------------------------- | ---------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to get the namespace. |
+| `id` <br/>_string_         | The id of the namespace.                             |
 
-| Attributes                                 | &nbsp;                                                                                    |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the namespace.                                                                  |
-| `apiVersion` <br/>_string_                 | APIVersion defines the versioned schema of this representation of a namespace object      |
-| `kind` <br/>_string_                       | A string value representing the REST resource this object represents                      |
-| `metadata` <br/>_object_                   | The metadata of the namespace                                                             |
-| `spec`<br/>_object_                        | The specification describes the attributes on a namespace.                                |
-| `status`<br/>_object_                      | The status information of the namespace                                                   |
+| Attributes                 | &nbsp;                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object. |
+| `kind` <br/>_string_       | A string value representing the REST resource this object represents.                 |
+| `metadata` <br/>_object_   | The metadata of the namespace.                                                        |
+| `spec`<br/>_object_        | The specification describes the attributes on a namespace.                            |
+| `status`<br/>_object_      | The status information of the namespace.                                              |

--- a/source/includes/kubernetes_extension/_k8_pods.md
+++ b/source/includes/kubernetes_extension/_k8_pods.md
@@ -1,6 +1,5 @@
 #### Pods
 
-
 <!-------------------- LIST PODS -------------------->
 
 ##### List pods
@@ -10,6 +9,7 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -204,35 +204,30 @@ curl -X GET \
 }
 ```
 
-
-
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods?cluster_id=:cluster_id</code>
 
 Retrieve a list of all pods in a given [environment](#administration-environments).
 
-Required | &nbsp;
-------- | -----------
-`cluster_id` <br/>*string* | The id of the cluster in which to list the pods.
+| Required                   | &nbsp;                                           |
+| -------------------------- | ------------------------------------------------ |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the pods. |
 
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id of the pod.
-`metadata` <br/>*object* | The metadata of the pod.
-`metadata.annotations` <br/>*map* | The annotations of the pod.
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string.
-`metadata.labels` <br/>*map* | The labels associated to the pod.
-`metadata.name` <br/>*string* | The name of the pod.
-`metadata.namespace` <br/>*string* | The namespace in which the pod is created.
-`metadata.uid` <br/>*object* | The UUID of the pod.
-`spec`<br/>*object* | The specification used to create and run the pod.
-`spec.container`<br/>*string* | The name of the container running.
-`status`<br/>*object* | The status information of the pod.
-`status.phase`<br/>*string* | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed.
-
+| Attributes                                 | &nbsp;                                                                                        |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the pod.                                                                            |
+| `metadata` <br/>_object_                   | The metadata of the pod.                                                                      |
+| `metadata.annotations` <br/>_map_          | The annotations of the pod.                                                                   |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the pod as a string.                                                  |
+| `metadata.labels` <br/>_map_               | The labels associated to the pod.                                                             |
+| `metadata.name` <br/>_string_              | The name of the pod.                                                                          |
+| `metadata.namespace` <br/>_string_         | The namespace in which the pod is created.                                                    |
+| `metadata.uid` <br/>_object_               | The UUID of the pod.                                                                          |
+| `spec`<br/>_object_                        | The specification used to create and run the pod.                                             |
+| `spec.container`<br/>_string_              | The name of the container running.                                                            |
+| `status`<br/>_object_                      | The status information of the pod.                                                            |
+| `status.phase`<br/>_string_                | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
-
-
 
 <!-------------------- GET A POD -------------------->
 
@@ -243,6 +238,7 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods/my-aerospike-0/default?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -437,38 +433,35 @@ curl -X GET \
 }
 ```
 
-
-
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id?cluster_id=:cluster_id</code>
 
 Retrieve a pod and all its info in a given [environment](#administration-environments).
 
-Required | &nbsp;
-------- | -----------
-`cluster_id` <br/>*string* | The id of the cluster in which to get the pod.
+| Required                   | &nbsp;                                         |
+| -------------------------- | ---------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the pod. |
+| `id` <br/>_string_         | The id of the pod.                             |
 
-
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id of the pod.
-`metadata` <br/>*object* | The metadata of the pod.
-`metadata.annotations` <br/>*map* | The annotations of the pod.
-`metadata.creationTimestamp` <br/>*string* | The date of creation of the pod as a string.
-`metadata.labels` <br/>*map* | The labels associated to the pod.
-`metadata.name` <br/>*string* | The name of the pod.
-`metadata.namespace` <br/>*string* | The namespace in which the pod is created.
-`metadata.uid` <br/>*object* | The UUID of the pod.
-`spec`<br/>*object* | The specification used to create and run the pod.
-`spec.container`<br/>*string* | The name of the container running.
-`status`<br/>*object* | The status information of the pod.
-`status.phase`<br/>*string* | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed.
-
+| Attributes                                 | &nbsp;                                                                                        |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `metadata` <br/>_object_                   | The metadata of the pod.                                                                      |
+| `metadata.annotations` <br/>_map_          | The annotations of the pod.                                                                   |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the pod as a string.                                                  |
+| `metadata.labels` <br/>_map_               | The labels associated to the pod.                                                             |
+| `metadata.name` <br/>_string_              | The name of the pod.                                                                          |
+| `metadata.namespace` <br/>_string_         | The namespace in which the pod is created.                                                    |
+| `metadata.uid` <br/>_object_               | The UUID of the pod.                                                                          |
+| `spec`<br/>_object_                        | The specification used to create and run the pod.                                             |
+| `spec.container`<br/>_string_              | The name of the container running.                                                            |
+| `status`<br/>_object_                      | The status information of the pod.                                                            |
+| `status.phase`<br/>_string_                | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
 <!-------------------- CREATE POD -------------------->
 
 ##### Create a pod
+
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
@@ -501,32 +494,31 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods?cluster_id=:cluster_id</code>
 
 Create a pod in a given [environment](#administration-environments).
 
-Required Attributes                 | &nbsp;
------------------------------------ | ------------------------------------------------------------
-`apiVersion` <br/>*string*          | The api version (versioned schema) of the pod
-`metadata` <br/>*object*            | The metadata of the pod
-`metadata.name` <br/>*string*       | The name of the pod
-`spec`<br/>*object*                 | The specification used to create and run the pod
-`spec.container.image`<br/>*string* | The docker image name
-`spec.container.name`<br/>*string*  | The (unique) name of the container specified as a DNS_LABEL
+| Required Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `cluster_id` <br/>_string_          | The id of the cluster in which to get the pod.              |
+| `apiVersion` <br/>_string_          | The api version (versioned schema) of the pod               |
+| `metadata` <br/>_object_            | The metadata of the pod                                     |
+| `metadata.name` <br/>_string_       | The name of the pod                                         |
+| `spec`<br/>_object_                 | The specification used to create and run the pod            |
+| `spec.container.image`<br/>_string_ | The docker image name                                       |
+| `spec.container.name`<br/>_string_  | The (unique) name of the container specified as a DNS_LABEL |
 
-| Optional Attributes                       | &nbsp;                                                                  |
-| ----------------------------------------- | ----------------------------------------------------------------------- |
-| `kind`<br/>_string_                       | The string value representing the REST resource this object represents  |
-| `metadata.namespace` <br/>*string*        | The namespace in which the pod is created                               |
+| Optional Attributes                | &nbsp;                                                                 |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| `kind`<br/>_string_                | The string value representing the REST resource this object represents |
+| `metadata.namespace` <br/>_string_ | The namespace in which the pod is created                              |
 
 Return value:
 
 | Attributes                 | &nbsp;                                       |
----------------------------- | ---------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the create pod task. |
-| `taskStatus` <br/>*string* | The status of the operation.                 |
-
-
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE POD -------------------->
 
@@ -537,6 +529,7 @@ curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods/my-aerospike-0/default?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -546,18 +539,18 @@ curl -X DELETE \
 }
 ```
 
-
-
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id?cluster_id=:cluster_id</code>
 
 Delete a pod from a given [environment](#administration-environments).
 
-Required | &nbsp;
-------- | -----------
-`cluster_id` <br/>*string* | The id of the cluster in which to delete the pod.
+| Required                   | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to delete the pod. |
+| `id` <br/>_string_         | The id of the pod.                                |
 
+Return value:
 
-Attributes | &nbsp;
-------- | -----------
-`taskId` <br/>*string* | The task id related to the delete pod task.
-`taskStatus` <br/>*string* | The status of the operation.
+| Attributes                 | &nbsp;                                      |
+| -------------------------- | ------------------------------------------- |
+| `taskId` <br/>_string_     | The task id related to the delete pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                |

--- a/source/includes/kubernetes_extension/_k8_secrets.md
+++ b/source/includes/kubernetes_extension/_k8_secrets.md
@@ -43,7 +43,7 @@ Retrieve a list of all secrets in a given [environment](#administration-environm
 | `cluster_id` <br/>_string_ | The id of the cluster in which to list the secrets. |
 
 | Attributes                 | &nbsp;                                                                     |
-| -------------------------- | ---------------------------------------------------------------------------|
+| -------------------------- | -------------------------------------------------------------------------- |
 | `id` <br/>_string_         | The id of the secret.                                                      |
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `data` <br/>_string_       | The data that the secret contains.                                         |
@@ -65,18 +65,18 @@ curl -X GET \
 
 ```json
 {
+  "data": {
+    "id": "default-token-xxxmt/default",
+    "apiVersion": "v1",
     "data": {
-        "id": "default-token-xxxmt/default",
-        "apiVersion": "v1",
-        "data": {
-            "ca.crt": [],
-            "namespace": [],
-            "token": []
-        },
-        "kind": "Secret",
-        "metadata": {},
-        "type": "kubernetes.io/service-account-token"
-    }
+      "ca.crt": [],
+      "namespace": [],
+      "token": []
+    },
+    "kind": "Secret",
+    "metadata": {},
+    "type": "kubernetes.io/service-account-token"
+  }
 }
 ```
 
@@ -87,10 +87,10 @@ Retrieve a secret and all its info in a given [environment](#administration-envi
 | Required                   | &nbsp;                                            |
 | -------------------------- | ------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to get the secret. |
+| `id` <br/>_string_         | The id of the secret.                             |
 
 | Attributes                 | &nbsp;                                                                     |
-| -------------------------- | ---------------------------------------------------------------------------|
-| `id` <br/>_string_         | The id of the secret.                                                      |
+| -------------------------- | -------------------------------------------------------------------------- |
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `data` <br/>_string_       | The data that the secret contains.                                         |
 | `metadata` <br/>_object_   | The metadata of the secret.                                                |

--- a/source/includes/kubernetes_extension/_k8_services.md
+++ b/source/includes/kubernetes_extension/_k8_services.md
@@ -17,10 +17,7 @@ curl -X GET \
   "data": [
     {
       "id": "alaintest-aerospike/default",
-      "ports": [
-        "3000/TCP",
-        "3002/TCP"
-      ],
+      "ports": ["3000/TCP", "3002/TCP"],
       "type": "ClusterIP",
       "metadata": {},
       "spec": {},
@@ -30,22 +27,18 @@ curl -X GET \
     },
     {
       "id": "alertmanager-operated/monitoring",
-      "ports": [
-        "9093/TCP",
-        "9094/TCP",
-        "9094/UDP"
-      ],
+      "ports": ["9093/TCP", "9094/TCP", "9094/UDP"],
       "type": "NodePort",
       "apiVersion": "v1",
       "kind": "Service",
       "metadata": {},
       "spec": {},
       "status": {
-       "loadBalancer": {}
+        "loadBalancer": {}
       }
     }
   ],
-    "metadata": {
+  "metadata": {
     "recordCount": 2
   }
 }
@@ -54,21 +47,21 @@ curl -X GET \
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services?cluster_id=:cluster_id</code>
 
 Retrieve a list of all services in a given [environment](#administration-environments).
-| Required                   | &nbsp;                                             |
+| Required | &nbsp; |
 | -------------------------- | -------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to get the service. |
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the service                                           |
-| `metadata` <br/>_object_                   | The metadata of the service                                     |
-| `metadata.name` <br/>_string_              | The name of the service                                         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the service is created                   |
-| `metadata.uid` <br/>_object_               | The UUID of the service                                         |
-| `type` <br/>_object_                       | The container images within a service                           |
-| `ports`<br/>_object_                       | The list of ports that are exposed by this service              |
-| `spec`<br/>_object_                        | The attributes that a user creates on a service                 |
-| `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
+| Attributes                         | &nbsp;                                                                                                   |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the service.                                                                                   |
+| `metadata` <br/>_object_           | The metadata of the service.                                                                             |
+| `metadata.name` <br/>_string_      | The name of the service.                                                                                 |
+| `metadata.namespace` <br/>_string_ | The namespace in which the service is created.                                                           |
+| `metadata.uid` <br/>_object_       | The UUID of the service.                                                                                 |
+| `type` <br/>_object_               | The container images within a service.                                                                   |
+| `ports`<br/>_object_               | The list of ports that are exposed by this service.                                                      |
+| `spec`<br/>_object_                | The attributes that a user creates on a service.                                                         |
+| `spec.selector`<br/>_object_       | The keys and values corresponding to pod labels, used to determine where service traffic will be routed. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -88,10 +81,7 @@ curl -X GET \
 {
   "data": {
     "id": "test-aerospike/auth",
-    "ports": [
-      "3000/TCP",
-      "3002/TCP"
-    ],
+    "ports": ["3000/TCP", "3002/TCP"],
     "type": "ClusterIP",
     "apiVersion": "v1",
     "kind": "Service",
@@ -111,17 +101,17 @@ Retrieve a service and all its info in a given [environment](#administration-env
 | Required                   | &nbsp;                                             |
 | -------------------------- | -------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to get the service. |
+| `id` <br/>_string_         | The id of the service.                             |
 
-| Attributes                                 | &nbsp;                                                          |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the service                                           |
-| `metadata` <br/>_object_                   | The metadata of the service                                     |
-| `metadata.name` <br/>_string_              | The name of the service                                         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the service is created                   |
-| `metadata.uid` <br/>_object_               | The UUID of the service                                         |
-| `type` <br/>_object_                       | The container images within a service                           |
-| `ports`<br/>_object_                       | The list of ports that are exposed by this service              |
-| `spec`<br/>_object_                        | The attributes that a user creates on a service                 |
-| `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
+| Attributes                         | &nbsp;                                                                                                   |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `metadata` <br/>_object_           | The metadata of the service.                                                                             |
+| `metadata.name` <br/>_string_      | The name of the service.                                                                                 |
+| `metadata.namespace` <br/>_string_ | The namespace in which the service is created.                                                           |
+| `metadata.uid` <br/>_object_       | The UUID of the service.                                                                                 |
+| `type` <br/>_object_               | The container images within a service.                                                                   |
+| `ports`<br/>_object_               | The list of ports that are exposed by this service.                                                      |
+| `spec`<br/>_object_                | The attributes that a user creates on a service.                                                         |
+| `spec.selector`<br/>_object_       | The keys and values corresponding to pod labels, used to determine where service traffic will be routed. |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -1,8 +1,8 @@
-#### Stateful Sets
+#### statefulsets
 
-<!-------------------- LIST STATEFUL SETS -------------------->
+<!-------------------- LIST statefulsetS -------------------->
 
-##### List stateful sets
+##### List statefulsets
 
 ```shell
 curl -X GET \
@@ -31,24 +31,24 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets?cluster_id=:cluster_id</code>
 
-Retrieve a list of all stateful sets in a given [environment](#administration-environments).
+Retrieve a list of all statefulsets in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                    |
-| -------------------------- | --------------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to list the stateful sets. |
+| Required                   | &nbsp;                                                   |
+| -------------------------- | -------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the statefulsets. |
 
-| Attributes                                 | &nbsp;                                                    |
-| ------------------------------------------ | --------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the stateful set                                |
-| `metadata` <br/>_object_                   | The metadata of the stateful set                          |
-| `spec`<br/>_object_                        | The specification used to create and run the stateful set |
-| `status`<br/>_object_                      | The status information of the stateful set                |
+| Attributes               | &nbsp;                                                    |
+| ------------------------ | --------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the statefulset.                                |
+| `metadata` <br/>_object_ | The metadata of the statefulset.                          |
+| `spec`<br/>_object_      | The specification used to create and run the statefulset. |
+| `status`<br/>_object_    | The status information of the statefulset.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- GET A STATEFUL SET -------------------->
+<!-------------------- GET A statefulset -------------------->
 
-##### Get a stateful set
+##### Get a statefulset
 
 ```shell
 curl -X GET \
@@ -75,24 +75,25 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id?cluster_id=:cluster_id</code>
 
-Retrieve a stateful set and all its info in a given [environment](#administration-environments).
+Retrieve a statefulset and all its info in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                  |
-| -------------------------- | ------------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to get the stateful set. |
+| Required                   | &nbsp;                                                 |
+| -------------------------- | ------------------------------------------------------ |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the statefulset. |
+| `id` <br/>_string_         | The id of the statefulset.                             |
 
-| Attributes                                 | &nbsp;                                                    |
-| ------------------------------------------ | --------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the stateful set                                |
-| `metadata` <br/>_object_                   | The metadata of the stateful set                          |
-| `spec`<br/>_object_                        | The specification used to create and run the stateful set |
-| `status`<br/>_object_                      | The status information of the stateful set                |
+| Attributes               | &nbsp;                                                    |
+| ------------------------ | --------------------------------------------------------- |
+| `metadata` <br/>_object_ | The metadata of the statefulset.                          |
+| `spec`<br/>_object_      | The specification used to create and run the statefulset. |
+| `status`<br/>_object_    | The status information of the statefulset.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- CREATE A STATEFUL SET -------------------->
+<!-------------------- CREATE A statefulset -------------------->
 
-##### Create a stateful set
+##### Create a statefulset
+
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
@@ -141,35 +142,35 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets?cluster_id=:cluster_id</code>
 
+Create a statefulset in a given [environment](#administration-environments).
 
-Create a stateful set in a given [environment](#administration-environments).
+| Required Attributes           | &nbsp;                                                                      |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `cluster_id` <br/>_string_    | The id of the cluster in which to delete the statefulset.                   |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the statefulset.                      |
+| `metadata` <br/>_object_      | The metadata of the statefulset.                                            |
+| `metadata.name` <br/>_string_ | The name of the statefulset.                                                |
+| `spec`<br/>_object_           | The specification used to create and run the statefulset.                   |
+| `spec.selector`<br/>_object_  | The label query over the statefulset's resources.                           |
+| `spec.template`<br/>_object_  | The data a statefulset's pod should have when created.                      |
+| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the statefulset. |
 
-| Required Attributes                        | &nbsp;                                                                      |
-| ------------------------------------------ | ----------------------------------------------------------------------------|
-| `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set                      |
-| `metadata` <br/>_object_                   | The metadata of the stateful set                                            |
-| `metadata.name` <br/>_string_              | The name of the stateful set                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the stateful set                   |
-| `spec.selector`<br/>_object_               | The label query over the stateful set's resources                           |
-| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created                      |
-| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the stateful set |
-
-| Optional Attributes                        | &nbsp;                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents    |
-| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created                        |
-| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set        |
+| Optional Attributes                      | &nbsp;                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                      | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_       | The namespace in which the statefulset is created.                      |
+| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a statefulset.      |
 
 Return value:
 
-| Attributes                 | &nbsp;                                                |
----------------------------- | ------------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the create stateful set task. |
-| `taskStatus` <br/>*string* | The status of the operation.                          |
+| Attributes                 | &nbsp;                                               |
+| -------------------------- | ---------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create statefulset task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                         |
 
-<!-------------------- DELETE STATEFUL SET -------------------->
+<!-------------------- DELETE statefulset -------------------->
 
-##### Delete a stateful set
+##### Delete a statefulset
 
 ```shell
 curl -X DELETE \
@@ -188,9 +189,16 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id?cluster_id=:cluster_id</code>
 
-Delete a stateful set from a given [environment](#administration-environments).
+Delete a statefulset from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                                |
-| -------------------------- | ----------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the delete stateful set task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                          |
+| Required                   | &nbsp;                                                    |
+| -------------------------- | --------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to delete the statefulset. |
+| `id` <br/>_string_         | The id of the statefulset.                                |
+
+Return value:
+
+| Attributes                 | &nbsp;                                               |
+| -------------------------- | ---------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete statefulset task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                         |

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -1,6 +1,6 @@
-#### statefulsets
+#### StatefulSets
 
-<!-------------------- LIST statefulsetS -------------------->
+<!-------------------- LIST STATEFULSETS -------------------->
 
 ##### List statefulsets
 
@@ -46,7 +46,7 @@ Retrieve a list of all statefulsets in a given [environment](#administration-env
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- GET A statefulset -------------------->
+<!-------------------- GET A STATEFULSET -------------------->
 
 ##### Get a statefulset
 
@@ -90,7 +90,7 @@ Retrieve a statefulset and all its info in a given [environment](#administration
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- CREATE A statefulset -------------------->
+<!-------------------- CREATE A STATEFULSET -------------------->
 
 ##### Create a statefulset
 
@@ -168,7 +168,7 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create statefulset task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                         |
 
-<!-------------------- DELETE statefulset -------------------->
+<!-------------------- DELETE A STATEFULSET -------------------->
 
 ##### Delete a statefulset
 

--- a/source/includes/kubernetes_extension/_k8_storageclasses.md
+++ b/source/includes/kubernetes_extension/_k8_storageclasses.md
@@ -57,13 +57,13 @@ curl -X GET \
 
 Retrieve a list of all storage classes in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                      |
-| -------------------------- | ----------------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to list the storage classes. |
+| Required                   | &nbsp;                                                         |
+| -------------------------- | -------------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the storage classes.    |
+| `id` <br/>_string_         | The id of the storage class. This is the name of the resource. |
 
 | Attributes                            | &nbsp;                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id` <br/>_string_                    | The id of the storage class. This is the name of the resource.                                                                              |
 | `isDefault` <br/>_boolean_            | Whether or not the storage class is the default one.                                                                                        |
 | `allowVolumeExpansion` <br/>_boolean_ | Whether not the storage class allows for expandable volumes.                                                                                |
 | `metadata` <br/>_object_              | The metadata of the storage class.                                                                                                          |
@@ -71,6 +71,7 @@ Retrieve a list of all storage classes in a given [environment](#administration-
 | `provisioner` <br/>_string_           | The provisioner for the storage class.                                                                                                      |
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
+
 <!-------------------- GET A storage class -------------------->
 
 ##### Get a storage class
@@ -85,37 +86,37 @@ curl -X GET \
 
 ```json
 {
-    "data": {
-      "id": "rook-ceph-block",
-      "isDefault": true,
-      "allowVolumeExpansion": true,
-      "metadata": {
-        "annotations": {
-          "storageclass.kubernetes.io/is-default-class": "true"
-        },
-        "creationTimestamp": "2020-04-20T16:08:54.000-04:00",
-        "name": "rook-ceph-block",
-        "resourceVersion": "107033002",
-        "selfLink": "/apis/storage.k8s.io/v1/storageclasses/rook-ceph-block",
-        "uid": "f289c0e6-3f20-4274-8cb8-5db8b34dece6"
+  "data": {
+    "id": "rook-ceph-block",
+    "isDefault": true,
+    "allowVolumeExpansion": true,
+    "metadata": {
+      "annotations": {
+        "storageclass.kubernetes.io/is-default-class": "true"
       },
-      "parameters": {
-        "clusterID": "rook-ceph",
-        "csi.storage.k8s.io/controller-expand-secret-name": "rook-csi-rbd-provisioner",
-        "csi.storage.k8s.io/controller-expand-secret-namespace": "rook-ceph",
-        "csi.storage.k8s.io/fstype": "ext4",
-        "csi.storage.k8s.io/node-stage-secret-name": "rook-csi-rbd-node",
-        "csi.storage.k8s.io/node-stage-secret-namespace": "rook-ceph",
-        "csi.storage.k8s.io/provisioner-secret-name": "rook-csi-rbd-provisioner",
-        "csi.storage.k8s.io/provisioner-secret-namespace": "rook-ceph",
-        "imageFeatures": "layering",
-        "imageFormat": "2",
-        "pool": "replicapool"
-      },
-      "provisioner": "rook-ceph.rbd.csi.ceph.com",
-      "reclaimPolicy": "Delete",
-      "volumeBindingMode": "Immediate"
-    }
+      "creationTimestamp": "2020-04-20T16:08:54.000-04:00",
+      "name": "rook-ceph-block",
+      "resourceVersion": "107033002",
+      "selfLink": "/apis/storage.k8s.io/v1/storageclasses/rook-ceph-block",
+      "uid": "f289c0e6-3f20-4274-8cb8-5db8b34dece6"
+    },
+    "parameters": {
+      "clusterID": "rook-ceph",
+      "csi.storage.k8s.io/controller-expand-secret-name": "rook-csi-rbd-provisioner",
+      "csi.storage.k8s.io/controller-expand-secret-namespace": "rook-ceph",
+      "csi.storage.k8s.io/fstype": "ext4",
+      "csi.storage.k8s.io/node-stage-secret-name": "rook-csi-rbd-node",
+      "csi.storage.k8s.io/node-stage-secret-namespace": "rook-ceph",
+      "csi.storage.k8s.io/provisioner-secret-name": "rook-csi-rbd-provisioner",
+      "csi.storage.k8s.io/provisioner-secret-namespace": "rook-ceph",
+      "imageFeatures": "layering",
+      "imageFormat": "2",
+      "pool": "replicapool"
+    },
+    "provisioner": "rook-ceph.rbd.csi.ceph.com",
+    "reclaimPolicy": "Delete",
+    "volumeBindingMode": "Immediate"
+  }
 }
 ```
 
@@ -123,22 +124,23 @@ curl -X GET \
 
 Retrieve a storage class and all its info in a given [environment](#administration-environments).
 
-| Required                   | &nbsp;                                                      |
-| -------------------------- | ----------------------------------------------------------- |
-| `cluster_id` <br/>_string_ | The id of the cluster in which to list the storage classes. |
+| Required                   | &nbsp;                                                         |
+| -------------------------- | -------------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to list the storage classes.    |
+| `id` <br/>_string_         | The id of the storage class. This is the name of the resource. |
 
 | Attributes                            | &nbsp;                                                                                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id` <br/>_string_                    | The id of the storage class. This is the name of the resource                                                                               |
-| `isDefault` <br/>_boolean_            | Whether or not the storage class is the default one                                                                                         |
+| `isDefault` <br/>_boolean_            | Whether or not the storage class is the default one.                                                                                        |
 | `allowVolumeExpansion` <br/>_boolean_ | Whether not the storage class allows for expandable volumes.                                                                                |
 | `metadata` <br/>_object_              | The metadata of the storage class.                                                                                                          |
 | `parameters` <br/>_object_            | The parameters for the storage provisioner. These are storage provisioner specific and you will likely have to read external documentation. |
-| `provisioner` <br/>_string_           | The provisioner for the storage class                                                                                                       |
+| `provisioner` <br/>_string_           | The provisioner for the storage class.                                                                                                      |
 | `reclaimPolicy` <br/>_string_         | The default volume reclaim policy for this storage class. You have a choice between `Reclaim` or `Delete`.                                  |
 | `volumeBindingMode` <br/>_string_     | The default volume binding model for this storage class. You have a choice between `Immediate` or `WaitForFirstConsumer`.                   |
 
 <!-------------------- DELETE A storage class -------------------->
+
 ##### Delete a storage class
 
 ```shell
@@ -160,7 +162,14 @@ curl -X DELETE \
 
 Delete a storage class from a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                              |
-| -------------------------- | --------------------------------------------------- |
+| Required                   | &nbsp;                                                      |
+| -------------------------- | ----------------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to delete the storage class. |
+| `id` <br/>_string_         | The id of the storage class.                                |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                 |
+| -------------------------- | ------------------------------------------------------ |
 | `taskId` <br/>_string_     | The id corresponding to the delete storage class task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                        |
+| `taskStatus` <br/>_string_ | The status of the operation.                           |


### PR DESCRIPTION
Changes:

- The ID fields in the get/delete requests are required.  I added them where they were missing.
- Some of the docs related to the hyperclouds were missing the cluster_id. I added it where is was missing.
- I also updated the attribute tables to always end with a `.` (we were really inconsistent).