### PR TITLE
MC-12212: Add docs for creates

### DIFF
--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -156,3 +156,67 @@ Retrieve an ingress and all its info in a given [environment](#administration-en
 | `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE INGRESS -------------------->
+
+#### Create an ingress
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/ingresses"
+  Content-Type: application/json
+  {
+  "apiVersion": "networking.k8s.io/v1beta1",
+  "kind": "Ingress",
+  "metadata": {
+    "name": "ingress-name",
+    "namespace": "default",
+    "annotations": {
+      "nginx.ingress.kubernetes.io/rewrite-target": "/"
+    }
+  },
+  "spec": {
+    "rules": [
+      {
+        "hostname": "endpoint.com",
+        "http": {
+          "paths": [
+            {
+              "path": "/testpath",
+              "pathType": "Prefix",
+              "backend": {
+                "serviceName": "test",
+                "servicePort": 80
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses</code>
+
+Create an ingress in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the ingress.                      |
+| `metadata` <br/>_object_                   | The metadata of the ingress.                                            |
+| `metadata.name` <br/>_string_              | The name of the ingress.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the ingress.                   |
+| `spec.rules`<br/>_object_                  | The list of host rules used to configure the ingress.                   |
+
+| Optional Attributes                        | &nbsp;                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------|
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created.                          |
+
+Return value:
+
+| Attributes                 | &nbsp;                                           |
+---------------------------- | -------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the create ingress task. |
+| `taskStatus` <br/>*string* | The status of the operation.                     |

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -137,7 +137,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingress/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id</code>
 
 Retrieve an ingress and all its info in a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -211,7 +211,7 @@ Create an ingress in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                  |
 | ------------------------------------------ | ------------------------------------------------------------------------|
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents. |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.      |
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created.                          |
 
 Return value:

--- a/source/includes/kubernetes/_k8_services.md
+++ b/source/includes/kubernetes/_k8_services.md
@@ -171,7 +171,7 @@ Create a service in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                  |
 | ------------------------------------------ | ------------------------------------------------------------------------|
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents. |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.      |
 | `metadata.namespace` <br/>_string_         | The namespace in which the service is created.                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a service.          |
 

--- a/source/includes/kubernetes/_k8_services.md
+++ b/source/includes/kubernetes/_k8_services.md
@@ -118,3 +118,66 @@ Retrieve a service and all its info in a given [environment](#administration-env
 | `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE SERVICE -------------------->
+
+#### Create a service
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services"
+  Content-Type: application/json
+  {
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "service-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 3000,
+        "protocol": "TCP"
+      }
+    ],
+    "type": "ClusterIP"
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services</code>
+
+Create a service in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the service.                      |
+| `metadata` <br/>_object_                   | The metadata of the service.                                            |
+| `metadata.name` <br/>_string_              | The name of the service.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the service.                   |
+| `spec.selector`<br/>_object_               | The label query over the service's set of resources.                    |
+| `spec.ports`<br/>_object_                  | The list of ports that are exposed by this service.                     |
+| `spec.type`<br/>*object*                   | The type of service (ClusterIP, NodePort, ExternalName or LoadBalancer) |
+
+| Optional Attributes                        | &nbsp;                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------|
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service is created.                          |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a service.          |
+
+Return value:
+
+| Attributes                 | &nbsp;                                           |
+---------------------------- | -------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the create service task. |
+| `taskStatus` <br/>*string* | The status of the operation.                     |

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -141,7 +141,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingress/:id?cluster_id=:cluster_id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id?cluster_id=:cluster_id</code>
 
 Retrieve an ingress and all its info in a given [environment](#administration-environments).
 
@@ -205,7 +205,7 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingress/:id?cluster_id=:cluster_id</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id?cluster_id=:cluster_id</code>
 
 Create an ingress in a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -164,3 +164,71 @@ Retrieve an ingress and all its info in a given [environment](#administration-en
 | `spec`<br/>_object_                        | The attributes that a user specifies for an ingress             |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE AN INGRESS -------------------->
+
+##### Create an ingress
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/ingresses"
+  Content-Type: application/json
+  {
+  "apiVersion": "networking.k8s.io/v1beta1",
+  "kind": "Ingress",
+  "metadata": {
+    "name": "ingress-name",
+    "namespace": "default",
+    "annotations": {
+      "nginx.ingress.kubernetes.io/rewrite-target": "/"
+    }
+  },
+  "spec": {
+    "rules": [
+      {
+        "hostname": "endpoint.com",
+        "http": {
+          "paths": [
+            {
+              "path": "/testpath",
+              "pathType": "Prefix",
+              "backend": {
+                "serviceName": "test",
+                "servicePort": 80
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingress/:id?cluster_id=:cluster_id</code>
+
+Create an ingress in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
+
+| Required Attributes                        | &nbsp;                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the ingress.                      |
+| `metadata` <br/>_object_                   | The metadata of the ingress.                                            |
+| `metadata.name` <br/>_string_              | The name of the ingress.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the ingress.                   |
+| `spec.rules`<br/>_object_                  | The list of host rules used to configure the ingress.                   |
+
+| Optional Attributes                        | &nbsp;                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------|
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created.                          |
+
+Return value:
+
+| Attributes                 | &nbsp;                                           |
+---------------------------- | -------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the create ingress task. |
+| `taskStatus` <br/>*string* | The status of the operation.                     |

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -223,7 +223,7 @@ Create an ingress in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                  |
 | ------------------------------------------ | ------------------------------------------------------------------------|
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents. |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.      |
 | `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created.                          |
 
 Return value:

--- a/source/includes/kubernetes_extension/_k8_services.md
+++ b/source/includes/kubernetes_extension/_k8_services.md
@@ -184,7 +184,7 @@ Create a service in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                  |
 | ------------------------------------------ | ------------------------------------------------------------------------|
-| `kind`<br/>_string_                        | The string value representing the REST resource this object represents. |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.      |
 | `metadata.namespace` <br/>_string_         | The namespace in which the service is created.                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a service.          |
 

--- a/source/includes/kubernetes_extension/_k8_services.md
+++ b/source/includes/kubernetes_extension/_k8_services.md
@@ -125,3 +125,72 @@ Retrieve a service and all its info in a given [environment](#administration-env
 | `spec.selector`<br/>_object_               | The keys and values corresponding to pod labels, used to determine where service traffic will be routed |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE A SERVICE -------------------->
+
+##### Create a service
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/services"
+  Content-Type: application/json
+  {
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "service-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 3000,
+        "protocol": "TCP"
+      }
+    ],
+    "type": "ClusterIP"
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/services/:id?cluster_id=:cluster_id</code>
+
+Create a service in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the service. |
+
+
+| Required Attributes                        | &nbsp;                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the service.                      |
+| `metadata` <br/>_object_                   | The metadata of the service.                                            |
+| `metadata.name` <br/>_string_              | The name of the service.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the service.                   |
+| `spec.selector`<br/>_object_               | The label query over the service's set of resources.                    |
+| `spec.ports`<br/>_object_                  | The list of ports that are exposed by this service.                     |
+| `spec.type`<br/>*object*                   | The type of service (ClusterIP, NodePort, ExternalName or LoadBalancer) |
+
+| Optional Attributes                        | &nbsp;                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------|
+| `kind`<br/>_string_                        | The string value representing the REST resource this object represents. |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service is created.                          |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a service.          |
+
+Return value:
+
+| Attributes                 | &nbsp;                                           |
+---------------------------- | -------------------------------------------------|
+| `taskId` <br/>*string*     | The id corresponding to the create service task. |
+| `taskStatus` <br/>*string* | The status of the operation.                     |


### PR DESCRIPTION
### Fixes [MC-12212](https://cloud-ops.atlassian.net/browse/MC-12212)

#### Changes made
<!-- Changes should match the template provided below -->
- Added the create documents for Ingress and Service entities

#### Related PRs
- [ksdk](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/144)
- [k8s-plugin](https://github.com/cloudops/cloudmc-kubernetes-plugin/pull/41)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->