### PR TITLE
Feature/MC-12077 Add Recaptcha to trial settings

### DIFF
--- a/source/includes/administration/_trials.md
+++ b/source/includes/administration/_trials.md
@@ -28,6 +28,9 @@ curl "https://cloudmc_endpoint/v1/trials_settings" \
       "cleanupDelayDays": 5,
       "expirationReminderDays": 3,
       "allowMultipleTrialSameEmail": false,
+      "enableRecaptcha": true,
+      "recaptchaSitekey": "6Lfg9rkZAAAAAHAwlr6_qs4QBTFRHVFgLhK3XXX",
+      "recaptchaSecretkey": "6Lfg9rkZAAAAAOSjYqghXeQ7zfagZTqXXXRmXXE",
       "contactUsEmail": "email@gmail.com",
       "contactUsPhone": "555-555-555",
       "registrationHTML": {
@@ -52,7 +55,10 @@ Attributes | &nbsp;
 `maxConcurrentTrials`<br/>*integer* | The number of organizations that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
 `cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system will delete the trial's resources.
 `expirationReminderDays`<br/>*integer* | The number of days before the trial's end that the trial administrator will receive an email notification that the trial is about to expire.
-`allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
+`allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address.
+`enableRecaptcha`<br/>*boolean* | If the reCAPTCHA verification on the sign up form is displayed. The reCAPTCHA site key and secret key must be present.
+`recaptchaSitekey`<br/>*string* | The site key obtained from the reCAPTCHA admin console (Google).
+`recaptchaSecretkey`<br/>*string* | The secret key obtained from the reCAPTCHA admin console (Google).
 `contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
 `contactUsPhone`<br/>*string* | The phone number that trial user can contact for more info/support.
 `registrationHTML`<br/>*Object* | Mapped object containing the registration information HTML in different languages.
@@ -83,6 +89,9 @@ curl "https://cloudmc_endpoint/v1/trials_settings/b41f2aa3-e2d1-48d8-9760-8b874c
     "cleanupDelayDays": 5,
     "expirationReminderDays": 3,
     "allowMultipleTrialSameEmail": false,
+    "enableRecaptcha": true,
+    "recaptchaSitekey": "6Lfg9rkZAAAAAHAwlr6_qs4QBTFRHVFgLhK3XXX",
+    "recaptchaSecretkey": "6Lfg9rkZAAAAAOSjYqghXeQ7zfagZTqXXXRmXXE",
     "contactUsEmail": "email@gmail.com",
     "contactUsPhone": "555-555-555",
     "registrationHTML": {
@@ -106,7 +115,10 @@ Attributes | &nbsp;
 `maxConcurrentTrials`<br/>*integer* | The number of organizations that can concurrently have an active trial account. A value of zero indicates that there is no upper limit.
 `cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system will delete the trial's resources.
 `expirationReminderDays`<br/>*integer* | The number of days before the trial's end that the trial administrator will receive an email notification that the trial is about to expire.
-`allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
+`allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address.
+`enableRecaptcha`<br/>*boolean* | If the reCAPTCHA verification on the sign up form is displayed. The reCAPTCHA site key and secret key must be present.
+`recaptchaSitekey`<br/>*string* | The site key obtained from the reCAPTCHA admin console (Google).
+`recaptchaSecretkey`<br/>*string* | The secret key obtained from the reCAPTCHA admin console (Google).
 `contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
 `contactUsPhone`<br/>*string* | The phone number that trial user can contact for more info/support.
 `registrationHTML`<br/>*Object* | Mapped object containing the registration information HTML in different languages.
@@ -136,6 +148,9 @@ curl -X PUT "https://cloudmc_endpoint/rest/trials_settings/:id" \
   "cleanupDelayDays": 5,
   "expirationReminderDays": 3,
   "allowMultipleTrialSameEmail": false,
+  "enableRecaptcha": true,
+  "recaptchaSitekey": "6Lfg9rkZAAAAAHAwlr6_qs4QBTFRHVFgLhK3XXX",
+  "recaptchaSecretkey": "6Lfg9rkZAAAAAOSjYqghXeQ7zfagZTqXXXRmXXE",
   "contactUsEmail": "email@gmail.com",
   "contactUsPhone": "555-555-555",
   "registrationHTML": {
@@ -160,6 +175,9 @@ curl -X PUT "https://cloudmc_endpoint/rest/trials_settings/:id" \
     "cleanupDelayDays": 5,
     "expirationReminderDays": 3,
     "allowMultipleTrialSameEmail": false,
+    "enableRecaptcha": true,
+    "recaptchaSitekey": "6Lfg9rkZAAAAAHAwlr6_qs4QBTFRHVFgLhK3XXX",
+    "recaptchaSecretkey": "6Lfg9rkZAAAAAOSjYqghXeQ7zfagZTqXXXRmXXE",
     "contactUsEmail": "email@gmail.com",
     "contactUsPhone": "555-555-555",
     "registrationHTML": {
@@ -185,6 +203,9 @@ Required | &nbsp;
 `cleanupDelayDays`<br/>*integer* | The number of days after the trial expiration before the system will delete the trial's resources.
 `expirationReminderDays`<br/>*integer* | The number of days before the trial's end that the trial administrator will receive an email notification that the trial is about to expire.
 `allowMultipleTrialSameEmail`<br/>*boolean* | If more than one trial account can be created using the same email address. 
+`enableRecaptcha`<br/>*boolean* | If the reCAPTCHA verification on the sign up form is displayed. The reCAPTCHA site key and secret key must be present.
+`recaptchaSitekey`<br/>*string* | The site key obtained from the reCAPTCHA admin console (Google).
+`recaptchaSecretkey`<br/>*string* | The secret key obtained from the reCAPTCHA admin console (Google).
 `contactUsEmail`<br/>*string* | The email address that trial user can contact for more info/support.
 `registrationHTML`<br/>*Object* | Mapped object containing the registration information HTML in different languages.
 `termsAndConditionsHTML`<br/>*Object* | Mapped object containing the terms and conditions HTML name in different languages.


### PR DESCRIPTION
### Fixes [MC-12077](https://cloud-ops.atlassian.net/browse/MC-12077)

#### Changes made
Added the enableRecaptcha, recaptcha sitekey and recaptcha secret key to the trial settings 

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->