### PR TITLE
MC-12530: added AccessControl tab and edited index file

### DIFF
--- a/source/includes/azure/_k8_accesscontrol.md.erb
+++ b/source/includes/azure/_k8_accesscontrol.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_accesscontrol.md" %>

--- a/source/includes/gcp/_k8_accesscontrol.md.erb
+++ b/source/includes/gcp/_k8_accesscontrol.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_accesscontrol.md" %>

--- a/source/includes/kubernetes/_k8_accesscontrol.md
+++ b/source/includes/kubernetes/_k8_accesscontrol.md
@@ -1,0 +1,1 @@
+## Access control

--- a/source/includes/kubernetes/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes/_k8_serviceaccounts.md
@@ -48,7 +48,7 @@ Retrieve a list of all service accounts in a given [environment](#administration
 | `metadata.name` <br/>_string_              | The name of the service account.                                                             |
 | `metadata.namespace` <br/>_string_         | The namespace in which the service account is created.                                       |
 | `metadata.uid` <br/>_object_               | The UUID of the service account.                                                             |
-| `metadata.secrets` <br/>_List<object>_     | The secrets of the service account.                                                          |
+| `metadata.secrets` <br/>_List&lt;object&gt;_     | The secrets of the service account.                                                          |
 | `secretsSize` <br/>_integer_               | The number of secrets of the service account.                                                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_accesscontrol.md
+++ b/source/includes/kubernetes_extension/_k8_accesscontrol.md
@@ -1,0 +1,1 @@
+### Access control

--- a/source/includes/kubernetes_extension/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes_extension/_k8_serviceaccounts.md
@@ -49,7 +49,7 @@ Retrieve a list of all service accounts in a given [environment](#administration
 | `metadata.name` <br/>_string_              | The name of the service account.                                                             |
 | `metadata.namespace` <br/>_string_         | The namespace in which the service account is created.                                       |
 | `metadata.uid` <br/>_object_               | The UUID of the service account.                                                             |
-| `metadata.secrets` <br/>_List<object>_     | The secrets of the service account.                                                          |
+| `metadata.secrets` <br/>_List&lt;object&gt;_     | The secrets of the service account.                                                          |
 | `secretsSize` <br/>_integer_               | The number of secrets of the service account.                                                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -108,6 +108,8 @@ includes:
   - gcp/k8_storageclasses
   - gcp/k8_persistentvolumes
   - gcp/k8_persistentvolumeclaims
+  - gcp/k8_accesscontrol
+  - gcp/k8_serviceaccounts
   - gcp/k8_releases
   - gcp/k8_charts
   - gcp/images
@@ -129,6 +131,8 @@ includes:
   - kubernetes/k8_storageclasses
   - kubernetes/k8_persistentvolumes
   - kubernetes/k8_persistentvolumeclaims
+  - kubernetes/k8_accesscontrol
+  - kubernetes/k8_serviceaccounts
   - kubernetes/k8_releases
   - kubernetes/k8_charts  
   - azure
@@ -161,6 +165,8 @@ includes:
   - azure/k8_storageclasses
   - azure/k8_persistentvolumes
   - azure/k8_persistentvolumeclaims
+  - azure/k8_accesscontrol
+  - azure/k8_serviceaccounts
   - masterportal
   - masterportal/applications
   - swift


### PR DESCRIPTION
### Fixes [MC-12530](https://cloud-ops.atlassian.net/browse/MC-12530)

#### Changes made
- Added Access Control tab
- Added Service Accounts page to indexes in GCP, Azure and Kubernetes

#### Related PRs
- [#189](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/189)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->