### PR TITLE
Improvement: Fix yucky sentence and formatting issues

### DIFF
--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -32,12 +32,12 @@ curl -X GET \
 
 Retrieve a list of all daemon sets in a given [environment](#administration-environments).
 
-| Attributes               | &nbsp;                                                  |
-| ------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_       | The id of the daemon set                                |
-| `metadata` <br/>_object_ | The metadata of the daemon set                          |
-| `spec`<br/>_object_      | The specification used to create and run the daemon set |
-| `status`<br/>_object_    | The status information of the daemon set                |
+| Attributes                                 | &nbsp;                                                   |
+| ------------------------------------------ | -------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the daemon set.                                |
+| `metadata` <br/>_object_                   | The metadata of the daemon set.                          |
+| `spec`<br/>_object_                        | The specification used to create and run the daemon set. |
+| `status`<br/>_object_                      | The status information of the daemon set.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -68,12 +68,12 @@ curl -X GET \
 
 Retrieve a daemon set and all its info in a given [environment](#administration-environments).
 
-| Attributes               | &nbsp;                                                  |
-| ------------------------ | ------------------------------------------------------- |
-| `id` <br/>_string_       | The id of the daemon set                                |
-| `metadata` <br/>_object_ | The metadata of the daemon set                          |
-| `spec`<br/>_object_      | The specification used to create and run the daemon set |
-| `status`<br/>_object_    | The status information of the daemon set                |
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the daemon set.                                       |
+| `metadata` <br/>_object_                   | The metadata of the daemon set.                                 |
+| `spec`<br/>_object_                        | The specification used to create and run the daemon set.        |
+| `status`<br/>_object_                      | The status information of the daemon set.                       |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -131,21 +131,22 @@ curl -X POST \
 
 Create a daemon set in a given [environment](#administration-environments).
 
-| Required Attributes           | &nbsp;                                                                    |
-| ----------------------------- | ------------------------------------------------------------------------- |
-| `apiVersion` <br/> _string_   | The api version (versioned schema) of the daemon set                      |
-| `metadata` <br/>_object_      | The metadata of the daemon set                                            |
-| `metadata.name` <br/>_string_ | The name of the daemon set                                                |
-| `spec`<br/>_object_           | The specification used to create and run the daemon set                   |
-| `spec.selector`<br/>_object_  | The label query over the daemon set's resources                           |
-| `spec.template`<br/>_object_  | The data a daemon set's pod should have when created                      |
-| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the daemon set |
+| Required Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | ---------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set.                      |
+| `metadata` <br/>_object_                   | The metadata of the daemon set.                                            |
+| `metadata.name` <br/>_string_              | The name of the daemon set.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the daemon set.                   |
+| `spec.selector`<br/>_object_               | The label query over the daemon set's resources.                           |
+| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created.                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set. |
 
-| Optional Attributes                      | &nbsp;                                                                 |
-| ---------------------------------------- | ---------------------------------------------------------------------- |
-| `kind`<br/>_string_                      | The string value representing the REST resource this object represents |
-| `metadata.namespace` <br/>_string_       | The namespace in which the daemon set is created                       |
-| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a daemon set       |
+
+| Optional Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created.                          |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set.          |
 
 Return value:
 

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -34,16 +34,16 @@ curl -X GET \
 
 Retrieve a list of all deployments in a given [environment](#administration-environments).
 
-| Attributes                         | &nbsp;                                                  |
-| ---------------------------------- | ------------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the deployment                                |
-| `metadata` <br/>_object_           | The metadata of the deployment                          |
-| `metadata.name` <br/>_string_      | The name of the deployment                              |
-| `metadata.namespace` <br/>_string_ | The namespace in which the deployment is created        |
-| `metadata.uid` <br/>_object_       | The UUID of the deployment                              |
-| `images` <br/>_object_             | The container images within a deployment                |
-| `spec`<br/>_object_                | The specification used to create and run the deployment |
-| `status`<br/>_object_              | The status information of the deployment                |
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the deployment.                                       |
+| `metadata` <br/>_object_                   | The metadata of the deployment.                                 |
+| `metadata.name` <br/>_string_              | The name of the deployment.                                     |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created.               |
+| `metadata.uid` <br/>_object_               | The UUID of the deployment.                                     |
+| `images` <br/>_object_                     | The container images within a deployment.                       |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment.        |
+| `status`<br/>_object_                      | The status information of the deployment.                       |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -76,13 +76,13 @@ curl -X GET \
 
 Retrieve a deployment and all its info in a given [environment](#administration-environments).
 
-| Attributes                     | &nbsp;                                                            |
-| ------------------------------ | ----------------------------------------------------------------- |
-| `id` <br/>_string_             | The id of the deployment                                          |
-| `deplomentStatus`<br/>_object_ | The status information of the deployment                          |
-| `readyRatio` <br/>_object_     | The ready replicas to total replicas ratio of this deployment set |
-| `metadata` <br/>_object_       | The metadata of the deployment                                    |
-| `spec`<br/>_object_            | The specification used to create and run the deployment           |
+| Attributes                                 | &nbsp;                                                            |
+| ------------------------------------------ | ----------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the deployment.                                         |
+| `deplomentStatus`<br/>_object_             | The status information of the deployment.                         |
+| `readyRatio` <br/>_object_                 | The ready replicas to total replicas ratio of this deployment set.|
+| `metadata` <br/>_object_                   | The metadata of the deployment.                                   |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment.          |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -140,21 +140,21 @@ curl -X POST \
 
 Create a deployment in a given [environment](#administration-environments).
 
-| Required Attributes           | &nbsp;                                                                    |
-| ----------------------------- | ------------------------------------------------------------------------- |
-| `apiVersion` <br/> _string_   | The api version (versioned schema) of the deployment                      |
-| `metadata` <br/>_object_      | The metadata of the deployment                                            |
-| `metadata.name` <br/>_string_ | The name of the deployment                                                |
-| `spec`<br/>_object_           | The specification used to create and run the deployment                   |
-| `spec.selector`<br/>_object_  | The label query over the deployment's set of resources                    |
-| `spec.template`<br/>_object_  | The data a deployment's pod should have when created                      |
-| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the deployment |
+| Required Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment.                      |
+| `metadata` <br/>_object_                   | The metadata of the deployment.                                            |
+| `metadata.name` <br/>_string_              | The name of the deployment.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment.                   |
+| `spec.selector`<br/>_object_               | The label query over the deployment's set of resources.                    |
+| `spec.template`<br/>_object_               | The data a deployment's pod should have when created.                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment. |
 
-| Optional Attributes                      | &nbsp;                                                                 |
-| ---------------------------------------- | ---------------------------------------------------------------------- |
-| `kind`<br/>_string_                      | The string value representing the REST resource this object represents |
-| `metadata.namespace` <br/>_string_       | The namespace in which the deployment is created                       |
-| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a deployment       |
+| Optional Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created.                          |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
 
 Return value:
 

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -79,19 +79,19 @@ curl -X GET \
 
 Retrieve a list of all ingresses in a given [environment](#administration-environments).
 
-| Attributes                         | &nbsp;                                              |
-| ---------------------------------- | --------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the ingress                               |
-| `endpoint` <br/>_string_           | The endpoint of the ingress                         |
-| `service` <br/>_object_            | The service associated with the ingress             |
-| `service.port` <br/>_string_       | The port of the service associated with the ingress |
-| `service.name` <br/>_string_       | The name of the service associated with the ingress |
-| `metadata` <br/>_object_           | The metadata of the ingress                         |
-| `metadata.name` <br/>_string_      | The name of the ingress                             |
-| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created       |
-| `metadata.labels` <br/>_object_    | The labels associated with the ingress              |
-| `metadata.uid` <br/>_object_       | The UUID of the ingress                             |
-| `spec`<br/>_object_                | The attributes that a user specifies for an ingress |
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the ingress.                                          |
+| `endpoint` <br/>_string_                   | The endpoint of the ingress.                                    |
+| `service` <br/>_object_                    | The service associated with the ingress.                        |
+| `service.port` <br/>_string_               | The port of the service associated with the ingress.            |
+| `service.name` <br/>_string_               | The name of the service associated with the ingress.            |
+| `metadata` <br/>_object_                   | The metadata of the ingress.                                    |
+| `metadata.name` <br/>_string_              | The name of the ingress.                                        |
+| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created.                  |
+| `metadata.labels` <br/>_object_            | The labels associated with the ingress.                         |
+| `metadata.uid` <br/>_object_               | The UUID of the ingress.                                        |
+| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress.            |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -141,19 +141,19 @@ curl -X GET \
 
 Retrieve an ingress and all its info in a given [environment](#administration-environments).
 
-| Attributes                         | &nbsp;                                              |
-| ---------------------------------- | --------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the ingress                               |
-| `endpoint` <br/>_string_           | The endpoint of the ingress                         |
-| `service` <br/>_object_            | The service associated with the ingress             |
-| `service.port` <br/>_string_       | The port of the service associated with the ingress |
-| `service.name` <br/>_string_       | The name of the service associated with the ingress |
-| `metadata` <br/>_object_           | The metadata of the ingress                         |
-| `metadata.name` <br/>_string_      | The name of the ingress                             |
-| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created       |
-| `metadata.labels` <br/>_object_    | The labels associated with the ingress              |
-| `metadata.uid` <br/>_object_       | The UUID of the ingress                             |
-| `spec`<br/>_object_                | The attributes that a user specifies for an ingress |
+| Attributes                                 | &nbsp;                                                          |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the ingress.                                          |
+| `endpoint` <br/>_string_                   | The endpoint of the ingress.                                    |
+| `service` <br/>_object_                    | The service associated with the ingress.                        |
+| `service.port` <br/>_string_               | The port of the service associated with the ingress.            |
+| `service.name` <br/>_string_               | The name of the service associated with the ingress.            |
+| `metadata` <br/>_object_                   | The metadata of the ingress.                                    |
+| `metadata.name` <br/>_string_              | The name of the ingress.                                        |
+| `metadata.namespace` <br/>_string_         | The namespace in which the ingress is created.                  |
+| `metadata.labels` <br/>_object_            | The labels associated with the ingress.                         |
+| `metadata.uid` <br/>_object_               | The UUID of the ingress.                                        |
+| `spec`<br/>_object_                        | The attributes that a user specifies for an ingress.            |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -218,5 +218,5 @@ Return value:
 
 | Attributes                 | &nbsp;                                           |
 ---------------------------- | -------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the create ingress task. |
-| `taskStatus` <br/>*string* | The status of the operation.                     |
+| `taskId` <br/>_string_     | The id corresponding to the create ingress task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                     |

--- a/source/includes/kubernetes/_k8_namespaces.md
+++ b/source/includes/kubernetes/_k8_namespaces.md
@@ -32,12 +32,12 @@ curl -X GET \
 
 Retrieve a list of all namespaces in a given [environment](#administration-environments).
 
-| Attributes               | &nbsp;                                                     |
-| ------------------------ | ---------------------------------------------------------- |
-| `id` <br/>_string_       | The id of the namespace.                                   |
-| `metadata` <br/>_object_ | The metadata of the namespace                              |
-| `spec`<br/>_object_      | The specification describes the attributes on a namespace. |
-| `status`<br/>_object_    | The status information of the namespace                    |
+| Attributes                     | &nbsp;                                                                                    |
+| ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `id` <br/>_string_             | The id of the namespace.                                                                  |
+| `metadata` <br/>_object_       | The metadata of the namespace.                                                            |
+| `spec`<br/>_object_            | The specification describes the attributes on a namespace.                                |
+| `status`<br/>_object_          | The status information of the namespace.                                                  |
 
 <!-------------------- GET A NAMESPACE -------------------->
 
@@ -68,11 +68,11 @@ curl -X GET \
 
 Retrieve a namespace and all its info in a given [environment](#administration-environments).
 
-| Attributes                 | &nbsp;                                                                               |
-| -------------------------- | ------------------------------------------------------------------------------------ |
-| `id` <br/>_string_         | The id of the namespace.                                                             |
-| `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object |
-| `kind` <br/>_string_       | A string value representing the REST resource this object represents                 |
-| `metadata` <br/>_object_   | The metadata of the namespace                                                        |
-| `spec`<br/>_object_        | The specification describes the attributes on a namespace.                           |
-| `status`<br/>_object_      | The status information of the namespace                                              |
+| Attributes                 | &nbsp;                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| `id` <br/>_string_         | The id of the namespace.                                                              |
+| `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object. |
+| `kind`<br/>_string_        | The string value of the REST resource that this object represents.                    |
+| `metadata` <br/>_object_   | The metadata of the namespace.                                                        |
+| `spec`<br/>_object_        | The specification describes the attributes on a namespace.                            |
+| `status`<br/>_object_      | The status information of the namespace.                                              |

--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -212,7 +212,7 @@ Create a persistent volume claim in a given [environment](#administration-enviro
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `kind`<br/>_string_                   | The string value representing the REST resource this object represents.                       |
+| `kind`<br/>_string_                   | The string value of the REST resource that this object represents.                            |
 | `metadata.namespace` <br/>_string_    | The namespace in which the pod is created, if not specified will create the claim in default. |
 | `spec.storageClassName` <br/>_string_ | The storage class for the persistent volume claim, will use the default if not specified.     |
 | `spec.resources.limits` <br/>_object_ | Limits describe the maximum number of storage resources allowed.                              |

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -211,17 +211,17 @@ Retrieve a list of all pods in a given [environment](#administration-environment
 | Attributes                                 | &nbsp;                                                                                       |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------- |
 | `id` <br/>_string_                         | The id of the pod.                                                                           |
-| `metadata` <br/>_object_                   | The metadata of the pod                                                                      |
-| `metadata.annotations` <br/>_map_          | The annotations of the pod                                                                   |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the pod as a string                                                  |
-| `metadata.labels` <br/>_map_               | The labels associated to the pod                                                             |
-| `metadata.name` <br/>_string_              | The name of the pod                                                                          |
-| `metadata.namespace` <br/>_string_         | The namespace in which the pod is created                                                    |
-| `metadata.uid` <br/>_object_               | The UUID of the pod                                                                          |
-| `spec`<br/>_object_                        | The specification used to create and run the pod                                             |
-| `spec.container`<br/>_string_              | The name of the container running                                                            |
-| `status`<br/>_object_                      | The status information of the pod                                                            |
-| `status.phase`<br/>_string_                | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed |
+| `metadata` <br/>_object_                   | The metadata of the pod.                                                                     |
+| `metadata.annotations` <br/>_map_          | The annotations of the pod.                                                                  |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the pod as a string.                                                 |
+| `metadata.labels` <br/>_map_               | The labels associated to the pod.                                                            |
+| `metadata.name` <br/>_string_              | The name of the pod.                                                                         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the pod is created.                                                   |
+| `metadata.uid` <br/>_object_               | The UUID of the pod.                                                                         |
+| `spec`<br/>_object_                        | The specification used to create and run the pod.                                            |
+| `spec.container`<br/>_string_              | The name of the container running.                                                           |
+| `status`<br/>_object_                      | The status information of the pod.                                                           |
+| `status.phase`<br/>_string_                | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -433,20 +433,21 @@ curl -X GET \
 
 Retrieve a pod and all its info in a given [environment](#administration-environments).
 
-| Attributes                                 | &nbsp;                                                                                       |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| `id` <br/>_string_                         | The id of the pod.                                                                           |
-| `metadata` <br/>_object_                   | The metadata of the pod                                                                      |
-| `metadata.annotations` <br/>_map_          | The annotations of the pod                                                                   |
-| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the pod as a string                                                  |
-| `metadata.labels` <br/>_map_               | The labels associated to the pod                                                             |
-| `metadata.name` <br/>_string_              | The name of the pod                                                                          |
-| `metadata.namespace` <br/>_string_         | The namespace in which the pod is created                                                    |
-| `metadata.uid` <br/>_object_               | The UUID of the pod                                                                          |
-| `spec`<br/>_object_                        | The specification used to create and run the pod                                             |
-| `spec.container`<br/>_string_              | The name of the container running                                                            |
-| `status`<br/>_object_                      | The status information of the pod                                                            |
-| `status.phase`<br/>_string_                | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed |
+Attributes                                 | &nbsp;
+------------------------------------------ | ---------------------------------------------------------------------------------------------
+`id` <br/>_string_                         | The id of the pod.
+`metadata` <br/>_object_                   | The metadata of the pod.
+`metadata.annotations` <br/>_map_          | The annotations of the pod.
+`metadata.creationTimestamp` <br/>_string_ | The date of creation of the pod as a string.
+`metadata.labels` <br/>_map_               | The labels associated to the pod.
+`metadata.name` <br/>_string_              | The name of the pod.
+`metadata.namespace` <br/>_string_         | The namespace in which the pod is created.
+`metadata.uid` <br/>_object_               | The UUID of the pod.
+`spec`<br/>_object_                        | The specification used to create and run the pod.
+`spec.container`<br/>_string_              | The name of the container running.
+`status`<br/>_object_                      | The status information of the pod.
+`status.phase`<br/>_string_                | The status of the pod. Possible statuses are Running, Pending, Succeeded, Unknown and Failed.
+
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -490,19 +491,19 @@ curl -X POST \
 
 Create a pod in a given [environment](#administration-environments).
 
-| Required Attributes                 | &nbsp;                                                      |
-| ----------------------------------- | ----------------------------------------------------------- |
-| `apiVersion` <br/>_string_          | The api version (versioned schema) of the pod               |
-| `metadata` <br/>_object_            | The metadata of the pod                                     |
-| `metadata.name` <br/>_string_       | The name of the pod                                         |
-| `spec`<br/>_object_                 | The specification used to create and run the pod            |
-| `spec.container.image`<br/>_string_ | The docker image name                                       |
-| `spec.container.name`<br/>_string_  | The (unique) name of the container specified as a DNS_LABEL |
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`spec`<br/>_object_                 | The specification used to create and run the pod.
+`spec.container.image`<br/>_string_ | The docker image name.
+`spec.container.name`<br/>_string_  | The (unique) name of the container specified as a DNS_LABEL.
 
-| Optional Attributes                | &nbsp;                                                                 |
-| ---------------------------------- | ---------------------------------------------------------------------- |
-| `kind`<br/>_string_                | The string value representing the REST resource this object represents |
-| `metadata.namespace` <br/>_string_ | The namespace in which the pod is created                              |
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                       | The string value of the REST resource that this object represents.      |
+| `metadata.namespace` <br/>_string_        | The namespace in which the pod is created                               |
 
 Return value:
 

--- a/source/includes/kubernetes/_k8_secrets.md
+++ b/source/includes/kubernetes/_k8_secrets.md
@@ -44,7 +44,7 @@ Retrieve a list of all secrets in a given [environment](#administration-environm
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                              |
 | `metadata` <br/>_object_   | The metadata of the secret.                                                |
-| `kind` <br/>_string_       | A string value representing the REST resource that this object represents. |
+| `kind`<br/>_string_        | The string value of the REST resource that this object represents.         |
 | `type` <br/>_string_       | A string used to facilitate programmatic handling of a secret's data.      |
 
 <!-------------------- GET A secret -------------------->
@@ -86,7 +86,7 @@ Retrieve a secret and all its info in a given [environment](#administration-envi
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                              |
 | `metadata` <br/>_object_   | The metadata of the secret.                                                |
-| `kind` <br/>_string_       | A string value representing the REST resource that this object represents. |
+| `kind`<br/>_string_        | The string value of the REST resource that this object represents.         |
 | `type` <br/>_string_       | A string used to facilitate programmatic handling of a secret's data.      |
 
 <!-------------------- CREATE A SECRET -------------------->
@@ -157,9 +157,9 @@ One of the following two attributes is also required.
 | `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                         |
 | `stringData`<br/>_object_  | The non-base64 encoded data to be encoded when the secret is created. |
 
-| Optional Attributes                | &nbsp;                                       |
-| ---------------------------------- | -------------------------------------------- |
-| `metadata.namespace` <br/>_string_ | The namespace in which the secret is created |
+| Optional Attributes                | &nbsp;                                        |
+| ---------------------------------- | --------------------------------------------- |
+| `metadata.namespace` <br/>_string_ | The namespace in which the secret is created. |
 
 Return value:
 

--- a/source/includes/kubernetes/_k8_services.md
+++ b/source/includes/kubernetes/_k8_services.md
@@ -157,7 +157,7 @@ Create a service in a given [environment](#administration-environments).
 | `spec`<br/>_object_                        | The specification used to create and run the service.                   |
 | `spec.selector`<br/>_object_               | The label query over the service's set of resources.                    |
 | `spec.ports`<br/>_object_                  | The list of ports that are exposed by this service.                     |
-| `spec.type`<br/>*object*                   | The type of service (ClusterIP, NodePort, ExternalName or LoadBalancer) |
+| `spec.type`<br/>_object_                   | The type of service (ClusterIP, NodePort, ExternalName or LoadBalancer) |
 
 | Optional Attributes                        | &nbsp;                                                                  |
 | ------------------------------------------ | ------------------------------------------------------------------------|
@@ -169,5 +169,5 @@ Return value:
 
 | Attributes                 | &nbsp;                                           |
 ---------------------------- | -------------------------------------------------|
-| `taskId` <br/>*string*     | The id corresponding to the create service task. |
-| `taskStatus` <br/>*string* | The status of the operation.                     |
+| `taskId` <br/>_string_     | The id corresponding to the create service task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                     |

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -33,12 +33,12 @@ curl -X GET \
 
 Retrieve a list of all stateful sets in a given [environment](#administration-environments).
 
-| Attributes               | &nbsp;                                                    |
-| ------------------------ | --------------------------------------------------------- |
-| `id` <br/>_string_       | The id of the stateful set                                |
-| `metadata` <br/>_object_ | The metadata of the stateful set                          |
-| `spec`<br/>_object_      | The specification used to create and run the stateful set |
-| `status`<br/>_object_    | The status information of the stateful set                |
+| Attributes               | &nbsp;                                                     |
+| ------------------------ | ---------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the stateful set.                                |
+| `metadata` <br/>_object_ | The metadata of the stateful set.                          |
+| `spec`<br/>_object_      | The specification used to create and run the stateful set. |
+| `status`<br/>_object_    | The status information of the stateful set.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -73,12 +73,12 @@ curl -X GET \
 
 Retrieve a stateful set and all its info in a given [environment](#administration-environments).
 
-| Attributes               | &nbsp;                                                    |
-| ------------------------ | --------------------------------------------------------- |
-| `id` <br/>_string_       | The id of the stateful set                                |
-| `metadata` <br/>_object_ | The metadata of the stateful set                          |
-| `spec`<br/>_object_      | The specification used to create and run the stateful set |
-| `status`<br/>_object_    | The status information of the stateful set                |
+| Attributes               | &nbsp;                                                     |
+| ------------------------ | ---------------------------------------------------------- |
+| `id` <br/>_string_       | The id of the stateful set.                                |
+| `metadata` <br/>_object_ | The metadata of the stateful set.                          |
+| `spec`<br/>_object_      | The specification used to create and run the stateful set. |
+| `status`<br/>_object_    | The status information of the stateful set.                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -136,21 +136,21 @@ curl -X POST \
 
 Create a stateful set in a given [environment](#administration-environments).
 
-| Required Attributes           | &nbsp;                                                                      |
-| ----------------------------- | --------------------------------------------------------------------------- |
-| `apiVersion` <br/> _string_   | The api version (versioned schema) of the stateful set                      |
-| `metadata` <br/>_object_      | The metadata of the stateful set                                            |
-| `metadata.name` <br/>_string_ | The name of the stateful set                                                |
-| `spec`<br/>_object_           | The specification used to create and run the stateful set                   |
-| `spec.selector`<br/>_object_  | The label query over the stateful set's of resources                        |
-| `spec.template`<br/>_object_  | The data a stateful set's pod should have when created                      |
-| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the stateful set |
+| Required Attributes                        | &nbsp;                                                                       |
+| ------------------------------------------ | -----------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set.                      |
+| `metadata` <br/>_object_                   | The metadata of the stateful set.                                            |
+| `metadata.name` <br/>_string_              | The name of the stateful set.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the stateful set.                   |
+| `spec.selector`<br/>_object_               | The label query over the stateful set's of resources.                        |
+| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created.                      |
+| `spec.spec`<br/>_object_                   | The specification used to create and run the pod(s) within the stateful set. |
 
-| Optional Attributes                      | &nbsp;                                                                 |
-| ---------------------------------------- | ---------------------------------------------------------------------- |
-| `kind`<br/>_string_                      | The string value representing the REST resource this object represents |
-| `metadata.namespace` <br/>_string_       | The namespace in which the stateful set is created                     |
-| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a stateful set     |
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.        |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created.                       |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set.       |
 
 Return value:
 

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -167,7 +167,7 @@ Create a storage class in a given [environment](#administration-environments).
 | Required Attributes               | &nbsp;                                                                                                                    |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `apiVersion` <br/> _string_       | The api version (versioned schema) of the storage class.                                                                  |
-| `kind`<br/>_string_               | The string value representing the REST resource this object represents.                                                   |
+| `kind`<br/>_string_               | The string value of the REST resource that this object represents.                                                        |
 | `metadata` <br/>_object_          | The metadata of the storage class.                                                                                        |
 | `metadata.name` <br/>_string_     | The name of the storage class.                                                                                            |
 | `provisioner` <br/>_string_       | The provisioner for the storage class                                                                                     |


### PR DESCRIPTION
Fixed some yucky sentences, as promised

#### Related PRs
- [207](https://github.com/cloudops/cloudmc-api-docs/pull/207)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->