### PR TITLE
MC-12530: added documentation for serviceaccounts

### DIFF
--- a/source/includes/azure/_k8_serviceaccounts.md.erb
+++ b/source/includes/azure/_k8_serviceaccounts.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_serviceaccounts.md" %>

--- a/source/includes/gcp/_k8_serviceaccounts.md.erb
+++ b/source/includes/gcp/_k8_serviceaccounts.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_serviceaccounts.md" %>

--- a/source/includes/kubernetes/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes/_k8_serviceaccounts.md
@@ -1,0 +1,54 @@
+### Service accounts
+
+<!-------------------- LIST SERVICE ACCOUNTS -------------------->
+
+#### List service accounts
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+      "metadata": {
+        "name": "vpnkit-controller",
+        "namespace": "kube-system",
+        "selfLink": "/api/v1/namespaces/kube-system/serviceaccounts/vpnkit-controller",
+        "uid": "b9afa8a8-3d64-4605-959f-12bb5c6cfba2",
+        "resourceVersion": "481",
+        "creationTimestamp": "2020-09-18T14:47:48Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"ServiceAccount\",\"metadata\":{\"annotations\":{},\"name\":\"vpnkit-controller\",\"namespace\":\"kube-system\"}}\n"
+        }
+      },
+      "secrets": [
+        {
+          "name": "vpnkit-controller-token-hl674"
+        }
+      ]
+    }
+  ]
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts</code>
+
+Retrieve a list of all service accounts in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the service account.                                                               |
+| `metadata.annotations` <br/>_map_          | The annotations of the service account.                                                      |
+| `metadata` <br/>_object_                   | The metadata of the service account.                                                         |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the service account as a string.                                     |
+| `metadata.name` <br/>_string_              | The name of the service account.                                                             |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service account is created.                                       |
+| `metadata.uid` <br/>_object_               | The UUID of the service account.                                                             |
+| `metadata.secrets` <br/>_List<object>_     | The secrets of the service account.                                                          |
+| `secretsSize` <br/>_integer_               | The number of secrets of the service account.                                                |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes_extension/_k8_serviceaccounts.md
@@ -1,14 +1,14 @@
-### Service accounts
+#### Service accounts
 
 
 <!-------------------- LIST SERVICE ACCOUNTS -------------------->
 
-#### List service accounts
+##### List service accounts
 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts?cluster_id=:cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -36,7 +36,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts?cluster_id=:cluster_id</code>
 
 Retrieve a list of all service accounts in a given [environment](#administration-environments).
 

--- a/source/includes/kubernetes_extension/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes_extension/_k8_serviceaccounts.md
@@ -1,0 +1,55 @@
+### Service accounts
+
+
+<!-------------------- LIST SERVICE ACCOUNTS -------------------->
+
+#### List service accounts
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+      "metadata": {
+        "name": "vpnkit-controller",
+        "namespace": "kube-system",
+        "selfLink": "/api/v1/namespaces/kube-system/serviceaccounts/vpnkit-controller",
+        "uid": "b9afa8a8-3d64-4605-959f-12bb5c6cfba2",
+        "resourceVersion": "481",
+        "creationTimestamp": "2020-09-18T14:47:48Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"ServiceAccount\",\"metadata\":{\"annotations\":{},\"name\":\"vpnkit-controller\",\"namespace\":\"kube-system\"}}\n"
+        }
+      },
+      "secrets": [
+        {
+          "name": "vpnkit-controller-token-hl674"
+        }
+      ]
+    }
+  ]
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts</code>
+
+Retrieve a list of all service accounts in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the service account.                                                               |
+| `metadata.annotations` <br/>_map_          | The annotations of the service account.                                                      |
+| `metadata` <br/>_object_                   | The metadata of the service account.                                                         |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the service account as a string.                                     |
+| `metadata.name` <br/>_string_              | The name of the service account.                                                             |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service account is created.                                       |
+| `metadata.uid` <br/>_object_               | The UUID of the service account.                                                             |
+| `metadata.secrets` <br/>_List<object>_     | The secrets of the service account.                                                          |
+| `secretsSize` <br/>_integer_               | The number of secrets of the service account.                                                |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).


### PR DESCRIPTION
### Fixes [MC-12530](https://cloud-ops.atlassian.net/browse/MC-12530)

#### Changes made
-added a ServiceAccounts page in kubernetes and kubernetes_extension

#### Related PRs
- [#189](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/189)
