### PR TITLE
MC-12530: FIX added GET service accounts in kubernetes

### DIFF
--- a/source/includes/kubernetes/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes/_k8_serviceaccounts.md
@@ -53,6 +53,58 @@ Retrieve a list of all service accounts in a given [environment](#administration
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
+<!-------------------- GET A SERVICE ACCOUNT -------------------->
+
+#### Get a service account
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts/serviceaccount-name/serviceaccount-namespace"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+            "id": "default",
+            "age": "1w5d",
+            "secretsSize": 1,
+            "metadata": {
+              "creationTimestamp": "2020-09-18T10:46:40.000-04:00",
+              "name": "default",
+              "namespace": "default",
+              "uid": "80a0de4d-a187-44c3-b691-1481220a5817"
+            },
+            "secrets": [
+              {
+                "name": "default-token-lrth9"
+              }
+            ]
+          },
+          "fieldTransitions": {},
+          "operations": []
+        }
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts/:id</code>
+
+Retrieve a service account and all its info in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the service account.                                                               |
+| `metadata` <br/>_object_                   | The metadata of the service account.                                                         |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the service account as a string.                                     |
+| `metadata.name` <br/>_string_              | The name of the service account.                                                             |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service account is created.                                       |
+| `metadata.uid` <br/>_object_               | The UUID of the service account.                                                             |
+| `metadata.secrets` <br/>_List&lt;object&gt;_     | The secrets of the service account.                                                          |
+| `secretsSize` <br/>_integer_               | The number of secrets of the service account.                                                |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
 <!-------------------- DELETE SERVICE ACCOUNT -------------------->
 
 #### Delete a service account

--- a/source/includes/kubernetes_extension/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes_extension/_k8_serviceaccounts.md
@@ -61,7 +61,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts/serviceaccount-name/serviceaccount-namespace?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts/serviceaccount-name/serviceaccount-namespace?cluster_id=:cluster_id"
 ```
 
 > The above command returns a JSON structured like this:

--- a/source/includes/kubernetes_extension/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes_extension/_k8_serviceaccounts.md
@@ -54,6 +54,59 @@ Retrieve a list of all service accounts in a given [environment](#administration
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
+<!-------------------- GET A SERVICE ACCOUNT -------------------->
+
+##### Get a service account
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts/serviceaccount-name/serviceaccount-namespace?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+            "id": "default",
+            "age": "1w5d",
+            "secretsSize": 1,
+            "metadata": {
+              "creationTimestamp": "2020-09-18T10:46:40.000-04:00",
+              "name": "default",
+              "namespace": "default",
+              "uid": "80a0de4d-a187-44c3-b691-1481220a5817"
+            },
+            "secrets": [
+              {
+                "name": "default-token-lrth9"
+              }
+            ]
+          },
+          "fieldTransitions": {},
+          "operations": []
+        }
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts/:id?cluster_id=:cluster_id</code>
+
+Retrieve a service account and all its info in a given [environment](#administration-environments).
+
+| Attributes                                 | &nbsp;                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `id` <br/>_string_                         | The id of the service account.                                                               |
+| `metadata` <br/>_object_                   | The metadata of the service account.                                                         |
+| `metadata.creationTimestamp` <br/>_string_ | The date of creation of the service account as a string.                                     |
+| `metadata.name` <br/>_string_              | The name of the service account.                                                             |
+| `metadata.namespace` <br/>_string_         | The namespace in which the service account is created.                                       |
+| `metadata.uid` <br/>_object_               | The UUID of the service account.                                                             |
+| `metadata.secrets` <br/>_List&lt;object&gt;_     | The secrets of the service account.                                                          |
+| `secretsSize` <br/>_integer_               | The number of secrets of the service account.                                                |
+
+Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+
 <!-------------------- DELETE SERVICE ACCOUNT -------------------->
 
 ##### Delete a service account


### PR DESCRIPTION
### Fixes [MC-12530](https://cloud-ops.atlassian.net/browse/MC-12530)

#### Changes made
<!-- Changes should match the template provided below -->
- Added documentation for the GET service accounts operation in kubernetes and kubernetes_extension

#### Related PRs
- [PR#189](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/189) in cloudmc-kubernetes-sdk

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->