### PR TITLE
MC-12532: added rolebindings documentation in k8s and k8s extension

### DIFF
--- a/source/includes/azure/_k8_rolebindings.md.erb
+++ b/source/includes/azure/_k8_rolebindings.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_rolebindings.md" %>

--- a/source/includes/gcp/_k8_rolebindings.md.erb
+++ b/source/includes/gcp/_k8_rolebindings.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_rolebindings.md" %>

--- a/source/includes/kubernetes/_k8_rolebindings.md
+++ b/source/includes/kubernetes/_k8_rolebindings.md
@@ -105,13 +105,13 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id</code>
 
-Retrieve a role and all its info in a given [environment](#administration-environments).
+Retrieve a role binding and all its info in a given [environment](#administration-environments).
 
 | Attributes                 | &nbsp;                                            |
 | -------------------------- | ------------------------------------------------- |
 | `id` <br/>_string_         | The id of the role binding.                          |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this role binding.  |
 | `metadata` <br/>_object_   | The metadata of the role binding.                    |
-| `rules` <br/>_array_       | The array of subjects associated with this role.|
+| `subjects` <br/>_array_       | The array of subjects associated with this role binding.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes/_k8_rolebindings.md
+++ b/source/includes/kubernetes/_k8_rolebindings.md
@@ -1,0 +1,117 @@
+### Role bindings
+
+<!-------------------- LIST ROLE BINDINGS -------------------->
+
+#### List role bindings
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/rolebindings"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+
+    "data": {
+        "entity": {
+          "id": "kubeadm:bootstrap-signer-clusterinfo",
+          "age": "1w5d",
+          "metadata": {
+            "creationTimestamp": "2020-09-18T10:46:32.000-04:00",
+            "name": "kubeadm:bootstrap-signer-clusterinfo",
+            "namespace": "kube-public",
+            "uid": "4fcfe5b9-a1c3-4b3b-9cb6-6df4a1da945f"
+          },
+          "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "Role",
+            "name": "kubeadm:bootstrap-signer-clusterinfo"
+          },
+          "subjects": [
+            {
+              "apiGroup": "rbac.authorization.k8s.io",
+              "kind": "User",
+              "name": "system:anonymous"
+            }
+          ]
+        },
+        "fieldTransitions": {},
+        "operations": []
+      },
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings</code>
+
+Retrieve a list of all role bindings in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the role binding.                                                               |                                                    |
+| `metadata` <br/>_object_                   | The metadata of the service account.                                                         |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the role binding as a string.                                     |
+| `metadata.name` <br/>_string_              | The name of the role binding.                                                             |
+| `metadata.namespace` <br/>_string_         | The namespace in which the role binding is created.                                       |
+| `metadata.uid` <br/>_object_               | The UUID of the role binding.                                                          |       `subjects`<br/>_array_      | The array of subjects associated with this role binding.                                               |                                             |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET A ROLE BINDING -------------------->
+
+#### Get a role binding
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/rolebindings/rolebinding-name/rolebinding-namespace"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+
+    "data": {
+
+          "id": "kubeadm:bootstrap-signer-clusterinfo",
+          "age": "1w5d",
+          "metadata": {
+            "creationTimestamp": "2020-09-18T10:46:32.000-04:00",
+            "name": "kubeadm:bootstrap-signer-clusterinfo",
+            "namespace": "kube-public",
+            "uid": "4fcfe5b9-a1c3-4b3b-9cb6-6df4a1da945f"
+          },
+          "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "Role",
+            "name": "kubeadm:bootstrap-signer-clusterinfo"
+          },
+          "subjects": [
+            {
+              "apiGroup": "rbac.authorization.k8s.io",
+              "kind": "User",
+              "name": "system:anonymous"
+            }
+          ]
+        },
+        "fieldTransitions": {},
+        "operations": []
+      },
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id</code>
+
+Retrieve a role and all its info in a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `id` <br/>_string_         | The id of the role binding.                          |
+| `apiVersion` <br/>_string_ | The API version used to retrieve this role binding.  |
+| `metadata` <br/>_object_   | The metadata of the role binding.                    |
+| `rules` <br/>_array_       | The array of subjects associated with this role.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes/_k8_rolebindings.md
+++ b/source/includes/kubernetes/_k8_rolebindings.md
@@ -51,7 +51,7 @@ Retrieve a list of all role bindings in a given [environment](#administration-en
 | Attributes                                 | &nbsp;                                                                                       |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------- |
 | `id` <br/>_string_                         | The id of the role binding.                                                               |                                                    |
-| `metadata` <br/>_object_                   | The metadata of the service account.                                                         |
+| `metadata` <br/>_object_                   | The metadata of the role binding.                                                         |
 | `metadata.creationTimestamp` <br/>_string_ | The date of creation of the role binding as a string.                                     |
 | `metadata.name` <br/>_string_              | The name of the role binding.                                                             |
 | `metadata.namespace` <br/>_string_         | The namespace in which the role binding is created.                                       |

--- a/source/includes/kubernetes_extension/_k8_rolebindings.md
+++ b/source/includes/kubernetes_extension/_k8_rolebindings.md
@@ -1,0 +1,117 @@
+#### Role bindings
+
+<!-------------------- LIST ROLE BINDINGS -------------------->
+
+##### List (namespace) role bindings
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/rolebindings?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+
+    "data": {
+        "entity": {
+          "id": "kubeadm:bootstrap-signer-clusterinfo",
+          "age": "1w5d",
+          "metadata": {
+            "creationTimestamp": "2020-09-18T10:46:32.000-04:00",
+            "name": "kubeadm:bootstrap-signer-clusterinfo",
+            "namespace": "kube-public",
+            "uid": "4fcfe5b9-a1c3-4b3b-9cb6-6df4a1da945f"
+          },
+          "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "Role",
+            "name": "kubeadm:bootstrap-signer-clusterinfo"
+          },
+          "subjects": [
+            {
+              "apiGroup": "rbac.authorization.k8s.io",
+              "kind": "User",
+              "name": "system:anonymous"
+            }
+          ]
+        },
+        "fieldTransitions": {},
+        "operations": []
+      },
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings?cluster_id=:cluster_id</code>
+
+Retrieve a list of all role bindings in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the role binding.                                                               |                                                    |
+| `metadata` <br/>_object_                   | The metadata of the service account.                                                         |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the role binding as a string.                                     |
+| `metadata.name` <br/>_string_              | The name of the role binding.                                                             |
+| `metadata.namespace` <br/>_string_         | The namespace in which the role binding is created.                                       |
+| `metadata.uid` <br/>_object_               | The UUID of the role binding.                                                          |       `subjects`<br/>_array_      | The array of subjects associated with this role binding.                                               |                                             |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- GET A ROLE BINDING -------------------->
+
+##### Get a role binding
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/rolebindings/rolebinding-name/rolebinding-namespace?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+
+    "data": {
+
+          "id": "kubeadm:bootstrap-signer-clusterinfo",
+          "age": "1w5d",
+          "metadata": {
+            "creationTimestamp": "2020-09-18T10:46:32.000-04:00",
+            "name": "kubeadm:bootstrap-signer-clusterinfo",
+            "namespace": "kube-public",
+            "uid": "4fcfe5b9-a1c3-4b3b-9cb6-6df4a1da945f"
+          },
+          "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "Role",
+            "name": "kubeadm:bootstrap-signer-clusterinfo"
+          },
+          "subjects": [
+            {
+              "apiGroup": "rbac.authorization.k8s.io",
+              "kind": "User",
+              "name": "system:anonymous"
+            }
+          ]
+        },
+        "fieldTransitions": {},
+        "operations": []
+      },
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id?cluster_id=:cluster_id</code>
+
+Retrieve a role and all its info in a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `id` <br/>_string_         | The id of the role binding.                          |
+| `apiVersion` <br/>_string_ | The API version used to retrieve this role binding.  |
+| `metadata` <br/>_object_   | The metadata of the role binding.                    |
+| `rules` <br/>_array_       | The array of subjects associated with this role.|
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_rolebindings.md
+++ b/source/includes/kubernetes_extension/_k8_rolebindings.md
@@ -105,13 +105,13 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id?cluster_id=:cluster_id</code>
 
