### PR TITLE
MC-12549: Add documentation for gcp delete snapshot opration

### DIFF
--- a/source/includes/gcp/_snapshots.md
+++ b/source/includes/gcp/_snapshots.md
@@ -150,3 +150,17 @@ Attributes | &nbsp;
 #### Create a snapshot
 
 See [take a snapshot of a disk](#gcp-take-a-snapshot-of-a-disk) to create a snapshot.
+
+<!-------------------- DELETE A DISK -------------------->
+
+#### Delete a snapshot
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/snapshots/463325715266630842"
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/snapshots/:id</code>
+
+Destroy an existing snapshot. A snapshot can only be deleted if it is in READY state.

--- a/source/includes/gcp/_snapshots.md
+++ b/source/includes/gcp/_snapshots.md
@@ -151,7 +151,7 @@ Attributes | &nbsp;
 
 See [take a snapshot of a disk](#gcp-take-a-snapshot-of-a-disk) to create a snapshot.
 
-<!-------------------- DELETE A DISK -------------------->
+<!-------------------- DELETE A SNAPSHOT -------------------->
 
 #### Delete a snapshot
 


### PR DESCRIPTION
### Fixes [MC-12549](https://cloud-ops.atlassian.net/browse/MC-12549)

#### Changes made
<!-- Changes should match the template provided below -->
- Added documentation for delete snapshot operation for GCP plugin

#### Related PRs
- [327](https://github.com/cloudops/cloudmc-gcp-plugin/pull/327)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->