### PR TITLE
MC-12540: adding 'create role binding' docs for k8

### DIFF
--- a/source/includes/kubernetes/_k8_rolebindings.md
+++ b/source/includes/kubernetes/_k8_rolebindings.md
@@ -115,3 +115,71 @@ Retrieve a role binding and all its info in a given [environment](#administratio
 | `subjects` <br/>_array_       | The array of subjects associated with this role binding.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE ROLE BINDING -------------------->
+
+#### Create a role binding
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/rolebindings"
+  Content-Type: application/json
+  {
+    "kind": "Rolebinding",
+    "metadata": {
+        "name": "rolebinding-name",
+        "namespace": "namespace-name"
+    },
+    "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "role-name"
+    },
+    "subjects": [
+        {
+            "kind": "ServiceAccount",
+            "name": "service-account-name",
+            "namespace": "service-account-namespace"
+        },
+        {
+            "kind": "Group",
+            "name": "group-name",
+            "namespace": "group-namespace"
+        },
+        {
+            "kind": "User",
+            "name": "user-name",
+        }
+
+    ]
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings</code>
+
+Create a role binding in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`metadata` <br/>_object_            | The metadata of the role binding.
+`metadata.name` <br/>_string_       | The name of the role binding.
+`metadata.namespace` <br/>_string_       | The namespace of the role binding.
+`roleRef`<br/>_object_                 | The role to bind. Can reference a Role in the current namespace or a ClusterRole in the global namespace.
+`subjects`<br/>_array_ | Subjects hold references to the objets the role applies to. Can be users, groups, or service accounts.
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create role binding task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes_extension/_k8_rolebindings.md
+++ b/source/includes/kubernetes_extension/_k8_rolebindings.md
@@ -115,3 +115,71 @@ Retrieve a role binding and all its info in a given [environment](#administratio
 | `subjects` <br/>_array_       | The array of subjects associated with this role binding.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+
+<!-------------------- CREATE ROLE BINDING -------------------->
+
+##### Create a role binding
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/rolebindings?cluster_id=:cluster_id"
+  Content-Type: application/json
+  {
+    "kind": "Rolebinding",
+    "metadata": {
+        "name": "rolebinding-name",
+        "namespace": "namespace-name"
+    },
+    "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "role-name"
+    },
+    "subjects": [
+        {
+            "kind": "ServiceAccount",
+            "name": "service-account-name",
+            "namespace": "service-account-namespace"
+        },
+        {
+            "kind": "Group",
+            "name": "group-name",
+            "namespace": "group-namespace"
+        },
+        {
+            "kind": "User",
+            "name": "user-name",
+        }
+
+    ]
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings?cluster_id=:cluster_id</code>
+
+Create a role binding in a given [environment](#administration-environments).
+
+Required Attributes                 | &nbsp;
+----------------------------------- | ------------------------------------------------------------
+`metadata` <br/>_object_            | The metadata of the role binding.
+`metadata.name` <br/>_string_       | The name of the role binding.
+`metadata.namespace` <br/>_string_       | The namespace of the role binding.
+`roleRef`<br/>_object_                 | The role to bind. Can reference a Role in the current namespace or a ClusterRole in the global namespace.
+`subjects`<br/>_array_ | Subjects hold references to the objets the role applies to. Can be users, groups, or service accounts.
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the create role binding task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |


### PR DESCRIPTION
### Fixes [MC-12540](https://cloud-ops.atlassian.net/browse/MC-12540)

#### Changes made
- Added docs for creating k8s role binding

#### Related PRs
- [#209](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/209)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->