### PR TITLE
MC-12601: Added api changes for pricing when there is missing currencies

### DIFF
--- a/source/includes/administration/_pricings.md
+++ b/source/includes/administration/_pricings.md
@@ -70,7 +70,7 @@ Attributes | &nbsp;
 `name`<br/>*Map* | A map from language to name value for that language
 `description`<br/>*Map* | A map from language to description value for that language
 `supportedCurrencies`<br/>*List* | A list of currencies supported by the pricing
-`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the change is missing the prices for one or more currencies.
+`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the changes is missing the prices for one or more currencies.
 `effectiveDate`<br/>*Date* | The date at which the pricing will take effect.
 `productCatalogs`<br/>*Array<ProductCatalog>* | A list of catalogs added to the pricing
 `organization`<br/>*Organization* | Organization where the pricing was created. Fields: `id`
@@ -155,7 +155,7 @@ Attributes | &nbsp;
 `name`<br/>*Map* | A map from language to name value for that language
 `description`<br/>*Map* | A map from language to description value for that language
 `supportedCurrencies`<br/>*List* | A list of currencies supported by the pricing
-`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the change is missing the prices for one or more currencies.
+`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the changes is missing the prices for one or more currencies.
 `effectiveDate`<br/>*Date* | The date at which the pricing will take effect.
 `productCatalogs`<br/>*Array<ProductCatalog>* | A list of catalogs added to the pricing
 `organization`<br/>*Organization* | Organization where the pricing was created. Fields: `id`
@@ -443,7 +443,7 @@ Attributes | &nbsp;
 `name`<br/>*Map* | A map from language to name value for that language
 `description`<br/>*Map* | A map from language to description value for that language
 `supportedCurrencies`<br/>*List* | A list of currencies supported by the pricing
-`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the change is missing the prices for one or more currencies.
+`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the changes is missing the prices for one or more currencies.
 `effectiveDate`<br/>*Date* | The date at which the pricing will take effect.
 `productCatalogs`<br/>*Array<ProductCatalog>* | A list of catalogs added to the pricing
 `organization`<br/>*Organization* | Organization where the pricing was created. Fields: `id`
@@ -575,7 +575,7 @@ Attributes | &nbsp;
 `pricedProductsToModify`<br/> *Array<PricedProductChange>* | A change to a priced product in the pricing. Only with MODIFY_PRODUCTS and ADD_CURRENCIES type.
 `pricedProductsToDeprecate`<br> *Array<UUID>* | Priced products to deprecate
 `currenciesToAdd`<br/> *Array<String>* | Currencies to add to the pricing. Only with ADD_CURRENCIES type.
-`missingCurrencies`<br/> *Array<String>* | Currencies that are missing some price for either the unitPrice or COGS.
+`missingCurrencies`<br/> *Array<String>* | Currencies that are missing some prices for either the unitPrice or COGS.
 `pricingChangeType`<br/> *string* | Type of change to apply
 `effectiveDate`<br/> *Date* | Date that the change should be applied
 `creationDate`<br/> *Date* | Date that the change was created

--- a/source/includes/administration/_pricings.md
+++ b/source/includes/administration/_pricings.md
@@ -32,6 +32,7 @@ curl "https://cloudmc_endpoint/v2/pricings" \
       "supportedCurrencies": [
         "CAD"
       ],
