### PR TITLE
MC-12533: Adding docs for deleting k8 service account

### DIFF
--- a/source/includes/kubernetes/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes/_k8_serviceaccounts.md
@@ -52,3 +52,31 @@ Retrieve a list of all service accounts in a given [environment](#administration
 | `secretsSize` <br/>_integer_               | The number of secrets of the service account.                                                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- DELETE SERVICE ACCOUNT -------------------->
+
+#### Delete a service account
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts/my-service-account/my-namespace"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts/:id</code>
+
+Delete a secret from a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                          |
+| -------------------------- | ----------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete service account task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                    |

--- a/source/includes/kubernetes/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes/_k8_serviceaccounts.md
@@ -74,7 +74,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts/:id</code>
 
-Delete a secret from a given [environment](#administration-environments).
+Delete a service account from a given [environment](#administration-environments).
 
 | Attributes                 | &nbsp;                                          |
 | -------------------------- | ----------------------------------------------- |

--- a/source/includes/kubernetes_extension/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes_extension/_k8_serviceaccounts.md
@@ -75,7 +75,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts/:id?cluster_id=:cluster_id</code>
 
-Delete a secret from a given [environment](#administration-environments).
+Delete a service account from a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                               |
 | -------------------------- | ---------------------------------------------------- |

--- a/source/includes/kubernetes_extension/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes_extension/_k8_serviceaccounts.md
@@ -53,3 +53,35 @@ Retrieve a list of all service accounts in a given [environment](#administration
 | `secretsSize` <br/>_integer_               | The number of secrets of the service account.                                                |
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- DELETE SERVICE ACCOUNT -------------------->
+
+##### Delete a service account
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts/my-service-account/my-namespace?cluster_id=a_cluster_id"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts/:id?cluster_id=:cluster_id</code>
+
+Delete a secret from a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                               |
+| -------------------------- | ---------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to delete the service account. |
+
+| Attributes                 | &nbsp;                                          |
+| -------------------------- | ----------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the delete service account task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                    |


### PR DESCRIPTION
### Fixes [MC-12533](https://cloud-ops.atlassian.net/browse/MC-12533)

#### Changes made
-Added DELETE operation for Service Accounts in Kubernetes and Kubernetes_extension

#### Related PRs
- [#198](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/198)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->