### PR TITLE
MC-12215: Kubernetes edit configmaps and secrets

### DIFF
--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -142,7 +142,8 @@ curl -X PUT \
   "apiVersion": "v1",
   "kind": "ConfigMap",
   "metadata": {
-    "name": "game-demo"
+    "name": "game-demo",
+    "namespace": "default"
   },
   "data": {
     "player_initial_lives": "5",

--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -136,7 +136,7 @@ Return value:
 ```shell
 curl -X PUT \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/configmaps/configmaps-name/default"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/configmaps/game-demo/default"
   Content-Type: application/json
   {
   "apiVersion": "v1",
@@ -173,16 +173,16 @@ Replace a config map in a given [environment](#administration-environments).
 | `metadata.name` <br/>_string_ | The name of the config map.                                              |
 | `data`<br/>_object_           | The non-confidential data (in key-value pairs) stored in the config map. |
 
-| Optional Attributes                | &nbsp;                                           |
-| ---------------------------------- | ------------------------------------------------ |
-| `metadata.namespace` <br/>_string_ | The namespace in which the config map is created |
+| Optional Attributes                | &nbsp;                                             |
+| ---------------------------------- | -------------------------------------------------- |
+| `metadata.namespace` <br/>_string_ | The namespace in which the config map is replaced. |
 
 Return value:
 
-| Attributes                 | &nbsp;                                               |
-| -------------------------- | ---------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create config maps task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                         |
+| Attributes                 | &nbsp;                                                |
+| -------------------------- | ----------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace config maps task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                          |
 
 <!-------------------- DELETE A CONFIG MAP -------------------->
 

--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -129,6 +129,61 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create config maps task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                         |
 
+<!-------------------- REPLACE A CONFIG MAP -------------------->
+
+#### Replace a config map
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/configmaps/configmaps-name/default"
+  Content-Type: application/json
+  {
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "game-demo"
+  },
+  "data": {
+    "player_initial_lives": "5",
+    "ui_properties_file_name": "user-interface.properties",
+    "game.properties": "enemy.types=aliens,monsters\nplayer.maximum-lives=5\n",
+    "user-interface.properties": "color.good=purple\ncolor.bad=yellow\nallow.textmode=true\n"
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps/:id</code>
+
+Replace a config map in a given [environment](#administration-environments).
+
+| Required Attributes           | &nbsp;                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the config map.                    |
+| `metadata` <br/>_object_      | The metadata of the config map.                                          |
+| `metadata.name` <br/>_string_ | The name of the config map.                                              |
+| `data`<br/>_object_           | The non-confidential data (in key-value pairs) stored in the config map. |
+
+| Optional Attributes                | &nbsp;                                           |
+| ---------------------------------- | ------------------------------------------------ |
+| `metadata.namespace` <br/>_string_ | The namespace in which the config map is created |
+
+Return value:
+
+| Attributes                 | &nbsp;                                               |
+| -------------------------- | ---------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create config maps task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                         |
+
 <!-------------------- DELETE A CONFIG MAP -------------------->
 
 #### Delete a config map

--- a/source/includes/kubernetes/_k8_secrets.md
+++ b/source/includes/kubernetes/_k8_secrets.md
@@ -168,6 +168,85 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create secret task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                    |
 
+<!-------------------- REPLACE A SECRET -------------------->
+
+#### Replace a secret
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/secrets/my-secret/shhh"
+  Content-Type: application/json
+  {
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": {
+    "name": "mysecret"
+  },
+  "type": "Opaque",
+  "stringData": {
+    "username": "my-username",
+    "password": "my-new-password"
+  }
+}
+
+# OR
+
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/secrets/my-secret/shhh"
+  Content-Type: application/json
+  {
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": {
+    "name": "mysecret"
+  },
+  "type": "Opaque",
+  "encodedData": {
+    "username": "YWRtaW4=",
+    "password": "MWYyFDZlMmU2N2Rm"
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/secrets/:id</code>
+
+Replace a secret in a given [environment](#administration-environments).
+
+| Required Attributes           | &nbsp;                                            |
+| ----------------------------- | ------------------------------------------------- |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the secret. |
+| `metadata` <br/>_object_      | The metadata of the secret.                       |
+| `metadata.name` <br/>_string_ | The name of the secret.                           |
+
+One of the following two attributes is also required.
+
+| Attributes                 | &nbsp;                                                                |
+| -------------------------- | --------------------------------------------------------------------- |
+| `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                         |
+| `stringData`<br/>_object_  | The non-base64 encoded data to be encoded when the secret is created. |
+
+| Optional Attributes                | &nbsp;                                        |
+| ---------------------------------- | --------------------------------------------- |
+| `metadata.namespace` <br/>_string_ | The namespace in which the secret is created. |
+
+Return value:
+
+| Attributes                 | &nbsp;                                          |
+| -------------------------- | ----------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create secret task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                    |
+
 <!-------------------- DELETE SECRET -------------------->
 
 #### Delete a secret

--- a/source/includes/kubernetes/_k8_secrets.md
+++ b/source/includes/kubernetes/_k8_secrets.md
@@ -181,7 +181,8 @@ curl -X PUT \
   "apiVersion": "v1",
   "kind": "Secret",
   "metadata": {
-    "name": "mysecret"
+    "name": "mysecret",
+    "namespace": "shhh"
   },
   "type": "Opaque",
   "stringData": {
@@ -231,21 +232,21 @@ Replace a secret in a given [environment](#administration-environments).
 
 One of the following two attributes is also required.
 
-| Attributes                 | &nbsp;                                                                |
-| -------------------------- | --------------------------------------------------------------------- |
-| `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                         |
-| `stringData`<br/>_object_  | The non-base64 encoded data to be encoded when the secret is created. |
+| Attributes                 | &nbsp;                                                                 |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                          |
+| `stringData`<br/>_object_  | The non-base64 encoded data to be encoded when the secret is replaced. |
 
-| Optional Attributes                | &nbsp;                                        |
-| ---------------------------------- | --------------------------------------------- |
-| `metadata.namespace` <br/>_string_ | The namespace in which the secret is created. |
+| Optional Attributes                | &nbsp;                                         |
+| ---------------------------------- | ---------------------------------------------- |
+| `metadata.namespace` <br/>_string_ | The namespace in which the secret is replaced. |
 
 Return value:
 
-| Attributes                 | &nbsp;                                          |
-| -------------------------- | ----------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create secret task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                    |
+| Attributes                 | &nbsp;                                           |
+| -------------------------- | ------------------------------------------------ |
+| `taskId` <br/>_string_     | The id corresponding to the replace secret task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                     |
 
 <!-------------------- DELETE SECRET -------------------->
 

--- a/source/includes/kubernetes_extension/_k8_configmaps.md
+++ b/source/includes/kubernetes_extension/_k8_configmaps.md
@@ -141,6 +141,62 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create config maps task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                         |
 
+<!-------------------- REPLACE A CONFIG MAP -------------------->
+
+##### Replace a config map
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/configmaps/my-configmap/default?cluster_id=:cluster_id"
+  Content-Type: application/json
+  {
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "game-demo"
+  },
+  "data": {
+    "player_initial_lives": "5",
+    "ui_properties_file_name": "user-interface.properties",
+    "game.properties": "enemy.types=aliens,monsters\nplayer.maximum-lives=5\n",
+    "user-interface.properties": "color.good=purple\ncolor.bad=yellow\nallow.textmode=true\n"
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/configmaps/:id?cluster_id=:cluster_id</code>
+
+Replace a config map in a given [environment](#administration-environments).
+
+| Required Attributes           | &nbsp;                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| `cluster_id` <br/>_string_    | The id of the cluster in which to create the config map.                 |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the config map.                    |
+| `metadata` <br/>_object_      | The metadata of the config map.                                          |
+| `metadata.name` <br/>_string_ | The name of the config map.                                              |
+| `data`<br/>_object_           | The non-confidential data (in key-value pairs) stored in the config map. |
+
+| Optional Attributes                | &nbsp;                                           |
+| ---------------------------------- | ------------------------------------------------ |
+| `metadata.namespace` <br/>_string_ | The namespace in which the config map is created |
+
+Return value:
+
+| Attributes                 | &nbsp;                                               |
+| -------------------------- | ---------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create config maps task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                         |
+
 <!-------------------- DELETE A CONFIG MAP -------------------->
 
 ##### Delete a config map

--- a/source/includes/kubernetes_extension/_k8_configmaps.md
+++ b/source/includes/kubernetes_extension/_k8_configmaps.md
@@ -154,7 +154,8 @@ curl -X PUT \
   "apiVersion": "v1",
   "kind": "ConfigMap",
   "metadata": {
-    "name": "game-demo"
+    "name": "game-demo",
+    "namespace": "default"
   },
   "data": {
     "player_initial_lives": "5",

--- a/source/includes/kubernetes_extension/_k8_configmaps.md
+++ b/source/includes/kubernetes_extension/_k8_configmaps.md
@@ -148,7 +148,7 @@ Return value:
 ```shell
 curl -X PUT \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/configmaps/my-configmap/default?cluster_id=:cluster_id"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/configmaps/game-demo/default?cluster_id=:cluster_id"
   Content-Type: application/json
   {
   "apiVersion": "v1",
@@ -180,22 +180,22 @@ Replace a config map in a given [environment](#administration-environments).
 
 | Required Attributes           | &nbsp;                                                                   |
 | ----------------------------- | ------------------------------------------------------------------------ |
-| `cluster_id` <br/>_string_    | The id of the cluster in which to create the config map.                 |
+| `cluster_id` <br/>_string_    | The id of the cluster in which to replace the config map.                |
 | `apiVersion` <br/> _string_   | The api version (versioned schema) of the config map.                    |
 | `metadata` <br/>_object_      | The metadata of the config map.                                          |
 | `metadata.name` <br/>_string_ | The name of the config map.                                              |
 | `data`<br/>_object_           | The non-confidential data (in key-value pairs) stored in the config map. |
 
-| Optional Attributes                | &nbsp;                                           |
-| ---------------------------------- | ------------------------------------------------ |
-| `metadata.namespace` <br/>_string_ | The namespace in which the config map is created |
+| Optional Attributes                | &nbsp;                                             |
+| ---------------------------------- | -------------------------------------------------- |
+| `metadata.namespace` <br/>_string_ | The namespace in which the config map is replaced. |
 
 Return value:
 
-| Attributes                 | &nbsp;                                               |
-| -------------------------- | ---------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create config maps task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                         |
+| Attributes                 | &nbsp;                                                |
+| -------------------------- | ----------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace config maps task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                          |
 
 <!-------------------- DELETE A CONFIG MAP -------------------->
 

--- a/source/includes/kubernetes_extension/_k8_secrets.md
+++ b/source/includes/kubernetes_extension/_k8_secrets.md
@@ -209,7 +209,8 @@ curl -X PUT \
   "apiVersion": "v1",
   "kind": "Secret",
   "metadata": {
-    "name": "mysecret"
+    "name": "mysecret",
+    "namespace": "shhh"
   },
   "type": "Opaque",
   "encodedData": {
@@ -232,30 +233,30 @@ curl -X PUT \
 
 Replace a secret in a given [environment](#administration-environments).
 
-| Required Attributes           | &nbsp;                                               |
-| ----------------------------- | ---------------------------------------------------- |
-| `cluster_id` <br/>_string_    | The id of the cluster in which to create the secret. |
-| `apiVersion` <br/> _string_   | The api version (versioned schema) of the secret.    |
-| `metadata` <br/>_object_      | The metadata of the secret.                          |
-| `metadata.name` <br/>_string_ | The name of the secret.                              |
+| Required Attributes           | &nbsp;                                                |
+| ----------------------------- | ----------------------------------------------------- |
+| `cluster_id` <br/>_string_    | The id of the cluster in which to replace the secret. |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the secret.     |
+| `metadata` <br/>_object_      | The metadata of the secret.                           |
+| `metadata.name` <br/>_string_ | The name of the secret.                               |
 
 One of the following two attributes is also required.
 
-| Attributes                 | &nbsp;                                                                |
-| -------------------------- | --------------------------------------------------------------------- |
-| `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                         |
-| `stringData`<br/>_object_  | The non-base64 encoded data to be encoded when the secret is created. |
+| Attributes                 | &nbsp;                                                                 |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                          |
+| `stringData`<br/>_object_  | The non-base64 encoded data to be encoded when the secret is replaced. |
 
-| Optional Attributes                | &nbsp;                                       |
-| ---------------------------------- | -------------------------------------------- |
-| `metadata.namespace` <br/>_string_ | The namespace in which the secret is created |
+| Optional Attributes                | &nbsp;                                        |
+| ---------------------------------- | --------------------------------------------- |
+| `metadata.namespace` <br/>_string_ | The namespace in which the secret is replaced |
 
 Return value:
 
-| Attributes                 | &nbsp;                                          |
-| -------------------------- | ----------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create secret task. |
-| `taskStatus` <br/>_string_ | The status of the operation.                    |
+| Attributes                 | &nbsp;                                           |
+| -------------------------- | ------------------------------------------------ |
+| `taskId` <br/>_string_     | The id corresponding to the replace secret task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                     |
 
 <!-------------------- DELETE SECRET -------------------->
 

--- a/source/includes/kubernetes_extension/_k8_secrets.md
+++ b/source/includes/kubernetes_extension/_k8_secrets.md
@@ -177,6 +177,86 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create secret task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                    |
 
+<!-------------------- REPLACE A SECRET -------------------->
+
+##### Replace a secret
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/secrets/my-secret/shhh"
+  Content-Type: application/json
+  {
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": {
+    "name": "mysecret"
+  },
+  "type": "Opaque",
+  "stringData": {
+    "username": "my-username",
+    "password": "my-new-password"
+  }
+}
+
+# OR
+
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/secrets?cluster_id=:cluster_id"
+  Content-Type: application/json
+  {
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": {
+    "name": "mysecret"
+  },
+  "type": "Opaque",
+  "encodedData": {
+    "username": "YWRtaW4=",
+    "password": "MWYyFZDlMmU2N2Rm"
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/secrets/:id?cluster_id=:cluster_id</code>
+
+Replace a secret in a given [environment](#administration-environments).
+
+| Required Attributes           | &nbsp;                                               |
+| ----------------------------- | ---------------------------------------------------- |
+| `cluster_id` <br/>_string_    | The id of the cluster in which to create the secret. |
+| `apiVersion` <br/> _string_   | The api version (versioned schema) of the secret.    |
+| `metadata` <br/>_object_      | The metadata of the secret.                          |
+| `metadata.name` <br/>_string_ | The name of the secret.                              |
+
+One of the following two attributes is also required.
+
+| Attributes                 | &nbsp;                                                                |
+| -------------------------- | --------------------------------------------------------------------- |
+| `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                         |
+| `stringData`<br/>_object_  | The non-base64 encoded data to be encoded when the secret is created. |
+
+| Optional Attributes                | &nbsp;                                       |
+| ---------------------------------- | -------------------------------------------- |
+| `metadata.namespace` <br/>_string_ | The namespace in which the secret is created |
+
+Return value:
+
+| Attributes                 | &nbsp;                                          |
+| -------------------------- | ----------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create secret task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                    |
+
 <!-------------------- DELETE SECRET -------------------->
 
 ##### Delete a secret


### PR DESCRIPTION
### Fixes [MC-12215](https://cloud-ops.atlassian.net/browse/MC-12215)

#### Changes made
<!-- Changes should match the template provided below -->
- Edit (replace) Configmaps
- Edit (replace)  Secrets

#### Related PRs
- [ksdk](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/169)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->