### PR TITLE
MC-12383: removed redundant kind attribute from k8s docs

### DIFF
--- a/source/includes/kubernetes/_k8_configmaps.md
+++ b/source/includes/kubernetes/_k8_configmaps.md
@@ -37,7 +37,6 @@ Retrieve a list of all config maps in a given [environment](#administration-envi
 | -------------------------- | ------------------------------------------------- |
 | `id` <br/>_string_         | The id of the config map.                         |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this config map. |
-| `kind` <br/>_string_       | The type of the returned resource. ie, ConfigMap. |
 | `metadata` <br/>_object_   | The metadata of the config map.                   |
 
 <!-------------------- GET A CONFIG MAP -------------------->
@@ -71,7 +70,6 @@ Retrieve a config map and all its info in a given [environment](#administration-
 | -------------------------- | ------------------------------------------------- |
 | `id` <br/>_string_         | The id of the config map.                         |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this config map. |
-| `kind` <br/>_string_       | The type of the returned resource. ie, ConfigMap. |
 | `metadata` <br/>_object_   | The metadata of the config map.                   |
 
 <!-------------------- CREATE A CONFIG MAP -------------------->

--- a/source/includes/kubernetes/_k8_daemonsets.md
+++ b/source/includes/kubernetes/_k8_daemonsets.md
@@ -144,7 +144,6 @@ Create a daemon set in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is created.                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set.          |
 
@@ -222,7 +221,6 @@ Replace a daemon set in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is replaced.                         |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set.          |
 

--- a/source/includes/kubernetes/_k8_deployments.md
+++ b/source/includes/kubernetes/_k8_deployments.md
@@ -152,7 +152,6 @@ Create a deployment in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the deployment is replaced.                         |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
 
@@ -229,7 +228,6 @@ Replace a deployment in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created.                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
 

--- a/source/includes/kubernetes/_k8_ingresses.md
+++ b/source/includes/kubernetes/_k8_ingresses.md
@@ -212,7 +212,6 @@ Create an ingress in a given [environment](#administration-environments).
 
 | Optional Attributes                | &nbsp;                                                             |
 | ---------------------------------- | ------------------------------------------------------------------ |
-| `kind`<br/>_string_                | The string value of the REST resource that this object represents. |
 | `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created.                     |
 
 Return value:
@@ -297,7 +296,6 @@ Replace an ingress in a given [environment](#administration-environments).
 | Required Attributes           | &nbsp;                                                             |
 | ----------------------------- | ------------------------------------------------------------------ |
 | `apiVersion` <br/> _string_   | The api version (versioned schema) of the ingress.                 |
-| `kind`<br/>_string_           | The string value of the REST resource that this object represents. |
 | `metadata` <br/>_object_      | The metadata of the ingress.                                       |
 | `metadata.name` <br/>_string_ | The name of the ingress.                                           |
 | `spec`<br/>_object_           | The specification used to create and run the ingress.              |

--- a/source/includes/kubernetes/_k8_namespaces.md
+++ b/source/includes/kubernetes/_k8_namespaces.md
@@ -72,7 +72,6 @@ Retrieve a namespace and all its info in a given [environment](#administration-e
 | -------------------------- | ------------------------------------------------------------------------------------- |
 | `id` <br/>_string_         | The id of the namespace.                                                              |
 | `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object. |
-| `kind`<br/>_string_        | The string value of the REST resource that this object represents.                    |
 | `metadata` <br/>_object_   | The metadata of the namespace.                                                        |
 | `spec`<br/>_object_        | The specification describes the attributes on a namespace.                            |
 | `status`<br/>_object_      | The status information of the namespace.                                              |
@@ -113,10 +112,6 @@ Create a namespace in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_   | The api version (versioned schema) of the namespace. |
 | `metadata` <br/>_object_      | The metadata of the namespace.                       |
 | `metadata.name` <br/>_string_ | The name of the namespace.                           |
-
-| Optional Attributes | &nbsp;                                                             |
-| ------------------- | ------------------------------------------------------------------ |
-| `kind`<br/>_string_ | The string value of the REST resource that this object represents. |
 
 Return value:
 

--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -212,7 +212,6 @@ Create a persistent volume claim in a given [environment](#administration-enviro
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `kind`<br/>_string_                   | The string value of the REST resource that this object represents.                            |
 | `metadata.namespace` <br/>_string_    | The namespace in which the pod is created, if not specified will create the claim in default. |
 | `spec.storageClassName` <br/>_string_ | The storage class for the persistent volume claim, will use the default if not specified.     |
 | `spec.resources.limits` <br/>_object_ | Limits describe the maximum number of storage resources allowed.                              |

--- a/source/includes/kubernetes/_k8_pods.md
+++ b/source/includes/kubernetes/_k8_pods.md
@@ -502,7 +502,6 @@ Required Attributes                 | &nbsp;
 
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
-| `kind`<br/>_string_                       | The string value of the REST resource that this object represents.      |
 | `metadata.namespace` <br/>_string_        | The namespace in which the pod is created                               |
 
 Return value:
@@ -563,7 +562,6 @@ Required Attributes                 | &nbsp;
 
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
-| `kind`<br/>_string_                       | The string value of the REST resource that this object represents.      |
 | `metadata.namespace` <br/>_string_        | The namespace in which the pod is replaced.                             |
 
 Return value:

--- a/source/includes/kubernetes/_k8_secrets.md
+++ b/source/includes/kubernetes/_k8_secrets.md
@@ -44,7 +44,6 @@ Retrieve a list of all secrets in a given [environment](#administration-environm
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                              |
 | `metadata` <br/>_object_   | The metadata of the secret.                                                |
-| `kind`<br/>_string_        | The string value of the REST resource that this object represents.         |
 | `type` <br/>_string_       | A string used to facilitate programmatic handling of a secret's data.      |
 
 <!-------------------- GET A secret -------------------->
@@ -86,7 +85,6 @@ Retrieve a secret and all its info in a given [environment](#administration-envi
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                              |
 | `metadata` <br/>_object_   | The metadata of the secret.                                                |
-| `kind`<br/>_string_        | The string value of the REST resource that this object represents.         |
 | `type` <br/>_string_       | A string used to facilitate programmatic handling of a secret's data.      |
 
 <!-------------------- CREATE A SECRET -------------------->

--- a/source/includes/kubernetes/_k8_services.md
+++ b/source/includes/kubernetes/_k8_services.md
@@ -161,7 +161,6 @@ Create a service in a given [environment](#administration-environments).
 
 | Optional Attributes                      | &nbsp;                                                             |
 | ---------------------------------------- | ------------------------------------------------------------------ |
-| `kind`<br/>_string_                      | The string value of the REST resource that this object represents. |
 | `metadata.namespace` <br/>_string_       | The namespace in which the service is created.                     |
 | `spec.selector`<br/>_object_             | The label query over the service's set of resources.               |
 | `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a service.     |
@@ -232,7 +231,6 @@ Replace a service in a given [environment](#administration-environments).
 | Required Attributes           | &nbsp;                                                             |
 | ----------------------------- | ------------------------------------------------------------------ |
 | `apiVersion` <br/> _string_   | The api version (versioned schema) of the service.                 |
-| `kind`<br/>_string_           | The string value of the REST resource that this object represents. |
 | `metadata` <br/>_object_      | The metadata of the service.                                       |
 | `metadata.name` <br/>_string_ | The name of the service.                                           |
 | `spec`<br/>_object_           | The specification used to create and run the service.              |

--- a/source/includes/kubernetes/_k8_statefulsets.md
+++ b/source/includes/kubernetes/_k8_statefulsets.md
@@ -148,7 +148,6 @@ Create a stateful set in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.        |
 | `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is created.                       |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set.       |
 
@@ -225,7 +224,6 @@ Replace a stateful set in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.        |
 | `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is replaced.                      |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set.       |
 

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -167,7 +167,6 @@ Create a storage class in a given [environment](#administration-environments).
 | Required Attributes               | &nbsp;                                                                                                                    |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `apiVersion` <br/> _string_       | The api version (versioned schema) of the storage class.                                                                  |
-| `kind`<br/>_string_               | The string value of the REST resource that this object represents.                                                        |
 | `metadata` <br/>_object_          | The metadata of the storage class.                                                                                        |
 | `metadata.name` <br/>_string_     | The name of the storage class.                                                                                            |
 | `provisioner` <br/>_string_       | The provisioner for the storage class                                                                                     |

--- a/source/includes/kubernetes_extension/_k8_configmaps.md
+++ b/source/includes/kubernetes_extension/_k8_configmaps.md
@@ -41,7 +41,6 @@ Retrieve a list of all config maps in a given [environment](#administration-envi
 | -------------------------- | ------------------------------------------------- |
 | `id` <br/>_string_         | The id of the config map.                         |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this config map. |
-| `kind` <br/>_string_       | The type of the returned resource. ie, ConfigMap. |
 | `metadata` <br/>_object_   | The metadata of the config map.                   |
 
 <!-------------------- GET A CONFIG MAP -------------------->
@@ -82,7 +81,6 @@ Retrieve a config map and all its info in a given [environment](#administration-
 | -------------------------- | ------------------------------------------------- |
 | `id` <br/>_string_         | The id of the config map.                         |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this config map. |
-| `kind` <br/>_string_       | The type of the returned resource. ie, ConfigMap. |
 | `metadata` <br/>_object_   | The metadata of the config map.                   |
 
 <!-------------------- CREATE A CONFIG MAP -------------------->

--- a/source/includes/kubernetes_extension/_k8_daemonsets.md
+++ b/source/includes/kubernetes_extension/_k8_daemonsets.md
@@ -155,7 +155,6 @@ Create a daemon set in a given [environment](#administration-environments).
 
 | Optional Attributes                      | &nbsp;                                                                 |
 | ---------------------------------------- | ---------------------------------------------------------------------- |
-| `kind`<br/>_string_                      | The string value representing the REST resource this object represents |
 | `metadata.namespace` <br/>_string_       | The namespace in which the daemon set is created                       |
 | `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a daemon set       |
 
@@ -233,7 +232,6 @@ Replace a daemon set in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the daemon set is replaced.                         |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a daemon set.          |
 

--- a/source/includes/kubernetes_extension/_k8_deployments.md
+++ b/source/includes/kubernetes_extension/_k8_deployments.md
@@ -161,7 +161,6 @@ Create a deployment in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the deployment is replaced.                         |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
 
@@ -238,7 +237,6 @@ Replace a deployment in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                     |
 | ------------------------------------------ | -------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.         |
 | `metadata.namespace` <br/>_string_         | The namespace in which the deployment is created.                          |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a deployment.          |
 

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -224,7 +224,6 @@ Create an ingress in a given [environment](#administration-environments).
 
 | Optional Attributes                | &nbsp;                                                             |
 | ---------------------------------- | ------------------------------------------------------------------ |
-| `kind`<br/>_string_                | The string value of the REST resource that this object represents. |
 | `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created.                     |
 
 Return value:
@@ -313,7 +312,6 @@ Replace an ingress in a given [environment](#administration-environments).
 | Required Attributes           | &nbsp;                                                             |
 | ----------------------------- | ------------------------------------------------------------------ |
 | `apiVersion` <br/> _string_   | The api version (versioned schema) of the ingress.                 |
-| `kind`<br/>_string_           | The string value of the REST resource that this object represents. |
 | `metadata` <br/>_object_      | The metadata of the ingress.                                       |
 | `metadata.name` <br/>_string_ | The name of the ingress.                                           |
 | `spec`<br/>_object_           | The specification used to create and run the ingress.              |

--- a/source/includes/kubernetes_extension/_k8_namespaces.md
+++ b/source/includes/kubernetes_extension/_k8_namespaces.md
@@ -40,7 +40,6 @@ Retrieve a list of all namespaces in a given [environment](#administration-envir
 | -------------------------- | ------------------------------------------------------------------------------------ |
 | `id` <br/>_string_         | The id of the namespace.                                                             |
 | `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object |
-| `kind` <br/>_string_       | A string value representing the REST resource this object represents                 |
 | `metadata` <br/>_object_   | The metadata of the namespace                                                        |
 | `spec`<br/>_object_        | The specification describes the attributes on a namespace.                           |
 | `status`<br/>_object_      | The status information of the namespace                                              |
@@ -82,7 +81,6 @@ Retrieve a namespace and all its info in a given [environment](#administration-e
 | -------------------------- | ------------------------------------------------------------------------------------ |
 | `id` <br/>_string_         | The id of the namespace.                                                             |
 | `apiVersion` <br/>_string_ | APIVersion defines the versioned schema of this representation of a namespace object |
-| `kind` <br/>_string_       | A string value representing the REST resource this object represents                 |
 | `metadata` <br/>_object_   | The metadata of the namespace                                                        |
 | `spec`<br/>_object_        | The specification describes the attributes on a namespace.                           |
 | `status`<br/>_object_      | The status information of the namespace                                              |
@@ -127,10 +125,6 @@ Create a namespace in a given [environment](#administration-environments).
 | `apiVersion` <br/> _string_   | The api version (versioned schema) of the namespace. |
 | `metadata` <br/>_object_      | The metadata of the namespace.                       |
 | `metadata.name` <br/>_string_ | The name of the namespace.                           |
-
-| Optional Attributes | &nbsp;                                                             |
-| ------------------- | ------------------------------------------------------------------ |
-| `kind`<br/>_string_ | The string value of the REST resource that this object represents. |
 
 Return value:
 

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -224,7 +224,6 @@ Create a persistent volume claim in a given [environment](#administration-enviro
 
 | Optional Attributes                   | &nbsp;                                                                                        |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `kind`<br/>_string_                   | The string value representing the REST resource this object represents.                       |
 | `metadata.namespace` <br/>_string_    | The namespace in which the pod is created, if not specified will create the claim in default. |
 | `spec.storageClassName` <br/>_string_ | The storage class for the persistent volume claim, will use the default if not specified.     |
 | `spec.resources.limits` <br/>_object_ | Limits describe the maximum number of storage resources allowed.                              |

--- a/source/includes/kubernetes_extension/_k8_pods.md
+++ b/source/includes/kubernetes_extension/_k8_pods.md
@@ -509,7 +509,6 @@ Create a pod in a given [environment](#administration-environments).
 
 | Optional Attributes                | &nbsp;                                                                 |
 | ---------------------------------- | ---------------------------------------------------------------------- |
-| `kind`<br/>_string_                | The string value representing the REST resource this object represents |
 | `metadata.namespace` <br/>_string_ | The namespace in which the pod is created                              |
 
 Return value:
@@ -570,7 +569,6 @@ Required Attributes                 | &nbsp;
 
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
-| `kind`<br/>_string_                       | The string value of the REST resource that this object represents.      |
 | `metadata.namespace` <br/>_string_        | The namespace in which the pod is replaced.                             |
 
 Return value:

--- a/source/includes/kubernetes_extension/_k8_secrets.md
+++ b/source/includes/kubernetes_extension/_k8_secrets.md
@@ -48,7 +48,6 @@ Retrieve a list of all secrets in a given [environment](#administration-environm
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                              |
 | `metadata` <br/>_object_   | The metadata of the secret.                                                |
-| `kind` <br/>_string_       | A string value representing the REST resource that this object represents. |
 | `type` <br/>_string_       | A string used to facilitate programmatic handling of a secret's data.      |
 
 <!-------------------- GET A secret -------------------->
@@ -94,7 +93,6 @@ Retrieve a secret and all its info in a given [environment](#administration-envi
 | `apiVersion` <br/>_string_ | The API version used to retrieve the secret.                               |
 | `encodedData`<br/>_object_ | The base64 encoded data stored in the secret.                              |
 | `metadata` <br/>_object_   | The metadata of the secret.                                                |
-| `kind` <br/>_string_       | A string value representing the REST resource that this object represents. |
 | `type` <br/>_string_       | A string used to facilitate programmatic handling of a secret's data.      |
 
 <!-------------------- CREATE A SECRET -------------------->

--- a/source/includes/kubernetes_extension/_k8_services.md
+++ b/source/includes/kubernetes_extension/_k8_services.md
@@ -173,7 +173,6 @@ Create a service in a given [environment](#administration-environments).
 
 | Optional Attributes                      | &nbsp;                                                             |
 | ---------------------------------------- | ------------------------------------------------------------------ |
-| `kind`<br/>_string_                      | The string value of the REST resource that this object represents. |
 | `metadata.namespace` <br/>_string_       | The namespace in which the service is created.                     |
 | `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a service.     |
 
@@ -247,7 +246,6 @@ Replace a service in a given [environment](#administration-environments).
 | Required Attributes           | &nbsp;                                                             |
 | ----------------------------- | ------------------------------------------------------------------ |
 | `apiVersion` <br/> _string_   | The api version (versioned schema) of the service.                 |
-| `kind`<br/>_string_           | The string value of the REST resource that this object represents. |
 | `metadata` <br/>_object_      | The metadata of the service.                                       |
 | `metadata.name` <br/>_string_ | The name of the service.                                           |
 | `spec`<br/>_object_           | The specification used to create and run the service.              |

--- a/source/includes/kubernetes_extension/_k8_statefulsets.md
+++ b/source/includes/kubernetes_extension/_k8_statefulsets.md
@@ -156,7 +156,6 @@ Create a stateful set in a given [environment](#administration-environments).
 
 | Optional Attributes                      | &nbsp;                                                                 |
 | ---------------------------------------- | ---------------------------------------------------------------------- |
-| `kind`<br/>_string_                      | The string value representing the REST resource this object represents |
 | `metadata.namespace` <br/>_string_       | The namespace in which the stateful set is created                     |
 | `spec.selector.matchLabels`<br/>_object_ | The key value pairs retrieved by a label query from a stateful set     |
 
@@ -233,7 +232,6 @@ Replace a stateful set in a given [environment](#administration-environments).
 
 | Optional Attributes                        | &nbsp;                                                                    |
 | ------------------------------------------ | ------------------------------------------------------------------------- |
-| `kind`<br/>_string_                        | The string value of the REST resource that this object represents.        |
 | `metadata.namespace` <br/>_string_         | The namespace in which the stateful set is replaced.                      |
 | `spec.selector.matchLabels`<br/>_object_   | The key value pairs retrieved by a label query from a stateful set.       |
 

--- a/source/includes/kubernetes_extension/_k8_storageclasses.md
+++ b/source/includes/kubernetes_extension/_k8_storageclasses.md
@@ -175,7 +175,6 @@ Create a storage class in a given [environment](#administration-environments).
 | Required Attributes               | &nbsp;                                                                                                                    |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `apiVersion` <br/> _string_       | The api version (versioned schema) of the storage class.                                                                  |
-| `kind`<br/>_string_               | The string value representing the REST resource this object represents.                                                   |
 | `metadata` <br/>_object_          | The metadata of the storage class.                                                                                        |
 | `metadata.name` <br/>_string_     | The name of the storage class.                                                                                            |
 | `provisioner` <br/>_string_       | The provisioner for the storage class                                                                                     |


### PR DESCRIPTION
It's obvious what exactly "kind" is from context, so no need to spell it out. Also, for any given entity type, only one value for kind will be accepted anyways.

### Fixes [MC-12383](https://cloud-ops.atlassian.net/browse/MC-12383)

#### Changes made
<!-- Changes should match the template provided below -->
- removed `kind` attribute from docs for k8s entities