### PR TITLE
Add docs

### DIFF
--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -248,12 +248,12 @@ curl -X POST "https://cloudmc_endpoint/rest/product_catalogs" \
             "fr": "category_fr",
             "es": "category_es"
           },
-					"id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+	  "id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
         }
       ],
       "products": [
         {
-					"categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
+	  "categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
           "metricType": "GAUGE",
           "unit": {
             "unit": "HOUR",
@@ -411,12 +411,12 @@ curl -X PUT "https://cloudmc_endpoint/rest/product_catalogs/b541a90b-afb6-44cf-8
             "fr": "category_fr",
             "es": "category_es"
           },
-					"id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+	  "id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
         }
       ],
       "products": [
         {
-					"categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
+	  "categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
           "metricType": "GAUGE",
           "unit": {
             "unit": "HOUR",

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -248,12 +248,12 @@ curl -X POST "https://cloudmc_endpoint/rest/product_catalogs" \
             "fr": "category_fr",
             "es": "category_es"
           },
-	  "id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+					"id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
         }
       ],
       "products": [
         {
-	  "categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
+					"categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
           "metricType": "GAUGE",
           "unit": {
             "unit": "HOUR",
@@ -411,12 +411,12 @@ curl -X PUT "https://cloudmc_endpoint/rest/product_catalogs/b541a90b-afb6-44cf-8
             "fr": "category_fr",
             "es": "category_es"
           },
-	  "id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+					"id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
         }
       ],
       "products": [
         {
-	  "categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
+					"categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
           "metricType": "GAUGE",
           "unit": {
             "unit": "HOUR",
@@ -517,6 +517,7 @@ Required | &nbsp;
 `products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
 `products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
 `products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
+`products.id`<br/>*UUID* | The ID of the product.
 `products.attribute`<br/>*string* | The attribute that will be used to compute usage from the service type usage.
 `products.source`<br/>*strubg* | The source of the usage to get from the service type.
 `products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -81,7 +81,7 @@ Attributes | &nbsp;
 `connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
 `changes`<br/>*Array[Object]* | Array of all changes done on the product catalog.
 `categories`<br/>*Array[Object]* | The list of product categories object.
-`categories.id`<br/>*string* | The id of product category object.
+`categories.id`<br/>*UUID* | The id of product category object.
 `categories.name`<br/>*Object* | The name object in each language for the category.
 `products`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
@@ -185,7 +185,7 @@ Attributes | &nbsp;
 `connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
 `changes`<br/>*Array[Object]* | Array of all changes done on the product catalog.
 `categories`<br/>*Array[Object]* | The list of product categories object.
-`categories.id`<br/>*string* | The id of product category object.
+`categories.id`<br/>*UUID* | The id of product category object.
 `categories.name`<br/>*Object* | The name object in each language for the category.
 `products`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
@@ -504,7 +504,7 @@ Required | &nbsp;
 `description`<br/>*string* | The description object in each language for the product catalog.
 `mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
 `categories`<br/>*Array[Object]* | The list of product categories object.
-`categories.id`<br/>*string* | The id of product category object. Required for each category object.
+`categories.id`<br/>*UUID* | The id of product category object. Required for each category object.
 `categories.name`<br/>*Object* | The name object in each language for the category.
 `products`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -373,7 +373,7 @@ Optional | &nbsp;
 
 Update an existing product catalog, including its associated categories and products.
 
-The catalog's service type as well as the existing product SKUs cannot be edited. In addition, users may not delete categories or products. Products may be marked as deprecated, deprecated products may not be updated or un-deprecated.
+The catalog's service type as well as the existing product SKUs cannot be edited. In addition, users may not delete categories or products. Products may be marked as deprecated. Deprecated products may not be updated or un-deprecated.
 
 ```shell
 # Updates a product catalog

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -205,3 +205,351 @@ Attributes | &nbsp;
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
 `products.sku`<br/>*string* | The SKU of the product information.
 `products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product.
+
+
+<!-------------------- CREATE PRODUCT CATALOG -------------------->
+#### Create product catalog
+
+`POST /product_catalogs`
+
+Create a new product catalog.
+
+```shell
+# Creates a new product catalog
+curl -X POST "https://cloudmc_endpoint/rest/product_catalogs" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```js
+ {
+      "mode": "ALL_CONNECTIONS_OF_TYPE",
+      "serviceType": "cloudca",
+      "connectionIds": [],
+      "name": {
+        "en": "name_en",
+        "fr": "name_fr",
+        "es": "name_es"
+      },
+      "description": {
+        "en": "beep boop",
+        "fr": "beep boop",
+        "es": "beep boop"
+      },
+      "categories": [
+        {
+          "name": {
+            "en": "category_en",
+            "fr": "category_fr",
+            "es": "category_es"
+          },
+					"id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+        }
+      ],
+      "products": [
+        {
+					"categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
+          "metricType": "GAUGE",
+          "unit": {
+            "unit": "HOUR",
+            "name": {}
+          },
+          "period": "HOUR",
+          "deprecated": false,
+          "name": {
+            "en": "product_en",
+            "fr": "product_fr",
+            "es": "product_es"
+          },
+          "transformer": {
+            "type": "PROPORTIONAL_TO_TIME"
+          },
+          "attribute": "RAWUSAGE",
+          "source": "1",
+          "filters": [],
+          "sku": "product_sku"
+        }
+      ]
+    }
+```
+> The above command return JSON structured like this:
+
+```js
+{
+  "data": {
+    "mode": "ALL_CONNECTIONS_OF_TYPE",
+    "serviceType": "cloudca",
+    "connectionIds": [],
+    "name": {
+      "en": "madeInApi",
+      "fr": "madeInApi",
+      "es": "madeInApi"
+    },
+    "description": {
+      "en": "beep boop",
+      "fr": "beep boop",
+      "es": "beep boop"
+    },
+    "id": "b541a90b-afb6-44cf-8a0d-3332668bbe12",
+    "categories": [
+      {
+        "name": {
+          "en": "category_en",
+          "fr": "category_fr",
+          "es": "category_es"
+        },
+        "id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+      }
+    ],
+    "products": [
+      {
+        "metricType": "GAUGE",
+        "unit": {
+          "unit": "HOUR",
+          "name": {}
+        },
+        "period": "HOUR",
+        "deprecated": false,
+        "name": {
+          "en": "product_en",
+          "fr": "product_fr",
+          "es": "product_es"
+        },
+        "transformer": {
+          "type": "PROPORTIONAL_TO_TIME"
+        },
+        "id": "e28f7a0a-ca4d-4840-af11-ac760bfcd42b",
+        "attribute": "RAWUSAGE",
+        "source": "1",
+        "filters": [],
+        "sku": "product_sku",
+        "categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+      }
+    ]
+  }
+}
+```
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*Object* | The name object in each language for the product catalog.
+`description`<br/>*string* | The description object in each language for the product catalog.
+`mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
+`serviceType`<br/>*Object* | The service connection type the product catalog is bound to.
+
+Optional | &nbsp;
+------- | -----------
+`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
+`categories`<br/>*Array[Object]* | The list of product categories object.
+`categories.id`<br/>*string* | The id of product category object. Required for each category object.
+`categories.name`<br/>*Object* | The name object in each language for the category.
+`products`<br/>*Array[Object]* | The list of products assigned to the catalog.
+`products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
+`products.unit`<br/>*Object* | The unit object of the product.
+`products.unit.unit`<br/>*string* | The unit value of the product.
+`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
+`products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
+`products.name`<br/>*Object* | The name object in each language for the product name.
+`products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
+`products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
+`products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
+`products.attribute`<br/>*string* | The attribute that will be used to compute usage from the service type usage.
+`products.source`<br/>*strubg* | The source of the usage to get from the service type.
+`products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
+`products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.
+`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION.
+`products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
+`products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
+`products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
+`products.sku`<br/>*string* | The SKU of the product information.
+`products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product. Required for each product.
+
+
+<!-------------------- UPDATE PRODUCT CATALOG -------------------->
+#### Update product catalog
+
+`PUT /product_catalogs/:id`
+
+Update an existing product catalog, including its associated categories and products.
+
+The catalog's service type as well as the existing product SKUs cannot be edited. In addition, users may not delete categories or products. Products may be marked as deprecated, deprecated products may not be updated or un-deprecated.
+
+```shell
+# Updates a product catalog
+curl -X PUT "https://cloudmc_endpoint/rest/product_catalogs/b541a90b-afb6-44cf-8a0d-3332668bbe12" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```js
+ {
+      "mode": "ALL_CONNECTIONS_OF_TYPE",
+      "connectionIds": [],
+      "name": {
+        "en": "updated_en",
+        "fr": "name_fr",
+        "es": "name_es"
+      },
+      "description": {
+        "en": "beep boop",
+        "fr": "beep boop",
+        "es": "beep boop"
+      },
+      "id": "b541a90b-afb6-44cf-8a0d-3332668bbe12",
+      "categories": [
+        {
+          "name": {
+            "en": "category_en",
+            "fr": "category_fr",
+            "es": "category_es"
+          },
+					"id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+        }
+      ],
+      "products": [
+        {
+					"categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3",
+          "metricType": "GAUGE",
+          "unit": {
+            "unit": "HOUR",
+            "name": {}
+          },
+          "period": "HOUR",
+          "deprecated": false,
+          "name": {
+            "en": "product_en",
+            "fr": "product_fr",
+            "es": "product_es"
+          },
+          "transformer": {
+            "type": "PROPORTIONAL_TO_TIME"
+          },
+          "id": "e28f7a0a-ca4d-4840-af11-ac760bfcd42b",
+          "attribute": "RAWUSAGE",
+          "source": "1",
+          "filters": [],
+        }
+      ]
+    }
+```
+> The above command return JSON structured like this:
+
+```js
+{
+  "data": {
+    "mode": "ALL_CONNECTIONS_OF_TYPE",
+    "serviceType": "cloudca",
+    "connectionIds": [],
+    "name": {
+      "en": "updated_en",
+      "fr": "name_fr",
+      "es": "name_es"
+    },
+    "description": {
+      "en": "beep boop",
+      "fr": "beep boop",
+      "es": "beep boop"
+    },
+    "id": "b541a90b-afb6-44cf-8a0d-3332668bbe12",
+    "categories": [
+      {
+        "name": {
+          "en": "category_en",
+          "fr": "category_fr",
+          "es": "category_es"
+        },
+        "id": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+      }
+    ],
+    "products": [
+      {
+        "metricType": "GAUGE",
+        "unit": {
+          "unit": "HOUR",
+          "name": {}
+        },
+        "period": "HOUR",
+        "deprecated": false,
+        "name": {
+          "en": "product_en",
+          "fr": "product_fr",
+          "es": "product_es"
+        },
+        "transformer": {
+          "type": "PROPORTIONAL_TO_TIME"
+        },
+        "id": "e28f7a0a-ca4d-4840-af11-ac760bfcd42b",
+        "attribute": "RAWUSAGE",
+        "source": "1",
+        "filters": [],
+        "sku": "product_sku",
+        "categoryId": "c14daee2-4678-4710-b9af-fc26fbd3c7f3"
+      }
+    ]
+  }
+}
+```
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*Object* | The name object in each language for the product catalog.
+`description`<br/>*string* | The description object in each language for the product catalog.
+`mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
+`categories`<br/>*Array[Object]* | The list of product categories object.
+`categories.id`<br/>*string* | The id of product category object. Required for each category object.
+`categories.name`<br/>*Object* | The name object in each language for the category.
+`products`<br/>*Array[Object]* | The list of products assigned to the catalog.
+`products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
+`products.unit`<br/>*Object* | The unit object of the product.
+`products.unit.unit`<br/>*string* | The unit value of the product.
+`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
+`products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
+`products.name`<br/>*Object* | The name object in each language for the product name.
+`products.deprecataed`<br>*boolean* | Whether or not the product is deprecated. Deprecated products may not be updated or undeprecated. Defaults to false.
+`products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
+`products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
+`products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
+`products.attribute`<br/>*string* | The attribute that will be used to compute usage from the service type usage.
+`products.source`<br/>*strubg* | The source of the usage to get from the service type.
+`products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
+`products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.
+`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION.
+`products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
+`products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
+`products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
+`products.sku`<br/>*string* | The SKU of the product information. May not be edited after product is created.
+`products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product. Required for each product.
+
+Optional | &nbsp;
+------- | -----------
+`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
+
+
+<!-------------------- DELETE PRODUCT CATALOG -------------------->
+#### Delete product catalog
+
+`DELETE /product_catalogs/:id`
+
+Delete an existing product catalog. Users may not delete a product catalog that has associated pricings.
+
+```shell
+# Deletes a specified product catalog
+curl -X DELETE "https://cloudmc_endpoint/rest/product_catalogs/b541a90b-afb6-44cf-8a0d-3332668bbe12" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
+  "taskStatus": "SUCCESS"
+}
+```
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the identity provider deletion.
+`taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -50,6 +50,7 @@ curl "https://cloudmc_endpoint/rest/product_catalogs" \
             "name": {}
           },
           "period": "HOUR",
+          "deprecated": false,
           "name": {
             "en": "vCPU",
             "fr": "vCPU"
@@ -86,8 +87,9 @@ Attributes | &nbsp;
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
 `products.unit`<br/>*Object* | The unit object of the product.
 `products.unit.unit`<br/>*string* | The unit value of the product.
-`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
+`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom units.
 `products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
+`products.deprecated`<br>*boolean* | Whether or not the product is deprecated. Defaults to false.
 `products.name`<br/>*Object* | The name object in each language for the product name.
 `products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
 `products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
@@ -101,7 +103,7 @@ Attributes | &nbsp;
 `products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
 `products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
-`products.sku`<br/>*string* | The SKU of the product information.
+`products.sku`<br/>*string* | The SKU of the product.
 `products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product.
 
 
@@ -152,6 +154,7 @@ curl "https://cloudmc_endpoint/rest/product_catalogs/03bc22bd-adc4-46b8-988d-afd
           "name": {}
         },
         "period": "HOUR",
+        "deprecated": false,
         "name": {
           "en": "vCPU",
           "fr": "vCPU"
@@ -188,8 +191,9 @@ Attributes | &nbsp;
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
 `products.unit`<br/>*Object* | The unit object of the product.
 `products.unit.unit`<br/>*string* | The unit value of the product.
-`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
+`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom units.
 `products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
+`products.deprecated`<br>*boolean* | Whether or not the product is deprecated. Deprecated products may not be updated or undeprecated. Defaults to false.
 `products.name`<br/>*Object* | The name object in each language for the product name.
 `products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
 `products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
@@ -203,7 +207,7 @@ Attributes | &nbsp;
 `products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
 `products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
-`products.sku`<br/>*string* | The SKU of the product information.
+`products.sku`<br/>*string* | The SKU of the product.
 `products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product.
 
 
@@ -342,18 +346,20 @@ Optional | &nbsp;
 ------- | -----------
 `connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
 `categories`<br/>*Array[Object]* | The list of product categories object.
-`categories.id`<br/>*string* | The id of product category object. Required for each category object.
+`categories.id`<br/>*UUID* | The id of product category object. Required for each category object.
 `categories.name`<br/>*Object* | The name object in each language for the category.
 `products`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
 `products.unit`<br/>*Object* | The unit object of the product.
 `products.unit.unit`<br/>*string* | The unit value of the product.
-`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
+`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom units.
 `products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
+`products.deprecated`<br>*boolean* | Whether or not the product is deprecated. Deprecated products may not be updated or undeprecated. Defaults to false.
 `products.name`<br/>*Object* | The name object in each language for the product name.
 `products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
 `products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
 `products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
+`products.id`<br/>*UUID* | The id of the product. Returned with the response.
 `products.attribute`<br/>*string* | The attribute that will be used to compute usage from the service type usage.
 `products.source`<br/>*strubg* | The source of the usage to get from the service type.
 `products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
@@ -362,7 +368,7 @@ Optional | &nbsp;
 `products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
 `products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
-`products.sku`<br/>*string* | The SKU of the product information.
+`products.sku`<br/>*string* | The SKU of the product.
 `products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product. Required for each product.
 
 
@@ -504,10 +510,10 @@ Required | &nbsp;
 `products.metricType`<br/>*string* | The type of metrics taken. Possible values: COUNTER, GAUGE.
 `products.unit`<br/>*Object* | The unit object of the product.
 `products.unit.unit`<br/>*string* | The unit value of the product.
-`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom unit.
+`products.unit.name`<br/>*Object* | The name of the unit of the product in the required language. Only present when defining custom units.
 `products.period`<br/>*string* | The period for the product capture. Possible values: HOURS, MONTH.
 `products.name`<br/>*Object* | The name object in each language for the product name.
-`products.deprecataed`<br>*boolean* | Whether or not the product is deprecated. Deprecated products may not be updated or undeprecated. Defaults to false.
+`products.deprecated`<br>*boolean* | Whether or not the product is deprecated. Deprecated products may not be updated or undeprecated. Defaults to false.
 `products.transformer`<br/>*Object* | The object representing the transformation to do on the product usage.
 `products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
 `products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
@@ -519,7 +525,7 @@ Required | &nbsp;
 `products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
 `products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
-`products.sku`<br/>*string* | The SKU of the product information. May not be edited after product is created.
+`products.sku`<br/>*string* | The SKU of the product. May not be edited after product is created.
 `products.categoryId`<br/>*UUID* | The UUID of the category to which belongs the product. Required for each product.
 
 Optional | &nbsp;

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -78,7 +78,7 @@ Attributes | &nbsp;
 `description`<br/>*string* | The description object in each language for the product catalog.
 `mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
 `serviceType`<br/>*Object* | The service connection type the product catalog is bound to.
-`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
+`connectionIds`<br/>*Array[UUID]* | Array of UUID for the service connections that the catalog is bound to.
 `changes`<br/>*Array[Object]* | Array of all changes done on the product catalog.
 `categories`<br/>*Array[Object]* | The list of product categories object.
 `categories.id`<br/>*UUID* | The id of product category object.
@@ -182,7 +182,7 @@ Attributes | &nbsp;
 `description`<br/>*string* | The description object in each language for the product catalog.
 `mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
 `serviceType`<br/>*Object* | The service connection type the product catalog is bound to.
-`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
+`connectionIds`<br/>*Array[UUID]* | Array of UUID for the service connections that the catalog is bound to.
 `changes`<br/>*Array[Object]* | Array of all changes done on the product catalog.
 `categories`<br/>*Array[Object]* | The list of product categories object.
 `categories.id`<br/>*UUID* | The id of product category object.
@@ -344,7 +344,7 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
-`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
+`connectionIds`<br/>*Array[UUID]* | Array of UUID for the service connections that the catalog is bound to.
 `categories`<br/>*Array[Object]* | The list of product categories object.
 `categories.id`<br/>*UUID* | The id of product category object. Required for each category object.
 `categories.name`<br/>*Object* | The name object in each language for the category.
@@ -531,7 +531,7 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
-`connectionIds`<br/>*Array[UUID]* | Array of the UUID service connection the catalog is bound to.
+`connectionIds`<br/>*Array[UUID]* | Array of UUID for the service connections that the catalog is bound to.
 
 
 <!-------------------- DELETE PRODUCT CATALOG -------------------->

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -99,7 +99,7 @@ Attributes | &nbsp;
 `products.source`<br/>*strubg* | The source of the usage to get from the service type.
 `products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.
-`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION.
+`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION. The expression must follow the syntax of Spring Expression Language(SPEL).
 `products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
 `products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
@@ -203,7 +203,7 @@ Attributes | &nbsp;
 `products.source`<br/>*strubg* | The source of the usage to get from the service type.
 `products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.
-`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION.
+`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION. The expression must follow the syntax of Spring Expression Language(SPEL).
 `products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
 `products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
@@ -364,7 +364,7 @@ Optional | &nbsp;
 `products.source`<br/>*strubg* | The source of the usage to get from the service type.
 `products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.
-`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION.
+`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION. The expression must follow the syntax of Spring Expression Language(SPEL).
 `products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
 `products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.
@@ -522,7 +522,7 @@ Required | &nbsp;
 `products.source`<br/>*strubg* | The source of the usage to get from the service type.
 `products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.
-`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION.
+`products.filters.expression`<br/>*string* | The expression to filter the product in the usage generation. Only required when the type is EXPRESSION. The expression must follow the syntax of Spring Expression Language(SPEL).
 `products.filters.field`<br/>*string* | The field to filter. This is only required when type is SIMPLE.
 `products.filters.operator`<br/>*string* | The operation to check on the selected field. This is only required when type is SIMPLE. Possible values: EQUAL, NOT_EQUAL, CONTAINS, STARTS_WITH, ENDS_WITH, MATCHES_REGEX, LESS_THAN, LESS_OR_EQUAL_THAN, BIGGER_THAN, BIGGER_OR_EQUAL_THAN.
 `products.filters.value`<br/>*string* | The value to use in the field combined with the operation. This is only required when type is SIMPLE.

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -360,7 +360,7 @@ Optional | &nbsp;
 `products.transformer.type`<br/>*string* | The type of transformation to apply. Possible values: PROPORTIONAL_TO_TIME, EXPRESSION, NONE.
 `products.transformer.expression`<br/>*string* | The transformation expression to apply. Only required if the type is EXPRESSION. 
 `products.id`<br/>*UUID* | The id of the product. Returned with the response.
-`products.attribute`<br/>*string* | The attribute that will be used to compute usage from the service type usage.
+`products.attribute`<br/>*string* | The source attribute that will be used to compute usage from the service type usage.
 `products.source`<br/>*strubg* | The source of the usage to get from the service type.
 `products.filters`<br/>*Array[Object]* | The list of products assigned to the catalog.
 `products.filters.type`<br/>*string* | The type of the filter. Possible values: EXPRESSION, SIMPLE.


### PR DESCRIPTION
### Fixes [MC-12290](https://cloud-ops.atlassian.net/browse/MC-12290)

#### Changes made
<!-- Changes should match the template provided below -->
- add create, update, delete documentation

#### Related PRs
- [deprecation](https://github.com/cloudops/cloudmc-core/pull/898)
- [update](https://github.com/cloudops/cloudmc-core/pull/891)
- [delete](https://github.com/cloudops/cloudmc-core/pull/905)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->