### PR TITLE
MC-12124 create pv docs added

### DIFF
--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -227,7 +227,7 @@ Create a persistent volume in a given [environment](#administration-environments
 | `spec` <br/>_object_                            | The spec for the persistent volume.                                                                                                                                                                        |
 | `spec.accessModes` <br/>_array_                 | A list of access modes, the options are: ReadWriteOnce, ReadOnlyMany and ReadWriteMany.                                                                                                                          |
 | `spec.capacity.storage` <br/>_string_           | Measured in bytes. You can express storage as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
-| `spec.hostPath.path` <br/>_string_              | Directory location on host. |
+| `spec.<VOLUME_TYPE>` <br/>_object_              | Volume types are identified by name and what volume types are supported differ heavily by Kubernetes deployment. The contents of the object also depend on the volume type. Examples of common volumes types are `nfs`, `hostPath`, or `local`. |
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |

--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -178,6 +178,77 @@ Retrieve a persistent volume and all its info in a given [environment](#administ
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
 
+<!-------------------- CREATE a persistent volume  -------------------->
+#### Create a persistent volume
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes"
+  Content-Type: application/json
+   {
+      "apiVersion": "v1",
+      "kind": "PersistentVolume",
+      "metadata": {
+         "name": "small-pvc",
+         "namespace": "default"
+      },
+      "spec": {
+         "accessModes": [
+            "ReadWriteOnce"
+         ],
+         "resources": {
+            "requests": {
+               "storage": "10G"
+            }
+         }
+      }
+   }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumes</code>
+
+Create a persistent volume in a given [environment](#administration-environments).
+
+| Required Attributes                             | &nbsp;                                                                                                                                                                                                          |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiVersion` <br/>_string_                      | The api version (versioned schema) of the persistent volume.                                                                                                                                               |
+| `metadata` <br/>_object_                        | The metadata of the persistent volume.                                                                                                                                                                     |
+| `metadata.name` <br/>_string_                   | The name of the persistent volume.                                                                                                                                                                         |
+| `spec` <br/>_object_                            | The spec for the persistent volume.                                                                                                                                                                        |
+| `spec.accessModes` <br/>_array_                 | A list of access modes, the options are: ReadWriteOnce, ReadOnlyMany and ReadWriteMany.                                                                                                                          |
+| `spec.capacity.storage` <br/>_string_           | Measured in bytes. You can express storage as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
+| `spec.hostPath.path` <br/>_string_              | Measured in bytes. You can express storage as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
+
+| Optional Attributes                   | &nbsp;                                                                                        |
+| ------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `kind`<br/>_string_                   | The string value representing the REST resource this object represents.                       |
+| `metadata.namespace` <br/>_string_    | The namespace in which the pod is created, if not specified will create the persistent volume in default. |
+| `spec.storageClassName` <br/>_string_ | Storage class associated to the volume.   |
+| `spec.claimRef` <br/>_array_          | The name of the PersistentVolumeClaim associated to the persistent volume.          |
+| `spec.mountOptions` <br/>_array_      | Mount options for when a Persistent Volume is mounted on a node.                             |
+| `spec.nodeAffinity` <br/>_array_      | Defines constraints that limit what nodes this volume can be accessed from.                   |
+| `spec.persistentVolumeReclaimPolicy` <br/>_array_ | One of `Retain` (manual reclamation), `Recycle` (basic scrub) or `Delete` (associated storage asset such as AWS EBS, GCE PD, Azure Disk, or OpenStack Cinder volume is deleted).  |
+| `spec.volumeMode` <br/>_array_        | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device.                           |
+| `status.phase` <br/>_string_          | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`.                |
+
+
+Return value:
+
+| Attributes                 | &nbsp;                                                           |
+| -------------------------- | ---------------------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create persistent volume task.       |
+| `taskStatus` <br/>_string_ | The status of the operation.                                     |
+
 <!-------------------- DELETE a persistent volume  -------------------->
 #### Delete a persistent volume
 

--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -227,7 +227,7 @@ Create a persistent volume in a given [environment](#administration-environments
 | `spec` <br/>_object_                            | The spec for the persistent volume.                                                                                                                                                                        |
 | `spec.accessModes` <br/>_array_                 | A list of access modes, the options are: ReadWriteOnce, ReadOnlyMany and ReadWriteMany.                                                                                                                          |
 | `spec.capacity.storage` <br/>_string_           | Measured in bytes. You can express storage as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
-| `spec.hostPath.path` <br/>_string_              | Measured in bytes. You can express storage as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
+| `spec.hostPath.path` <br/>_string_              | Directory location on host. |
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |

--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -188,7 +188,6 @@ curl -X POST \
   Content-Type: application/json
    {
       "apiVersion": "v1",
-      "kind": "PersistentVolume",
       "metadata": {
          "name": "small-pvc",
          "namespace": "default"
@@ -231,7 +230,6 @@ Create a persistent volume in a given [environment](#administration-environments
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `kind`<br/>_string_                   | The string value representing the REST resource this object represents.                       |
 | `metadata.namespace` <br/>_string_    | The namespace in which the pod is created, if not specified will create the persistent volume in default. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume.   |
 | `spec.claimRef` <br/>_array_          | The name of the PersistentVolumeClaim associated to the persistent volume.          |

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -235,7 +235,8 @@ Create a persistent volume in a given [environment](#administration-environments
 | `spec` <br/>_object_                            | The spec for the persistent volume.                                                                                                                                                                        |
 | `spec.accessModes` <br/>_array_                 | A list of access modes, the options are: ReadWriteOnce, ReadOnlyMany and ReadWriteMany.                                                                                                                          |
 | `spec.capacity.storage` <br/>_string_           | Measured in bytes. You can express storage as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
-| `spec.hostPath.path` <br/>_string_              | A hostPath volume mounts a file or directory from the host node's filesystem into your Pod.  |
+| `spec.hostPath.path` <br/>_string_              | Directory location on host.|
+
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -186,6 +186,78 @@ Retrieve a persistent volume and all its info in a given [environment](#administ
 | `spec.capacity.volumeMode` <br/>_string_ | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device. |
 | `status.phase` <br/>_string_ | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`. |
 
+<!-------------------- CREATE a persistent volume  -------------------->
+
+##### Create a persistent volume 
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes"
+  Content-Type: application/json
+   {
+      "apiVersion": "v1",
+      "kind": "PersistentVolume",
+      "metadata": {
+         "name": "small-pvc",
+         "namespace": "default"
+      },
+      "spec": {
+         "accessModes": [
+            "ReadWriteOnce"
+         ],
+         "resources": {
+            "requests": {
+               "storage": "10G"
+            }
+         }
+      }
+   }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumes</code>
+
+Create a persistent volume in a given [environment](#administration-environments).
+
+| Required Attributes                             | &nbsp;                                                                                                                                                                                                          |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiVersion` <br/>_string_                      | The api version (versioned schema) of the persistent volume.                                                                                                                                               |
+| `metadata` <br/>_object_                        | The metadata of the persistent volume.                                                                                                                                                                     |
+| `metadata.name` <br/>_string_                   | The name of the persistent volume.                                                                                                                                                                         |
+| `spec` <br/>_object_                            | The spec for the persistent volume.                                                                                                                                                                        |
+| `spec.accessModes` <br/>_array_                 | A list of access modes, the options are: ReadWriteOnce, ReadOnlyMany and ReadWriteMany.                                                                                                                          |
+| `spec.capacity.storage` <br/>_string_           | Measured in bytes. You can express storage as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
+| `spec.hostPath.path` <br/>_string_              | A hostPath volume mounts a file or directory from the host node's filesystem into your Pod.  |
+
+| Optional Attributes                   | &nbsp;                                                                                        |
+| ------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `kind`<br/>_string_                   | The string value representing the REST resource this object represents.                       |
+| `metadata.namespace` <br/>_string_    | The namespace in which the pod is created, if not specified will create the persistent volume in default. |
+| `spec.storageClassName` <br/>_string_ | Storage class associated to the volume.   |
+| `spec.claimRef` <br/>_array_          | The name of the PersistentVolumeClaim associated to the persistent volume.          |
+| `spec.mountOptions` <br/>_array_      | Mount options for when a Persistent Volume is mounted on a node.                             |
+| `spec.nodeAffinity` <br/>_array_      | Defines constraints that limit what nodes this volume can be accessed from.                   |
+| `spec.persistentVolumeReclaimPolicy` <br/>_array_ | One of `Retain` (manual reclamation), `Recycle` (basic scrub) or `Delete` (associated storage asset such as AWS EBS, GCE PD, Azure Disk, or OpenStack Cinder volume is deleted).  |
+| `spec.volumeMode` <br/>_array_        | If set to `Filesystem` (default value), the volume is mounted into Pods into a directory. If set to `Block`, then the volume is used as a raw block device.                           |
+| `status.phase` <br/>_string_          | Volume is in one of the following phases: `Available`, `Bound`, `Released` or `Failed`.                |
+
+
+Return value:
+
+| Attributes                 | &nbsp;                                                           |
+| -------------------------- | ---------------------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create persistent volume task.       |
+| `taskStatus` <br/>_string_ | The status of the operation.                                     |
+
+
 <!-------------------- DELETE a persistent volume  -------------------->
 ##### Delete a persistent volume
 

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -196,7 +196,6 @@ curl -X POST \
   Content-Type: application/json
    {
       "apiVersion": "v1",
-      "kind": "PersistentVolume",
       "metadata": {
          "name": "small-pvc",
          "namespace": "default"
@@ -240,7 +239,6 @@ Create a persistent volume in a given [environment](#administration-environments
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `kind`<br/>_string_                   | The string value representing the REST resource this object represents.                       |
 | `metadata.namespace` <br/>_string_    | The namespace in which the pod is created, if not specified will create the persistent volume in default. |
 | `spec.storageClassName` <br/>_string_ | Storage class associated to the volume.   |
 | `spec.claimRef` <br/>_array_          | The name of the PersistentVolumeClaim associated to the persistent volume.          |

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -235,8 +235,7 @@ Create a persistent volume in a given [environment](#administration-environments
 | `spec` <br/>_object_                            | The spec for the persistent volume.                                                                                                                                                                        |
 | `spec.accessModes` <br/>_array_                 | A list of access modes, the options are: ReadWriteOnce, ReadOnlyMany and ReadWriteMany.                                                                                                                          |
 | `spec.capacity.storage` <br/>_string_           | Measured in bytes. You can express storage as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki. |
-| `spec.hostPath.path` <br/>_string_              | Directory location on host.|
-
+| `spec.<VOLUME_TYPE>` <br/>_object_              | Volume types are identified by name and what volume types are supported differ heavily by Kubernetes deployment. The contents of the object also depend on the volume type. Examples of common volumes types are `nfs`, `hostPath`, or `local`. |
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
### Fixes [MC-12124](https://cloud-ops.atlassian.net/browse/MC-12124)

#### Changes made
<!-- Changes should match the template provided below -->
- Added create api documents

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->