-Retrieve a role and all its info in a given [environment](#administration-environments).
+Retrieve a role binding and all its info in a given [environment](#administration-environments).
 
 | Attributes                 | &nbsp;                                            |
 | -------------------------- | ------------------------------------------------- |
 | `id` <br/>_string_         | The id of the role binding.                          |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this role binding.  |
 | `metadata` <br/>_object_   | The metadata of the role binding.                    |
-| `rules` <br/>_array_       | The array of subjects associated with this role.|
+| `subjects` <br/>_array_       | The array of subjects associated with this role binding.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).

--- a/source/includes/kubernetes_extension/_k8_rolebindings.md
+++ b/source/includes/kubernetes_extension/_k8_rolebindings.md
@@ -51,7 +51,7 @@ Retrieve a list of all role bindings in a given [environment](#administration-en
 | Attributes                                 | &nbsp;                                                                                       |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------- |
 | `id` <br/>_string_                         | The id of the role binding.                                                               |                                                    |
-| `metadata` <br/>_object_                   | The metadata of the service account.                                                         |
+| `metadata` <br/>_object_                   | The metadata of the role binding.                                                         |
 | `metadata.creationTimestamp` <br/>_string_ | The date of creation of the role binding as a string.                                     |
 | `metadata.name` <br/>_string_              | The name of the role binding.                                                             |
 | `metadata.namespace` <br/>_string_         | The namespace in which the role binding is created.                                       |

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -111,6 +111,7 @@ includes:
   - gcp/k8_accesscontrol
   - gcp/k8_serviceaccounts
   - gcp/k8_roles
+  - gcp/k8_rolebindings
   - gcp/k8_releases
   - gcp/k8_charts
   - gcp/images
@@ -135,6 +136,7 @@ includes:
   - kubernetes/k8_accesscontrol
   - kubernetes/k8_serviceaccounts
   - kubernetes/k8_roles
+  - kubernetes/k8_rolebindings
   - kubernetes/k8_releases
   - kubernetes/k8_charts  
   - azure
@@ -170,6 +172,7 @@ includes:
   - azure/k8_accesscontrol
   - azure/k8_serviceaccounts
   - azure/k8_roles
+  - azure/k8_rolebindings
   - masterportal
   - masterportal/applications
   - swift


### PR DESCRIPTION
### Fixes [MC-12532](https://cloud-ops.atlassian.net/browse/MC-12532)

#### Changes made
<!-- Changes should match the template provided below -->
- added RoleBindings documentation to list and get role bindings (in Kubernetes plugin and Kubernetes extension for GCP and Azure)

#### Related PRs
- [PR#195](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/195) in cloudmc-kubernetes-sdk

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->