### PR TITLE
MC-12760, 12790: document swift support for public object preview and new digests

### DIFF
--- a/source/includes/swift/_objects.md
+++ b/source/includes/swift/_objects.md
@@ -13,10 +13,11 @@ curl -X GET \
 ```
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/objects/:id/redirect</code>
 
-Preview both public and private objects. Previews of private object will generate a temporary URL that provides GET access for limited time. The generated URL will expire after one hour.
+Preview both public and private objects. Previews of private objects will generate a temporary URL that provides GET access for limited time. The generated URL will expire after one hour.
 
 <aside class="notice">
-Preview of private objects requires <a href="https://docs.openstack.org/swift/latest/api/temporary_url_middleware.html">TempURL Middleware</a> be configured on the cluster with support for HTTP <code>GET</code> requests. Currently, private object preview supports digests <code>SHA-1</code>, <code>SHA-256</code> and <code>SHA-512</code>. The most secure of the supported digests will be used if allowed on the cluster.
+Preview of private objects requires <a href="https://docs.openstack.org/swift/latest/api/temporary_url_middleware.html">TempURL Middleware</a> be configured on the cluster with support for HTTP <code>GET</code> requests. Currently, private object preview supports digests <code>SHA-1</code>, <code>SHA-256</code> and <code>SHA-512</code>. The most secure digest configured on the cluster will be used.
+
 <br/>
 If the secret <code>X-Account-Meta-Temp-URL-Key</code> key does not already exist, the operation will set one on the user account.
 </aside>

--- a/source/includes/swift/_objects.md
+++ b/source/includes/swift/_objects.md
@@ -13,12 +13,10 @@ curl -X GET \
 ```
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/objects/:id/redirect</code>
 
-Preview private objects by generating a temporary URL that provides GET access for limited time. The generated URL will expire after one hour.
+Preview both public and private objects. Previews of private object will generate a temporary URL that provides GET access for limited time. The generated URL will expire after one hour.
 
 <aside class="notice">
-Object preview is only available for private objects. The Get URL operation is preferred for public objects.
-<br/>
-Object preview requires  <a href="https://docs.openstack.org/swift/latest/api/temporary_url_middleware.html">TempURL Middleware</a>  be configured on the cluster. At time of writing, object preview only supports <code>SHA-1</code> digests. Ensure HTTP <code>GET</code> requests and digest <code>SHA-1</code> is allowed on the cluster.
+Preview of private objects requires <a href="https://docs.openstack.org/swift/latest/api/temporary_url_middleware.html">TempURL Middleware</a> be configured on the cluster with support for HTTP <code>GET</code> requests. Currently, private object preview supports digests <code>SHA-1</code>, <code>SHA-256</code> and <code>SHA-512</code>. The most secure of the supported digests will be used if allowed on the cluster.
 <br/>
 If the secret <code>X-Account-Meta-Temp-URL-Key</code> key does not already exist, the operation will set one on the user account.
 </aside>


### PR DESCRIPTION
### Fixes [MC-12760](https://cloud-ops.atlassian.net/browse/MC-12760) and [MC-12790](https://cloud-ops.atlassian.net/browse/MC-12790)

#### Changes made
- Update swift object preview with support for public objects
- Document support for `sha256` and `sha512`, used when previewing private objects via tempurl

#### Related PRs
- https://github.com/cloudops/cloudmc-swift-plugin/pull/75

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->