### PR TITLE
MC-11762: added api docs for workloads

### DIFF
--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -155,6 +155,84 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create daemon set task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
+<!-------------------- REPLACE DAEMON SET -------------------->
+
+#### Replace a daemon set
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/daemonsets/daemonset-name/default"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "kind": "DaemonSet",
+  "metadata": {
+    "name": "daemonset-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "name": "fluentd-elasticsearch"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "fluentd-elasticsearch"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "fluentd-elasticsearch",
+            "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
+
+Replace a daemon set in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | ---------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set.                      |
+| `metadata` <br/>_object_                   | The metadata of the daemon set.                                            |
+| `metadata.name` <br/>_string_              | The name of the daemon set.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the daemon set.                   |
+| `spec.selector`<br/>_object_               | The label query over the daemon set's resources.                           |
+| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created.                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set. |
+
+
+| Optional Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created.                          |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set.          |
+
+Return value:
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create daemon set task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |
+
 <!-------------------- DELETE DAEMON SET -------------------->
 
 #### Delete a daemon set

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -214,23 +214,23 @@ Replace a daemon set in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set.                      |
 | `metadata` <br/>_object_                   | The metadata of the daemon set.                                            |
 | `metadata.name` <br/>_string_              | The name of the daemon set.                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set.                   |
+| `spec`<br/>_object_                        | The specification used to replace and run the daemon set.                  |
 | `spec.selector`<br/>_object_               | The label query over the daemon set's resources.                           |
-| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created.                      |
+| `spec.template`<br/>_object_               | The data a daemon set's pod should have when replaced.                     |
 | `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set. |
 
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created.                          |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is replaced.                         |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set.          |
 
 Return value:
 
 | Attributes                 | &nbsp;                                              |
 | -------------------------- | --------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create daemon set task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace daemon set task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
 <!-------------------- DELETE DAEMON SET -------------------->

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -145,22 +145,22 @@ Create a deployment in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment.                      |
 | `metadata` <br/>_object_                   | The metadata of the deployment.                                            |
 | `metadata.name` <br/>_string_              | The name of the deployment.                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the deployment.                   |
+| `spec`<br/>_object_                        | The specification used to replace and run the deployment.                  |
 | `spec.selector`<br/>_object_               | The label query over the deployment's set of resources.                    |
-| `spec.template`<br/>_object_               | The data a deployment's pod should have when created.                      |
-| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment. |
+| `spec.template`<br/>_object_               | The data a deployment's pod should have when replaced.                     |
+| `spec.spec`<br/>*object*                   | The specification used to replace and run the pod(s) within the deployment.|
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created.                          |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is replaced.                         |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
 
 Return value:
 
 | Attributes                 | &nbsp;                                              |
 | -------------------------- | --------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create deployment task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace deployment task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
 <!-------------------- REPLACE DEPLOYMENT ------------------->

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -163,6 +163,83 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create deployment task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
+<!-------------------- REPLACE DEPLOYMENT ------------------->
+
+#### Replace a deployment
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/deployments/deployment-name/default"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "deployment-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id</code>
+
+Replace a deployment in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment.                      |
+| `metadata` <br/>_object_                   | The metadata of the deployment.                                            |
+| `metadata.name` <br/>_string_              | The name of the deployment.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment.                   |
+| `spec.selector`<br/>_object_               | The label query over the deployment's set of resources.                    |
+| `spec.template`<br/>_object_               | The data a deployment's pod should have when created.                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment. |
+
+| Optional Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created.                          |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
+
+Return value:
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create deployment task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |
+
 <!-------------------- DELETE DEPLOYMENT -------------------->
 
 #### Delete a deployment

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -512,6 +512,67 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create pod task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
+<!-------------------- REPLACE POD -------------------->
+
+#### Replace a pod
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods/edgar-allen-pod/default"
+  Content-Type: application/json
+  {
+	  "apiVersion": "v1",
+    "kind": "Pod",
+	  "metadata": {
+	  	"name": "edgar-allen-pod",
+		  "namespace": "default"
+  	},
+	  "spec": {
+		"containers": [
+			{
+				"image": "nginx",
+				"name": "nginx"
+			}
+		  ]
+	  }
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id</code>
+
+Replace a pod in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`spec`<br/>_object_                 | The specification used to create and run the pod.
+`spec.container.image`<br/>_string_ | The docker image name.
+`spec.container.name`<br/>_string_  | The (unique) name of the container specified as a DNS_LABEL.
+
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                       | The string value of the REST resource that this object represents.      |
+| `metadata.namespace` <br/>_string_        | The namespace in which the pod is created                               |
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
 <!-------------------- DELETE POD -------------------->
 
 #### Delete a pod

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -557,20 +557,20 @@ Required Attributes                 | &nbsp;
 `apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
 `metadata` <br/>_object_            | The metadata of the pod.
 `metadata.name` <br/>_string_       | The name of the pod.
-`spec`<br/>_object_                 | The specification used to create and run the pod.
+`spec`<br/>_object_                 | The specification used to replace and run the pod.
 `spec.container.image`<br/>_string_ | The docker image name.
 `spec.container.name`<br/>_string_  | The (unique) name of the container specified as a DNS_LABEL.
 
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
 | `kind`<br/>_string_                       | The string value of the REST resource that this object represents.      |
-| `metadata.namespace` <br/>_string_        | The namespace in which the pod is created                               |
+| `metadata.namespace` <br/>_string_        | The namespace in which the pod is replaced.                             |
 
 Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create pod task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE POD -------------------->

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -522,12 +522,12 @@ curl -X PUT \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods/edgar-allen-pod/default"
   Content-Type: application/json
   {
-	  "apiVersion": "v1",
+    "apiVersion": "v1",
     "kind": "Pod",
 	  "metadata": {
 	  	"name": "edgar-allen-pod",
 		  "namespace": "default"
-  	},
+  },
 	  "spec": {
 		"containers": [
 			{

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -218,22 +218,22 @@ Replace a stateful set in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set.                      |
 | `metadata` <br/>_object_                   | The metadata of the stateful set.                                            |
 | `metadata.name` <br/>_string_              | The name of the stateful set.                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the stateful set.                   |
+| `spec`<br/>_object_                        | The specification used to replaced and run the stateful set.                   |
 | `spec.selector`<br/>_object_               | The label query over the stateful set's of resources.                        |
-| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created.                      |
-| `spec.spec`<br/>_object_                   | The specification used to create and run the pod(s) within the stateful set. |
+| `spec.template`<br/>_object_               | The data a stateful set's pod should have when replaced.                      |
+| `spec.spec`<br/>_object_                   | The specification used to replace and run the pod(s) within the stateful set. |
 
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value of the REST resource that this object represents.        |
-| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created.                       |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is replaced.                      |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set.       |
 
 Return value:
 
 | Attributes                 | &nbsp;                                                |
 | -------------------------- | ----------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create stateful set task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace stateful set task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                          |
 
 <!-------------------- DELETE STATEFUL SET -------------------->

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -159,6 +159,83 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create stateful set task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                          |
 
+<!-------------------- REPLACE A STATEFUL SET -------------------->
+
+#### Replace a stateful set
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets/stateful-set-name/default"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "stateful-set-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "k8s.gcr.io/nginx-slim:0.8"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id</code>
+
+Replace a stateful set in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                       |
+| ------------------------------------------ | -----------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set.                      |
+| `metadata` <br/>_object_                   | The metadata of the stateful set.                                            |
+| `metadata.name` <br/>_string_              | The name of the stateful set.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the stateful set.                   |
+| `spec.selector`<br/>_object_               | The label query over the stateful set's of resources.                        |
+| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created.                      |
+| `spec.spec`<br/>_object_                   | The specification used to create and run the pod(s) within the stateful set. |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.        |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created.                       |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set.       |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                |
+| -------------------------- | ----------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create stateful set task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                          |
+
 <!-------------------- DELETE STATEFUL SET -------------------->
 
 #### Delete a stateful set

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -168,7 +168,7 @@ Return value:
 
 <!-------------------- REPLACE DAEMON SET -------------------->
 
-#### Replace a daemon set
+##### Replace a daemon set
 
 ```shell
 curl -X PUT \

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -225,23 +225,23 @@ Replace a daemon set in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set.                      |
 | `metadata` <br/>_object_                   | The metadata of the daemon set.                                            |
 | `metadata.name` <br/>_string_              | The name of the daemon set.                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the daemon set.                   |
+| `spec`<br/>_object_                        | The specification used to replace and run the daemon set.                  |
 | `spec.selector`<br/>_object_               | The label query over the daemon set's resources.                           |
-| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created.                      |
+| `spec.template`<br/>_object_               | The data a daemon set's pod should have when replaced.                     |
 | `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set. |
 
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
-| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created.                          |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is replaced.                         |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set.          |
 
 Return value:
 
 | Attributes                 | &nbsp;                                              |
 | -------------------------- | --------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create daemon set task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace daemon set task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
 <!-------------------- DELETE DAEMON SET -------------------->

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -166,6 +166,84 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create daemon set task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
+<!-------------------- REPLACE DAEMON SET -------------------->
+
+#### Replace a daemon set
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/daemonsets/daemonset-name/default"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "kind": "DaemonSet",
+  "metadata": {
+    "name": "daemonset-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "name": "fluentd-elasticsearch"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "fluentd-elasticsearch"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "fluentd-elasticsearch",
+            "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/daemonsets/:id</code>
+
+Replace a daemon set in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | ---------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the daemon set.                      |
+| `metadata` <br/>_object_                   | The metadata of the daemon set.                                            |
+| `metadata.name` <br/>_string_              | The name of the daemon set.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the daemon set.                   |
+| `spec.selector`<br/>_object_               | The label query over the daemon set's resources.                           |
+| `spec.template`<br/>_object_               | The data a daemon set's pod should have when created.                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the daemon set. |
+
+
+| Optional Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created.                          |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set.          |
+
+Return value:
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create daemon set task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |
+
 <!-------------------- DELETE DAEMON SET -------------------->
 
 ##### Delete a daemon set

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -174,7 +174,7 @@ Return value:
 
 <!-------------------- REPLACE DEPLOYMENT ------------------->
 
-#### Replace a deployment
+##### Replace a deployment
 
 ```shell
 curl -X PUT \

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -173,6 +173,83 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create deployment task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
+<!-------------------- REPLACE DEPLOYMENT ------------------->
+
+#### Replace a deployment
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/deployments/deployment-name/default"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "deployment-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deployments/:id</code>
+
+Replace a deployment in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment.                      |
+| `metadata` <br/>_object_                   | The metadata of the deployment.                                            |
+| `metadata.name` <br/>_string_              | The name of the deployment.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the deployment.                   |
+| `spec.selector`<br/>_object_               | The label query over the deployment's set of resources.                    |
+| `spec.template`<br/>_object_               | The data a deployment's pod should have when created.                      |
+| `spec.spec`<br/>*object*                   | The specification used to create and run the pod(s) within the deployment. |
+
+| Optional Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created.                          |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
+
+Return value:
+
+| Attributes                 | &nbsp;                                              |
+| -------------------------- | --------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create deployment task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                        |
+
 <!-------------------- DELETE DEPLOYMENT -------------------->
 
 ##### Delete a deployment

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -149,28 +149,27 @@ curl -X POST \
 
 Create a deployment in a given [environment](#administration-environments).
 
-| Required Attributes           | &nbsp;                                                                    |
-| ----------------------------- | ------------------------------------------------------------------------- |
-| `cluster_id` <br/>_string_    | The id of the cluster in which to list the deployments.                   |
-| `apiVersion` <br/> _string_   | The api version (versioned schema) of the deployment                      |
-| `metadata` <br/>_object_      | The metadata of the deployment                                            |
-| `metadata.name` <br/>_string_ | The name of the deployment                                                |
-| `spec`<br/>_object_           | The specification used to create and run the deployment                   |
-| `spec.selector`<br/>_object_  | The label query over the deployment's set of resources                    |
-| `spec.template`<br/>_object_  | The data a deployment's pod should have when created                      |
-| `spec.spec`<br/>_object_      | The specification used to create and run the pod(s) within the deployment |
+| Required Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the deployment.                      |
+| `metadata` <br/>_object_                   | The metadata of the deployment.                                            |
+| `metadata.name` <br/>_string_              | The name of the deployment.                                                |
+| `spec`<br/>_object_                        | The specification used to replace and run the deployment.                  |
+| `spec.selector`<br/>_object_               | The label query over the deployment's set of resources.                    |
+| `spec.template`<br/>_object_               | The data a deployment's pod should have when replaced.                     |
+| `spec.spec`<br/>*object*                   | The specification used to replace and run the pod(s) within the deployment.|
 
-| Optional Attributes                      | &nbsp;                                                                 |
-| ---------------------------------------- | ---------------------------------------------------------------------- |
-| `kind`<br/>_string_                      | The string value representing the REST resource this object represents |
-| `metadata.namespace` <br/>_string_       | The namespace in which the deployment is created                       |
-| `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a deployment       |
+| Optional Attributes                        | &nbsp;                                                                     |
+| ------------------------------------------ | -------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
+| `metadata.namespace` <br/>_string_         | The namespace in which the deployment is replaced.                         |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
 
 Return value:
 
 | Attributes                 | &nbsp;                                              |
 | -------------------------- | --------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create deployment task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace deployment task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                        |
 
 <!-------------------- REPLACE DEPLOYMENT ------------------->

--- a/source/includes/kubernetes_extension/_k8_pods.md
+++ b/source/includes/kubernetes_extension/_k8_pods.md
@@ -519,6 +519,67 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create pod task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
+<!-------------------- REPLACE POD -------------------->
+
+#### Replace a pod
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods/edgar-allen-pod/default"
+  Content-Type: application/json
+  {
+	  "apiVersion": "v1",
+    "kind": "Pod",
+	  "metadata": {
+	  	"name": "edgar-allen-pod",
+		  "namespace": "default"
+  	},
+	  "spec": {
+		"containers": [
+			{
+				"image": "nginx",
+				"name": "nginx"
+			}
+		  ]
+	  }
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/pods/:id</code>
+
+Replace a pod in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`spec`<br/>_object_                 | The specification used to create and run the pod.
+`spec.container.image`<br/>_string_ | The docker image name.
+`spec.container.name`<br/>_string_  | The (unique) name of the container specified as a DNS_LABEL.
+
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `kind`<br/>_string_                       | The string value of the REST resource that this object represents.      |
+| `metadata.namespace` <br/>_string_        | The namespace in which the pod is created                               |
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create pod task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
 <!-------------------- DELETE POD -------------------->
 
 ##### Delete a pod

--- a/source/includes/kubernetes_extension/_k8_pods.md
+++ b/source/includes/kubernetes_extension/_k8_pods.md
@@ -564,20 +564,20 @@ Required Attributes                 | &nbsp;
 `apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
 `metadata` <br/>_object_            | The metadata of the pod.
 `metadata.name` <br/>_string_       | The name of the pod.
-`spec`<br/>_object_                 | The specification used to create and run the pod.
+`spec`<br/>_object_                 | The specification used to replace and run the pod.
 `spec.container.image`<br/>_string_ | The docker image name.
 `spec.container.name`<br/>_string_  | The (unique) name of the container specified as a DNS_LABEL.
 
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
 | `kind`<br/>_string_                       | The string value of the REST resource that this object represents.      |
-| `metadata.namespace` <br/>_string_        | The namespace in which the pod is created                               |
+| `metadata.namespace` <br/>_string_        | The namespace in which the pod is replaced.                             |
 
 Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create pod task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE POD -------------------->

--- a/source/includes/kubernetes_extension/_k8_pods.md
+++ b/source/includes/kubernetes_extension/_k8_pods.md
@@ -521,7 +521,7 @@ Return value:
 
 <!-------------------- REPLACE POD -------------------->
 
-#### Replace a pod
+##### Replace a pod
 
 ```shell
 curl -X PUT \
@@ -529,12 +529,12 @@ curl -X PUT \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/pods/edgar-allen-pod/default"
   Content-Type: application/json
   {
-	  "apiVersion": "v1",
+    "apiVersion": "v1",
     "kind": "Pod",
 	  "metadata": {
 	  	"name": "edgar-allen-pod",
 		  "namespace": "default"
-  	},
+  },
 	  "spec": {
 		"containers": [
 			{

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -169,7 +169,7 @@ Return value:
 
 <!-------------------- REPLACE A STATEFUL SET -------------------->
 
-#### Replace a stateful set
+##### Replace a stateful set
 
 ```shell
 curl -X PUT \

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -167,6 +167,83 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create stateful set task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                          |
 
+<!-------------------- REPLACE A STATEFUL SET -------------------->
+
+#### Replace a stateful set
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/statefulsets/stateful-set-name/default"
+  Content-Type: application/json
+  {
+  "apiVersion": "apps/v1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "stateful-set-name",
+    "namespace": "default"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "nginx"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "k8s.gcr.io/nginx-slim:0.8"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/statefulsets/:id</code>
+
+Replace a stateful set in a given [environment](#administration-environments).
+
+| Required Attributes                        | &nbsp;                                                                       |
+| ------------------------------------------ | -----------------------------------------------------------------------------|
+| `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set.                      |
+| `metadata` <br/>_object_                   | The metadata of the stateful set.                                            |
+| `metadata.name` <br/>_string_              | The name of the stateful set.                                                |
+| `spec`<br/>_object_                        | The specification used to create and run the stateful set.                   |
+| `spec.selector`<br/>_object_               | The label query over the stateful set's of resources.                        |
+| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created.                      |
+| `spec.spec`<br/>_object_                   | The specification used to create and run the pod(s) within the stateful set. |
+
+| Optional Attributes                        | &nbsp;                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.        |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created.                       |
+| `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set.       |
+
+Return value:
+
+| Attributes                 | &nbsp;                                                |
+| -------------------------- | ----------------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create stateful set task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                          |
+
 <!-------------------- DELETE STATEFUL SET -------------------->
 
 ##### Delete a stateful set

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -226,22 +226,22 @@ Replace a stateful set in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_                | The api version (versioned schema) of the stateful set.                      |
 | `metadata` <br/>_object_                   | The metadata of the stateful set.                                            |
 | `metadata.name` <br/>_string_              | The name of the stateful set.                                                |
-| `spec`<br/>_object_                        | The specification used to create and run the stateful set.                   |
+| `spec`<br/>_object_                        | The specification used to replaced and run the stateful set.                   |
 | `spec.selector`<br/>_object_               | The label query over the stateful set's of resources.                        |
-| `spec.template`<br/>_object_               | The data a stateful set's pod should have when created.                      |
-| `spec.spec`<br/>_object_                   | The specification used to create and run the pod(s) within the stateful set. |
+| `spec.template`<br/>_object_               | The data a stateful set's pod should have when replaced.                      |
+| `spec.spec`<br/>_object_                   | The specification used to replace and run the pod(s) within the stateful set. |
 
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | `kind`<br/>_string_                        | The string value of the REST resource that this object represents.        |
-| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created.                       |
+| `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is replaced.                      |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set.       |
 
 Return value:
 
 | Attributes                 | &nbsp;                                                |
 | -------------------------- | ----------------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create stateful set task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace stateful set task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                          |
 
 <!-------------------- DELETE STATEFUL SET -------------------->


### PR DESCRIPTION
### Fixes [MC-11762](https://cloud-ops.atlassian.net/browse/MC-11762)

#### Changes made
- Added api docs editing kubernetes workloads (i.e., deployments, pods, daemon sets, and stateful sets)

#### Related PRs
- [ksdk part 1](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/160)
- [ksdk part 2](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/171)