### PR TITLE
MC-12535: adding 'update' docs for k8 service accounts

### DIFF
--- a/source/includes/kubernetes/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes/_k8_serviceaccounts.md
@@ -150,6 +150,48 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create service account task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
+<!-------------------- REPLACE SERVICE ACCOUNT -------------------->
+
+#### Replace a service account
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts/service-account-name/namespace-name"
+  Content-Type: application/json
+  {
+    "metadata": {
+        "name": "service-account-name",
+        "namespace": "namespace-name"
+    }
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts/:id</code>
+
+Replace a service account in a given [environment](#administration-environments).
+
+| Required Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `metadata` <br/>_object_            | The metadata of the service account.                                     |
+| `metadata.name` <br/>_string_       | The name of the service account.                                         |
+| `metadata.namespace` <br/>_string_       | The namespace of the service account.                                         |
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create service account task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE SERVICE ACCOUNT -------------------->
 

--- a/source/includes/kubernetes_extension/_k8_serviceaccounts.md
+++ b/source/includes/kubernetes_extension/_k8_serviceaccounts.md
@@ -151,6 +151,49 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create service account task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
+<!-------------------- REPLACE SERVICE ACCOUNT -------------------->
+
+##### Replace a service account
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/serviceaccounts/service-account-name/namespace-name?cluster_id=:cluster_id"
+  Content-Type: application/json
+  {
+    "metadata": {
+        "name": "service-account-name",
+        "namespace": "namespace-name"
+    }
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/serviceaccounts/:id?cluster_id=:cluster_id</code>
+
+Replace a service account in a given [environment](#administration-environments).
+
+| Required Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `metadata` <br/>_object_            | The metadata of the service account.                                     |
+| `metadata.name` <br/>_string_       | The name of the service account.                                         |
+| `metadata.namespace` <br/>_string_       | The namespace of the service account.                                         |
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create service account task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
 <!-------------------- DELETE SERVICE ACCOUNT -------------------->
 
 ##### Delete a service account


### PR DESCRIPTION
### Fixes [MC-12535](https://cloud-ops.atlassian.net/browse/MC-12535)

#### Changes made
- Added 'update/replace' docs for k8s service accounts

#### Related PRs
- [#207](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/207)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->