### PR TITLE
MC-12531: Documentation for (namespace) roles in K8

### DIFF
--- a/source/includes/azure/_k8_roles.md.erb
+++ b/source/includes/azure/_k8_roles.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_roles.md" %>

--- a/source/includes/gcp/_k8_roles.md.erb
+++ b/source/includes/gcp/_k8_roles.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_roles.md" %>

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -1,0 +1,107 @@
+### Roles
+
+<!-------------------- LIST ROLES -------------------->
+
+#### List (namespace) Roles
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "data": [
+        {
+            "id": "role-id",
+            "age": "1w4d",
+            "metadata": {
+                "creationTimestamp": "2020-09-18T10:01:26.000-04:00",
+                "name": "kubeadm:bootstrap-signer-clusterinfo",
+                "namespace": "kube-public",
+                "uid": "57ef0321-e44a-43c9-9f2a-e448c3a66a46"
+            },
+            "rules": [
+                {
+                    "apiGroups": [],
+                    "resourceNames": [],
+                    "resources": [],
+                    "verbs": []
+                }
+            ]
+        }
+    ],
+    "metadata": {
+        "recordCount": 1
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles</code>
+
+Retrieve a list of all service accounts in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the role.|
+| `metadata` <br/>_object_                   | The metadata of the role.|
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the service account as a string.|
+| `metadata.name` <br/>_string_              | The name of the role.|
+| `metadata.namespace` <br/>_string_         | The namespace in which the role is created.|
+| `metadata.uid` <br/>_object_               | The UUID of the role.|
+| `rules` <br/>_array_               | The array of rules assocaited with this role.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET A ROLE -------------------->
+
+#### Get a role
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles/role-name/role-namespace"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "data": {
+        "id": "kubeadm:bootstrap-signer-clusterinfo",
+        "age": "1w4d",
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "Role",
+        "metadata": {
+            "creationTimestamp": "2020-09-18T10:01:26.000-04:00",
+            "name": "kubeadm:bootstrap-signer-clusterinfo",
+            "namespace": "kube-public",
+            "uid": "57ef0321-e44a-43c9-9f2a-e448c3a66a47"
+        },
+        "rules": [
+            {
+                "apiGroups": [],
+                "resourceNames": [],
+                "resources": [],
+                "verbs": []
+            }
+        ]
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles/:id/:namespace</code>
+
+Retrieve a role and all its info in a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `id` <br/>_string_         | The id of the role.                          |
+| `apiVersion` <br/>_string_ | The API version used to retrieve this role.  |
+| `metadata` <br/>_object_   | The metadata of the role.                    |
+| `rules` <br/>_array_       | The array of rules assocaited with this role.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -42,7 +42,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles</code>
 
-Retrieve a list of all service accounts in a given [environment](#administration-environments).
+Retrieve a list of all roles in a given [environment](#administration-environments).
 
 | Attributes                                 | &nbsp;                                                                                       |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------- |

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -1,0 +1,107 @@
+#### Roles
+
+<!-------------------- LIST ROLES -------------------->
+
+##### List (namespace) Roles
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "data": [
+        {
+            "id": "role-id",
+            "age": "1w4d",
+            "metadata": {
+                "creationTimestamp": "2020-09-18T10:01:26.000-04:00",
+                "name": "kubeadm:bootstrap-signer-clusterinfo",
+                "namespace": "kube-public",
+                "uid": "57ef0321-e44a-43c9-9f2a-e448c3a66a46"
+            },
+            "rules": [
+                {
+                    "apiGroups": [],
+                    "resourceNames": [],
+                    "resources": [],
+                    "verbs": []
+                }
+            ]
+        }
+    ],
+    "metadata": {
+        "recordCount": 1
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles?cluster_id=:cluster_id</code>
+
+Retrieve a list of all service accounts in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the role.|
+| `metadata` <br/>_object_                   | The metadata of the role.|
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the service account as a string.|
+| `metadata.name` <br/>_string_              | The name of the role.|
+| `metadata.namespace` <br/>_string_         | The namespace in which the role is created.|
+| `metadata.uid` <br/>_object_               | The UUID of the role.|
+| `rules` <br/>_array_               | The array of rules assocaited with this role.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET A ROLE -------------------->
+
+##### Get a role
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles/role-name/role-namespace?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "data": {
+        "id": "kubeadm:bootstrap-signer-clusterinfo",
+        "age": "1w4d",
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "Role",
+        "metadata": {
+            "creationTimestamp": "2020-09-18T10:01:26.000-04:00",
+            "name": "kubeadm:bootstrap-signer-clusterinfo",
+            "namespace": "kube-public",
+            "uid": "57ef0321-e44a-43c9-9f2a-e448c3a66a47"
+        },
+        "rules": [
+            {
+                "apiGroups": [],
+                "resourceNames": [],
+                "resources": [],
+                "verbs": []
+            }
+        ]
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles/:id/:namespace?cluster_id=:cluster_id</code>
+
+Retrieve a role and all its info in a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `id` <br/>_string_         | The id of the role.                          |
+| `apiVersion` <br/>_string_ | The API version used to retrieve this role.  |
+| `metadata` <br/>_object_   | The metadata of the role.                    |
+| `rules` <br/>_array_       | The array of rules assocaited with this role.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -42,7 +42,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles?cluster_id=:cluster_id</code>
 
-Retrieve a list of all service accounts in a given [environment](#administration-environments).
+Retrieve a list of all roles in a given [environment](#administration-environments).
 
 | Attributes                                 | &nbsp;                                                                                       |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------- |

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -110,6 +110,7 @@ includes:
   - gcp/k8_persistentvolumeclaims
   - gcp/k8_accesscontrol
   - gcp/k8_serviceaccounts
+  - gcp/k8_roles
   - gcp/k8_releases
   - gcp/k8_charts
   - gcp/images
@@ -133,6 +134,7 @@ includes:
   - kubernetes/k8_persistentvolumeclaims
   - kubernetes/k8_accesscontrol
   - kubernetes/k8_serviceaccounts
+  - kubernetes/k8_roles
   - kubernetes/k8_releases
   - kubernetes/k8_charts  
   - azure
@@ -167,6 +169,7 @@ includes:
   - azure/k8_persistentvolumeclaims
   - azure/k8_accesscontrol
   - azure/k8_serviceaccounts
+  - azure/k8_roles
   - masterportal
   - masterportal/applications
   - swift


### PR DESCRIPTION
### Fixes [MC-12531](https://cloud-ops.atlassian.net/browse/MC-12531)

#### Changes made
- Added namespace roles to gcp, azure and K8 docs (list and get)

#### Related PRs
- [193](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/193)
- [45](https://github.com/cloudops/cloudmc-kubernetes-plugin/pull/45)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->