### PR TITLE
Feature/mc 12506 updating api documentation for kubernetes storage entities

### DIFF
--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -223,6 +223,77 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create persistent volume claim task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                                     |
 
+<!-------------------- REPLACE PERSISTENT VOLUME CLAIM -------------------->
+
+#### Replace a persistent volume claim
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/my-persistent-volume-claim/default"
+  Content-Type: application/json
+  {
+    "id": "pv-claim-name/default",
+    "apiVersion": "v1",
+    "kind": "PersistentVolumeClaim",
+    "metadata": {
+        "name": "pv-claim-name",
+        "namespace": "default"
+    },
+    "spec": {
+        "accessModes": [
+            "ReadWriteOnce"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "1Gi"
+            }
+        },
+        "storageClassName": "standard",
+        "volumeName": "persistentvolumes-name",
+        "dataSource": "dataSource"
+    }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id</code>
+
+Replace a persistent volume claim in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`spec`<br/>_object_                 | The specification used to replace and run the pod.
+`spec.accessModes`<br/>_string_ | The desired access modes the volume should have.
+`spec.resources.requests.storage`<br/>_string_  | The size of the claim.
+`spec.storageClassName`<br/>_string_  | The name of the StorageClass required by the claim.
+`spec.volumeName`<br/>_string_  | The binding reference to the PersistentVolume backing this claim. Only required if claim is bound.
+
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `spec.volumemode` <br/>_string_        | What type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.|
+| `spec.dataSource` <br/>_string_        | This field can be used to specify either: an existing VolumeSnapshot object, an existing PVC or an existing custom resource/object that implements data population.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core).
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
 <!-------------------- DELETE a persistent volume claim  -------------------->
 
 #### Delete a persistent volume claim