+      "missingCurrenciesPricing": false,
       "effectiveDate": "2020-08-31T15:43:53Z",
       "productCatalogs": [
         {
@@ -69,6 +70,7 @@ Attributes | &nbsp;
 `name`<br/>*Map* | A map from language to name value for that language
 `description`<br/>*Map* | A map from language to description value for that language
 `supportedCurrencies`<br/>*List* | A list of currencies supported by the pricing
+`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the change is missing the prices for one or more currencies.
 `effectiveDate`<br/>*Date* | The date at which the pricing will take effect.
 `productCatalogs`<br/>*Array<ProductCatalog>* | A list of catalogs added to the pricing
 `organization`<br/>*Organization* | Organization where the pricing was created. Fields: `id`
@@ -116,6 +118,7 @@ curl "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25dff5da5"
       "supportedCurrencies": [
         "CAD"
       ],
+      "missingCurrenciesPricing": false,
       "effectiveDate": "2020-08-31T15:43:53Z",
       "productCatalogs": [
         {
@@ -152,6 +155,7 @@ Attributes | &nbsp;
 `name`<br/>*Map* | A map from language to name value for that language
 `description`<br/>*Map* | A map from language to description value for that language
 `supportedCurrencies`<br/>*List* | A list of currencies supported by the pricing
+`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the change is missing the prices for one or more currencies.
 `effectiveDate`<br/>*Date* | The date at which the pricing will take effect.
 `productCatalogs`<br/>*Array<ProductCatalog>* | A list of catalogs added to the pricing
 `organization`<br/>*Organization* | Organization where the pricing was created. Fields: `id`
@@ -398,6 +402,7 @@ curl "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25dff5da5/
       "supportedCurrencies": [
         "CAD"
       ],
+      "missingCurrenciesPricing": false,
       "effectiveDate": "2020-08-31T15:43:53Z",
       "productCatalogs": [
         {
@@ -438,6 +443,7 @@ Attributes | &nbsp;
 `name`<br/>*Map* | A map from language to name value for that language
 `description`<br/>*Map* | A map from language to description value for that language
 `supportedCurrencies`<br/>*List* | A list of currencies supported by the pricing
+`missingCurrenciesPricing`<br/>*boolean* | Specifies if one of the change is missing the prices for one or more currencies.
 `effectiveDate`<br/>*Date* | The date at which the pricing will take effect.
 `productCatalogs`<br/>*Array<ProductCatalog>* | A list of catalogs added to the pricing
 `organization`<br/>*Organization* | Organization where the pricing was created. Fields: `id`
@@ -492,6 +498,7 @@ curl "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25dff5da5/
       ],
       "creationDate": "2020-09-01T18:34:43Z",
       "effectiveDate": "2020-09-02T12:00:00Z",
+      "missingCurrencies": [],
       "pricingChangeType": "ADD_PRODUCTS"
     },
     {
@@ -510,6 +517,7 @@ curl "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25dff5da5/
       ],
       "creationDate": "2020-09-01T15:08:40Z",
       "effectiveDate": "2020-09-02T12:00:00Z",
+      "missingCurrencies": [],
       "pricingChangeType": "MODIFY_PRODUCTS"
     },
     {
@@ -523,6 +531,7 @@ curl "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25dff5da5/
       "pricedProductsToDeprecate": [
         "dd3fcab9-5b31-4f08-9b50-ed3326bccfb4"
       ],
+      "missingCurrencies": [],
       "pricingChangeType": "REMOVE_PRODUCTS"
     },
     {
@@ -550,6 +559,7 @@ curl "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25dff5da5/
       ],
       "creationDate": "2020-09-01T18:34:43Z",
       "effectiveDate": "2020-09-02T12:00:00Z",
+      "missingCurrencies": [],
       "pricingChangeType": "ADD_CURRENCIES"
     }
   ]
@@ -565,6 +575,7 @@ Attributes | &nbsp;
 `pricedProductsToModify`<br/> *Array<PricedProductChange>* | A change to a priced product in the pricing. Only with MODIFY_PRODUCTS and ADD_CURRENCIES type.
 `pricedProductsToDeprecate`<br> *Array<UUID>* | Priced products to deprecate
 `currenciesToAdd`<br/> *Array<String>* | Currencies to add to the pricing. Only with ADD_CURRENCIES type.
+`missingCurrencies`<br/> *Array<String>* | Currencies that are missing some price for either the unitPrice or COGS.
 `pricingChangeType`<br/> *string* | Type of change to apply
 `effectiveDate`<br/> *Date* | Date that the change should be applied
 `creationDate`<br/> *Date* | Date that the change was created


### PR DESCRIPTION
### Fixes [MC-12601](https://cloud-ops.atlassian.net/browse/MC-12601)

#### Changes made
* Added missing currencies on changes
* Added flag of missing currencies on change at the pricing level


#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->