### PR TITLE
MC-12050: Updated documentation for gcp disks and instances

### DIFF
--- a/source/includes/gcp/_disks.md
+++ b/source/includes/gcp/_disks.md
@@ -180,12 +180,25 @@ Optional | &nbsp;
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/disks/5333546534174463697"
+```
+
+> Request body example:
+
+```json
+{
+   "deleteSnapshots": true,
+}
 ```
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/disks/:id</code>
 
 Destroy an existing disk. A disk can only be deleted if it's not attached to an [instance](#gcp-instances).
+
+Optional | &nbsp;
+------ | -----------
+`deleteSnapshots`<br/>*boolean* | Whether captured snapshops should be deleted
 
 <!-------------------- ATTACH A DISK -------------------->
 

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -390,13 +390,25 @@ Optional | &nbsp;
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
    "https://cloudmc_endpoint/v1/services/gcp/test-area/instances/5611478403377505138"
+```
+
+> Request body example:
+
+```json
+{
+   "deleteSnapshots": true,
+}
 ```
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id</code>
 
 Delete an existing instance.
 
+Optional | &nbsp;
+------ | -----------
+`deleteSnapshots`<br/>*boolean* | Whether captured snapshops of associated auto-deletable disks should be deleted
 <!-------------------- CHANGE MACHINE TYPE -------------------->
 
 #### Change machine type


### PR DESCRIPTION
### Fixes [MC-12640(https://cloud-ops.atlassian.net/browse/MC-12640)

#### Changes made
<!-- Changes should match the template provided below -->
- Updated documentation for Gcp delete disk and Gcp delete instance

#### Related PRs
- [331](https://github.com/cloudops/cloudmc-gcp-plugin/pull/331)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->