--- a/source/includes/kubernetes/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes/_k8_persistentvolumeclaims.md
@@ -271,10 +271,10 @@ Replace a persistent volume claim in a given [environment](#administration-envir
 
 Required Attributes                 | &nbsp;
 ----------------------------------- | ------------------------------------------------------------
-`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
-`metadata` <br/>_object_            | The metadata of the pod.
-`metadata.name` <br/>_string_       | The name of the pod.
-`spec`<br/>_object_                 | The specification used to replace and run the pod.
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the claim.
+`metadata` <br/>_object_            | The metadata of the claim.
+`metadata.name` <br/>_string_       | The name of the claim.
+`spec`<br/>_object_                 | The specification used to replace and run the claim.
 `spec.accessModes`<br/>_string_ | The desired access modes the volume should have.
 `spec.resources.requests.storage`<br/>_string_  | The size of the claim.
 `spec.storageClassName`<br/>_string_  | The name of the StorageClass required by the claim.
@@ -291,7 +291,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskId` <br/>_string_     | The id corresponding to the replace persistent volume claim task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE a persistent volume claim  -------------------->

--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -296,10 +296,10 @@ Replace a persistent volume in a given [environment](#administration-environment
 
 Required Attributes                 | &nbsp;
 ----------------------------------- | ------------------------------------------------------------
-`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
-`metadata` <br/>_object_            | The metadata of the pod.
-`metadata.name` <br/>_string_       | The name of the pod.
-`spec`<br/>_object_                 | The specification used to replace and run the pod.
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the volume.
+`metadata` <br/>_object_            | The metadata of the volume.
+`metadata.name` <br/>_string_       | The name of the volume.
+`spec`<br/>_object_                 | The specification used to replace and run the volume.
 `spec.accessModes`<br/>_string_ | The desired access modes the volume should have.
 `spec.capacity.storage`<br/>_string_  | The size of the claim.
 `spec.hostPath.path`<br/>_string_  | The path of the directory on the host.
@@ -318,7 +318,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskId` <br/>_string_     | The id corresponding to the replace volume task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 

--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -238,6 +238,90 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create persistent volume task.       |
 | `taskStatus` <br/>_string_ | The status of the operation.                                     |
 
+<!-------------------- REPLACE PERSISTENT VOLUME -------------------->
+
+#### Replace a persistent volume
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes/my-persistent-volume"
+  Content-Type: application/json
+  {
+    "apiVersion": "v1",
+    "kind": "PersistentVolume",
+    "metadata": {
+        "annotations": {
+            "key": "value"
+        },
+        "name": "persistentvolumes-name"
+    },
+    "spec": {
+        "accessModes": [
+            "ReadWriteMany"
+        ],
+        "capacity": {
+            "storage": "2Gi"
+        },
+        "claimRef": {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "name": "pv-claim-name",
+            "namespace": "default",
+            "resourceVersion": "259087",
+            "uid": "11957feb-1acc-4c7e-911e-f77d5d7be5ac"
+        },
+        "hostPath": {
+            "path": "/etc/path"
+        },
+        "persistentVolumeReclaimPolicy": "Retain",
+        "storageClassName": "standard",
+        "volumeMode": "Filesystem"
+    }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumes/:id</code>
+
+Replace a persistent volume in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`spec`<br/>_object_                 | The specification used to replace and run the pod.
+`spec.accessModes`<br/>_string_ | The desired access modes the volume should have.
+`spec.capacity.storage`<br/>_string_  | The size of the claim.
+`spec.hostPath.path`<br/>_string_  | The path of the directory on the host.
+
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `metadata.annotations` <br/>_string_        | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.|
+| `spec.claimRef` <br/>_string_        | part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound|
+| `spec.persistentVolumeReclaimPolicy` <br/>_string_        | What happens to a persistent volume when released from its claim.|
+| `spec.storageClassName` <br/>_string_        | Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.|
+| `spec.volumeMode` <br/>_string_        | Defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolume-v1-core).
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
+
 <!-------------------- DELETE a persistent volume  -------------------->
 
 #### Delete a persistent volume

--- a/source/includes/kubernetes/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes/_k8_persistentvolumes.md
@@ -307,7 +307,7 @@ Required Attributes                 | &nbsp;
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
 | `metadata.annotations` <br/>_string_        | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.|
-| `spec.claimRef` <br/>_string_        | part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound|
+| `spec.claimRef` <br/>_string_        | part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound.|
 | `spec.persistentVolumeReclaimPolicy` <br/>_string_        | What happens to a persistent volume when released from its claim.|
 | `spec.storageClassName` <br/>_string_        | Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.|
 | `spec.volumeMode` <br/>_string_        | Defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.|

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -185,6 +185,57 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create stateful set task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                          |
 
+<!-------------------- REPLACE STORAGE CLASS -------------------->
+
+#### Replace a storage class
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses/rook-ceph-block"
+  Content-Type: application/json
+  {
+    "apiVersion": "storage.k8s.io/v1",
+    "metadata": {
+        "name": "hostpath"
+    },
+    "provisioner": "docker.io/hostpath"
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses/:id</code>
+
+Replace a persistent volume claim in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`provisioner`<br/>_object_          | The type of provisioner.
+
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `reclaimPolicy` <br/>_string_        | Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#storageclass-v1-storage-k8s-io).
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
 <!-------------------- DELETE A storage class -------------------->
 
 #### Delete a storage class

--- a/source/includes/kubernetes/_k8_storageclasses.md
+++ b/source/includes/kubernetes/_k8_storageclasses.md
@@ -214,13 +214,13 @@ curl -X PUT \
 
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses/:id</code>
 
-Replace a persistent volume claim in a given [environment](#administration-environments).
+Replace a storage class in a given [environment](#administration-environments).
 
 Required Attributes                 | &nbsp;
 ----------------------------------- | ------------------------------------------------------------
-`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
-`metadata` <br/>_object_            | The metadata of the pod.
-`metadata.name` <br/>_string_       | The name of the pod.
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the storage class.
+`metadata` <br/>_object_            | The metadata of the storage class.
+`metadata.name` <br/>_string_       | The name of the storage class.
 `provisioner`<br/>_object_          | The type of provisioner.
 
 | Optional Attributes                       | &nbsp;                                                                  |
@@ -233,7 +233,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskId` <br/>_string_     | The id corresponding to the replace storage class task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE A storage class -------------------->

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -283,10 +283,10 @@ Replace a persistent volume claim in a given [environment](#administration-envir
 
 Required Attributes                 | &nbsp;
 ----------------------------------- | ------------------------------------------------------------
-`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
-`metadata` <br/>_object_            | The metadata of the pod.
-`metadata.name` <br/>_string_       | The name of the pod.
-`spec`<br/>_object_                 | The specification used to replace and run the pod.
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the claim.
+`metadata` <br/>_object_            | The metadata of the claim.
+`metadata.name` <br/>_string_       | The name of the claim.
+`spec`<br/>_object_                 | The specification used to replace and run the claim.
 `spec.accessModes`<br/>_string_ | The desired access modes the volume should have.
 `spec.resources.requests.storage`<br/>_string_  | The size of the claim.
 `spec.storageClassName`<br/>_string_  | The name of the StorageClass required by the claim.
@@ -303,7 +303,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskId` <br/>_string_     | The id corresponding to the replace persistent volume claim task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE a persistent volume claim  -------------------->

--- a/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumeclaims.md
@@ -235,6 +235,77 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create persistent volume claim task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                                     |
 
+<!-------------------- REPLACE PERSISTENT VOLUME CLAIM -------------------->
+
+#### Replace a persistent volume claim
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumeclaims/my-persistent-volume-claim/default?cluster_id=a_cluster_id"
+  Content-Type: application/json
+  {
+    "id": "pv-claim-name/default",
+    "apiVersion": "v1",
+    "kind": "PersistentVolumeClaim",
+    "metadata": {
+        "name": "pv-claim-name",
+        "namespace": "default"
+    },
+    "spec": {
+        "accessModes": [
+            "ReadWriteOnce"
+        ],
+        "resources": {
+            "requests": {
+                "storage": "1Gi"
+            }
+        },
+        "storageClassName": "standard",
+        "volumeName": "persistentvolumes-name",
+        "dataSource": "dataSource"
+    }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumeclaims/:id?cluster_id=:cluster_id</code>
+
+Replace a persistent volume claim in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`spec`<br/>_object_                 | The specification used to replace and run the pod.
+`spec.accessModes`<br/>_string_ | The desired access modes the volume should have.
+`spec.resources.requests.storage`<br/>_string_  | The size of the claim.
+`spec.storageClassName`<br/>_string_  | The name of the StorageClass required by the claim.
+
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `spec.volumeName`<br/>_string_  | The binding reference to the PersistentVolume backing this claim. Only required if claim is bound. |
+| `spec.volumemode` <br/>_string_        | What type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.|
+| `spec.dataSource` <br/>_string_        | This field can be used to specify either: an existing VolumeSnapshot object, an existing PVC or an existing custom resource/object that implements data population.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core).
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
 <!-------------------- DELETE a persistent volume claim  -------------------->
 
 ##### Delete a persistent volume claim

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -246,6 +246,89 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create persistent volume task.       |
 | `taskStatus` <br/>_string_ | The status of the operation.                                     |
 
+<!-------------------- REPLACE PERSISTENT VOLUME -------------------->
+
+#### Replace a persistent volume
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/persistentvolumes/my-persistent-volume?cluster_id=a_cluster_id"
+  Content-Type: application/json
+  {
+    "apiVersion": "v1",
+    "kind": "PersistentVolume",
+    "metadata": {
+        "annotations": {
+            "key": "value"
+        },
+        "name": "persistentvolumes-name"
+    },
+    "spec": {
+        "accessModes": [
+            "ReadWriteMany"
+        ],
+        "capacity": {
+            "storage": "2Gi"
+        },
+        "claimRef": {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "name": "pv-claim-name",
+            "namespace": "default",
+            "resourceVersion": "259087",
+            "uid": "11957feb-1acc-4c7e-911e-f77d5d7be5ac"
+        },
+        "hostPath": {
+            "path": "/etc/path"
+        },
+        "persistentVolumeReclaimPolicy": "Retain",
+        "storageClassName": "standard",
+        "volumeMode": "Filesystem"
+    }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/persistentvolumes/:id?cluster_id=a_cluster_id</code>
+
+Replace a persistent volume in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`spec`<br/>_object_                 | The specification used to replace and run the pod.
+`spec.accessModes`<br/>_string_ | The desired access modes the volume should have.
+`spec.capacity.storage`<br/>_string_  | The size of the claim.
+`spec.hostPath.path`<br/>_string_  | The path of the directory on the host.
+
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `metadata.annotations` <br/>_string_        | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.|
+| `spec.claimRef` <br/>_string_        | part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound|
+| `spec.persistentVolumeReclaimPolicy` <br/>_string_        | What happens to a persistent volume when released from its claim.|
+| `spec.storageClassName` <br/>_string_        | Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.|
+| `spec.volumeMode` <br/>_string_        | Defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolume-v1-core).
+
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE a persistent volume  -------------------->
 

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -304,10 +304,10 @@ Replace a persistent volume in a given [environment](#administration-environment
 
 Required Attributes                 | &nbsp;
 ----------------------------------- | ------------------------------------------------------------
-`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
-`metadata` <br/>_object_            | The metadata of the pod.
-`metadata.name` <br/>_string_       | The name of the pod.
-`spec`<br/>_object_                 | The specification used to replace and run the pod.
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the volume.
+`metadata` <br/>_object_            | The metadata of the volume.
+`metadata.name` <br/>_string_       | The name of the volume.
+`spec`<br/>_object_                 | The specification used to replace and run the volume.
 `spec.accessModes`<br/>_string_ | The desired access modes the volume should have.
 `spec.capacity.storage`<br/>_string_  | The size of the claim.
 `spec.hostPath.path`<br/>_string_  | The path of the directory on the host.
@@ -327,7 +327,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskId` <br/>_string_     | The id corresponding to the replace volume task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE a persistent volume  -------------------->

--- a/source/includes/kubernetes_extension/_k8_persistentvolumes.md
+++ b/source/includes/kubernetes_extension/_k8_persistentvolumes.md
@@ -315,7 +315,7 @@ Required Attributes                 | &nbsp;
 | Optional Attributes                       | &nbsp;                                                                  |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
 | `metadata.annotations` <br/>_string_        | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata.|
-| `spec.claimRef` <br/>_string_        | part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound|
+| `spec.claimRef` <br/>_string_        | part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound.|
 | `spec.persistentVolumeReclaimPolicy` <br/>_string_        | What happens to a persistent volume when released from its claim.|
 | `spec.storageClassName` <br/>_string_        | Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.|
 | `spec.volumeMode` <br/>_string_        | Defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.|

--- a/source/includes/kubernetes_extension/_k8_storageclasses.md
+++ b/source/includes/kubernetes_extension/_k8_storageclasses.md
@@ -193,6 +193,57 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create stateful set task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                          |
 
+<!-------------------- REPLACE STORAGE CLASS -------------------->
+
+#### Replace a storage class
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/storageclasses/rook-ceph-block?cluster_id=a_cluster_id"
+  Content-Type: application/json
+  {
+    "apiVersion": "storage.k8s.io/v1",
+    "metadata": {
+        "name": "hostpath"
+    },
+    "provisioner": "docker.io/hostpath"
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses/:id?cluster_id=:cluster_id</code>
+
+Replace a persistent volume claim in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
+`metadata` <br/>_object_            | The metadata of the pod.
+`metadata.name` <br/>_string_       | The name of the pod.
+`provisioner`<br/>_object_          | The type of provisioner.
+
+| Optional Attributes                       | &nbsp;                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| `reclaimPolicy` <br/>_string_        | Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#storageclass-v1-storage-k8s-io).
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
 <!-------------------- DELETE A storage class -------------------->
 
 ##### Delete a storage class

--- a/source/includes/kubernetes_extension/_k8_storageclasses.md
+++ b/source/includes/kubernetes_extension/_k8_storageclasses.md
@@ -222,13 +222,13 @@ curl -X PUT \
 
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/storageclasses/:id?cluster_id=:cluster_id</code>
 
-Replace a persistent volume claim in a given [environment](#administration-environments).
+Replace a storage class in a given [environment](#administration-environments).
 
 Required Attributes                 | &nbsp;
 ----------------------------------- | ------------------------------------------------------------
-`apiVersion` <br/>_string_          | The api version (versioned schema) of the pod.
-`metadata` <br/>_object_            | The metadata of the pod.
-`metadata.name` <br/>_string_       | The name of the pod.
+`apiVersion` <br/>_string_          | The api version (versioned schema) of the storage class.
+`metadata` <br/>_object_            | The metadata of the storage class.
+`metadata.name` <br/>_string_       | The name of the storage class.
 `provisioner`<br/>_object_          | The type of provisioner.
 
 | Optional Attributes                       | &nbsp;                                                                  |
@@ -241,7 +241,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the replace pod task.|
+| `taskId` <br/>_string_     | The id corresponding to the replace storage class task.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE A storage class -------------------->


### PR DESCRIPTION

### Fixes [MC-12506](https://cloud-ops.atlassian.net/browse/MC-12506)

#### Changes made
<!-- Changes should match the template provided below -->
-Added documentation in Kubernetes and Kubernetes_extension for updating storage classes, persistent volumes, and persistent volume claims

#### Related PRs
- [#188 ](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/188)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->