### PR TITLE
MC-12536: added documentation for Create Role in K8 and K8 extension

### DIFF
--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -105,3 +105,66 @@ Retrieve a role and all its info in a given [environment](#administration-enviro
 | `rules` <br/>_array_       | The array of rules assocaited with this role.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE ROLE -------------------->
+
+#### Create a role
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles"
+  Content-Type: application/json
+  {
+   "apiVersion": "rbac.authorization.k8s.io/v1",
+   "kind": "Role",
+   "namespace": "default",
+   "name": "test-name",
+   "metadata": {
+      "namespace": "default",
+      "name": "test-name"
+   },
+   "rules": [
+      {
+         "apiGroups": [
+            ""
+         ],
+         "resources": [
+            "resource"
+         ],
+         "verbs": [
+            "get",
+            "watch"
+         ]
+      }
+   ]
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles</code>
+
+Create a role in a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `id` <br/>_string_         | The id of the role.                          |
+| `apiVersion` <br/>_string_ | The API version used to create this role.  |
+| `metadata.name` <br/>_string_   | The name of the role.                    |
+| `metadata.namespace` <br/>_string_   | The namespace of the role.                    |
+| `rules` <br/>_array_       | The array of rules assocaited with this role.|
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create role task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -102,7 +102,7 @@ Retrieve a role and all its info in a given [environment](#administration-enviro
 | `id` <br/>_string_         | The id of the role.                          |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this role.  |
 | `metadata` <br/>_object_   | The metadata of the role.                    |
-| `rules` <br/>_array_       | The array of rules assocaited with this role.|
+| `rules` <br/>_array_       | The array of rules associated with this role.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -52,7 +52,7 @@ Retrieve a list of all roles in a given [environment](#administration-environmen
 | `metadata.name` <br/>_string_              | The name of the role.|
 | `metadata.namespace` <br/>_string_         | The namespace in which the role is created.|
 | `metadata.uid` <br/>_object_               | The UUID of the role.|
-| `rules` <br/>_array_               | The array of rules assocaited with this role.|
+| `rules` <br/>_array_               | The array of rules associated with this role.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -160,7 +160,7 @@ Create a role in a given [environment](#administration-environments).
 | `apiVersion` <br/>_string_ | The API version used to create this role.  |
 | `metadata.name` <br/>_string_   | The name of the role.                    |
 | `metadata.namespace` <br/>_string_   | The namespace of the role.                    |
-| `rules` <br/>_array_       | The array of rules assocaited with this role.|
+| `rules` <br/>_array_       | The array of rules associated with this role.|
 
 Return value:
 

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -105,3 +105,66 @@ Retrieve a role and all its info in a given [environment](#administration-enviro
 | `rules` <br/>_array_       | The array of rules assocaited with this role.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE ROLE -------------------->
+
+##### Create a role
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles"
+  Content-Type: application/json
+  {
+   "apiVersion": "rbac.authorization.k8s.io/v1",
+   "kind": "Role",
+   "namespace": "default",
+   "name": "test-name",
+   "metadata": {
+      "namespace": "default",
+      "name": "test-name"
+   },
+   "rules": [
+      {
+         "apiGroups": [
+            ""
+         ],
+         "resources": [
+            "resource"
+         ],
+         "verbs": [
+            "get",
+            "watch"
+         ]
+      }
+   ]
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles</code>
+
+Create a role in a given [environment](#administration-environments).
+
+| Attributes                 | &nbsp;                                            |
+| -------------------------- | ------------------------------------------------- |
+| `id` <br/>_string_         | The id of the role.                          |
+| `apiVersion` <br/>_string_ | The API version used to create this role.  |
+| `metadata.name` <br/>_string_   | The name of the role.                    |
+| `metadata.namespace` <br/>_string_   | The namespace of the role.                    |
+| `rules` <br/>_array_       | The array of rules assocaited with this role.|
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create role task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -52,7 +52,7 @@ Retrieve a list of all roles in a given [environment](#administration-environmen
 | `metadata.name` <br/>_string_              | The name of the role.|
 | `metadata.namespace` <br/>_string_         | The namespace in which the role is created.|
 | `metadata.uid` <br/>_object_               | The UUID of the role.|
-| `rules` <br/>_array_               | The array of rules assocaited with this role.|
+| `rules` <br/>_array_               | The array of rules associated with this role.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -160,7 +160,7 @@ Create a role in a given [environment](#administration-environments).
 | `apiVersion` <br/>_string_ | The API version used to create this role.  |
 | `metadata.name` <br/>_string_   | The name of the role.                    |
 | `metadata.namespace` <br/>_string_   | The namespace of the role.                    |
-| `rules` <br/>_array_       | The array of rules assocaited with this role.|
+| `rules` <br/>_array_       | The array of rules assocted with this role.|
 
 Return value:
 

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -160,7 +160,7 @@ Create a role in a given [environment](#administration-environments).
 | `apiVersion` <br/>_string_ | The API version used to create this role.  |
 | `metadata.name` <br/>_string_   | The name of the role.                    |
 | `metadata.namespace` <br/>_string_   | The namespace of the role.                    |
-| `rules` <br/>_array_       | The array of rules assocted with this role.|
+| `rules` <br/>_array_       | The array of rules associated with this role.|
 
 Return value:
 

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -102,7 +102,7 @@ Retrieve a role and all its info in a given [environment](#administration-enviro
 | `id` <br/>_string_         | The id of the role.                          |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this role.  |
 | `metadata` <br/>_object_   | The metadata of the role.                    |
-| `rules` <br/>_array_       | The array of rules assocaited with this role.|
+| `rules` <br/>_array_       | The array of rules associated with this role.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -113,7 +113,7 @@ Note that the list is not complete, since it is refering to the [kubernetes api 
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles?cluster_id=:cluster_id"
   Content-Type: application/json
   {
    "apiVersion": "rbac.authorization.k8s.io/v1",
@@ -150,7 +150,7 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles?cluster_id=:cluster_id</code>
 
 Create a role in a given [environment](#administration-environments).
 


### PR DESCRIPTION
### Fixes [MC-12536](https://cloud-ops.atlassian.net/browse/MC-12536)

#### Changes made
- Added documentation for CreateRole in kubernetes and kubernetes extension

#### Related PRs
- [PR#202](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/202) in cloudmc-kubernetes-sdk

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->