### PR TITLE
Fixed Pricing position in the menu. Fixed display of the examples

### DIFF
--- a/source/includes/administration/_pricings.md
+++ b/source/includes/administration/_pricings.md
@@ -1,8 +1,8 @@
-## Pricings
+### Pricings
 
 
 <!-------------------- LIST PRICINGS -------------------->
-### List pricings
+#### List pricings
 
 `GET /pricings`
 
@@ -88,7 +88,7 @@ Attributes | &nbsp;
 
 
 <!-------------------- FIND PRICING -------------------->
-### Retrieve pricing
+#### Retrieve pricing
 
 `GET /pricings/:id`
 
@@ -172,7 +172,7 @@ Attributes | &nbsp;
 `deprecated`<br/>*Boolean* | True if priced product is deprecated
 
 <!-------------------- CREATE PRICING -------------------->
-### Create Pricing
+#### Create Pricing
 
 `POST /pricings`
 
@@ -281,7 +281,7 @@ Required | &nbsp;
 
 
 <!-------------------- UPDATE PRICING -------------------->
-### Update Pricing 
+#### Update Pricing 
 
 `PUT /pricings/:id`
 
@@ -357,7 +357,7 @@ Priced product
 ```
 
 <!-------------------- DELETE PRICING -------------------->
-### Delete Pricing 
+#### Delete Pricing 
 
 `DELETE /pricings/:id`
 
@@ -372,7 +372,7 @@ curl -X DELETE "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad
 ```
 
 <!-------------------- FIND EFFECTIVE PRICING -------------------->
-### Retrieve Effective Pricing
+#### Retrieve Effective Pricing
 
 `GET /pricings/:id`
 
@@ -461,7 +461,7 @@ Attributes | &nbsp;
 
 
 <!-------------------- List PRICING CHANGES -------------------->
-### List pricing changes
+#### List pricing changes
 
 `GET /pricings/:id/changes`
 
@@ -602,7 +602,7 @@ Attributes | &nbsp;
 
 
 <!-------------------- CREATE PRICING CHANGES -------------------->
-### Add pricing change
+#### Add pricing change
 
 `POST /pricings/:id/changes`
 
@@ -613,8 +613,9 @@ Add a pricing change to a pricing
 curl -X POST "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25dff5da5/changes" \
    -H "MC-Api-Key: your_api_key"
 ```
-> Request body example:
+> Request body example: 
 > Add product body
+
 ```json
 {
     "description": "Adding a product",
@@ -636,6 +637,7 @@ curl -X POST "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25
 }
 ```
 > Modify product body
+
 ```json
 {
     "description": "Modifying a product",
@@ -652,6 +654,7 @@ curl -X POST "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25
 }
 ```
 > Remove product body
+
 ```json
 {
     "description": "Removing a product",
@@ -663,6 +666,7 @@ curl -X POST "https://cloudmc_endpoint/v2/pricings/73eb0d75-03b0-44e2-9cbf-9ad25
 }
 ```
 > Add currency to pricing body
+
 ```json
 {
     "description": "Adding a currency",
@@ -746,7 +750,7 @@ Attributes | &nbsp;
 
 
 <!-------------------- UPDATE PRICING CHANGES -------------------->
-### Update pricing change
+#### Update pricing change
 
 `PUT /pricings/:id/changes/:change_id`
 
@@ -762,7 +766,7 @@ See Add Pricing Change for body. You cannot change the `pricingChangeType`
 
 
 <!-------------------- REMOVE PRICING CHANGES -------------------->
-### Remove pricing change
+#### Remove pricing change
 
 `DELETE /pricings/:id/changes/:change_id`
 


### PR DESCRIPTION
### Fixes [MC-12601](https://cloud-ops.atlassian.net/browse/MC-12601)

#### Changes made
Fixed layout and menu position of pricing items.
![image](https://user-images.githubusercontent.com/56133634/94946975-e9e54400-04aa-11eb-8bb8-66047669e5b1.png)


#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->