### PR TITLE
MC-12541: docs for replacing/editing a role binding in k8

### DIFF
--- a/source/includes/kubernetes/_k8_rolebindings.md
+++ b/source/includes/kubernetes/_k8_rolebindings.md
@@ -181,7 +181,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create role binding operation. |
+| `taskId` <br/>_string_     | The id corresponding to the create role binding task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- REPLACE ROLE BINDING -------------------->
@@ -242,7 +242,6 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-<<<<<<< HEAD
 | `taskId` <br/>_string_     | The id corresponding to the replace role binding operation.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
@@ -266,7 +265,5 @@ Delete a role binding from a given [environment](#administration-environments).
 | -------------------------- | ----------------------------------------------- |
 | `taskId` <br/>_string_     | The id corresponding to the delete role binding task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                    |
-=======
 | `taskId` <br/>_string_     | The id corresponding to the replace role binding operation. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
->>>>>>> MC-12541: grammar changes

--- a/source/includes/kubernetes/_k8_rolebindings.md
+++ b/source/includes/kubernetes/_k8_rolebindings.md
@@ -181,7 +181,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the create role binding task. |
+| `taskId` <br/>_string_     | The id corresponding to the create role binding operation. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- REPLACE ROLE BINDING -------------------->
@@ -242,6 +242,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
+<<<<<<< HEAD
 | `taskId` <br/>_string_     | The id corresponding to the replace role binding operation.|
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
@@ -265,3 +266,7 @@ Delete a role binding from a given [environment](#administration-environments).
 | -------------------------- | ----------------------------------------------- |
 | `taskId` <br/>_string_     | The id corresponding to the delete role binding task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                    |
+=======
+| `taskId` <br/>_string_     | The id corresponding to the replace role binding operation. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+>>>>>>> MC-12541: grammar changes

--- a/source/includes/kubernetes/_k8_rolebindings.md
+++ b/source/includes/kubernetes/_k8_rolebindings.md
@@ -184,6 +184,66 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create role binding task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
+<!-------------------- REPLACE ROLE BINDING -------------------->
+
+#### Replace a role binding
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/rolebindings/rolebinding-name/namespace-name"
+  Content-Type: application/json
+  {
+    "metadata": {
+        "name": "service-account-name",
+        "namespace": "namespace-name"
+    },
+    "roleRef": {
+      "apiGroup": "",
+      "kind": "Role",
+      "name": "role-name"
+    },
+    "subjects": [
+      {
+        "kind": "ServiceAccount",
+        "name": "default",
+        "namespace": "default"
+      },
+      {
+        "kind": "user",
+        "name": "user1",
+      }
+    ]
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id</code>
+
+Replace a role binding in a given [environment](#administration-environments).
+
+| Required Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `metadata` <br/>_object_            | The metadata of the role binding.|
+| `metadata.name` <br/>_string_       | The name of the role binding.|
+| `metadata.namespace` <br/>_string_       | The namespace of the role binding.|
+|`roleRef`<br/>_object_                 | The role to bind. Can reference a Role in the current namespace or a ClusterRole in the global namespace.|
+|`subjects`<br/>_array_ | Subjects hold references to the objets the role applies to. Can be users, groups, or service accounts.|
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace role binding operation.|
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE ROLE BINDING -------------------->
 
@@ -196,12 +256,6 @@ curl -X DELETE \
 ```
 
 > The above command returns a JSON structured like this:
-```json
-{
-  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
-  "taskStatus": "PENDING"
-}
-```
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id</code>
 

--- a/source/includes/kubernetes_extension/_k8_rolebindings.md
+++ b/source/includes/kubernetes_extension/_k8_rolebindings.md
@@ -243,7 +243,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the replace role binding task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace role binding operation. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 <!-------------------- DELETE A ROLE BINDING -------------------->

--- a/source/includes/kubernetes_extension/_k8_rolebindings.md
+++ b/source/includes/kubernetes_extension/_k8_rolebindings.md
@@ -112,7 +112,8 @@ Retrieve a role binding and all its info in a given [environment](#administratio
 | `id` <br/>_string_         | The id of the role binding.                          |
 | `apiVersion` <br/>_string_ | The API version used to retrieve this role binding.  |
 | `metadata` <br/>_object_   | The metadata of the role binding.                    |
-| `subjects` <br/>_array_       | The array of subjects associated with this role binding.|
+|`roleRef`<br/>_object_      | The role to bind. Can reference a Role in the current namespace or a ClusterRole in the global namespace.|
+| `subjects` <br/>_array_    | The array of subjects associated with this role binding.|
 
 Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
@@ -184,6 +185,67 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create role binding task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
+<!-------------------- REPLACE ROLE BINDING -------------------->
+
+##### Replace a role binding
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/rolebindings/rolebinding-name/namespace-name?cluster_id=:cluster_id"
+  Content-Type: application/json
+  {
+    "metadata": {
+        "name": "service-account-name",
+        "namespace": "namespace-name"
+    },
+    "roleRef": {
+      "apiGroup": "",
+      "kind": "Role",
+      "name": "role-name"
+    },
+    "subjects": [
+      {
+        "kind": "ServiceAccount",
+        "name": "default",
+        "namespace": "default"
+      },
+      {
+        "kind": "user",
+        "name": "user1",
+      }
+    ]
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id?cluster_id=:cluster_id</code>
+
+Replace a role binding in a given [environment](#administration-environments).
+
+| Required Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `metadata` <br/>_object_            | The metadata of the role binding.|
+| `metadata.name` <br/>_string_       | The name of the role binding.|
+| `metadata.namespace` <br/>_string_       | The namespace of the role binding.|
+|`roleRef`<br/>_object_                 | The role to bind. Can reference a Role in the current namespace or a ClusterRole in the global namespace.|
+|`subjects`<br/>_array_ | Subjects hold references to the objets the role applies to. Can be users, groups, or service accounts.|
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the replace role binding task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |
+
 <!-------------------- DELETE A ROLE BINDING -------------------->
 
 ##### Delete a role binding
@@ -195,13 +257,6 @@ curl -X DELETE \
 ```
 
 > The above command returns a JSON structured like this:
-```json
-{
-  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
-  "taskStatus": "PENDING"
-}
-```
-
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id?cluster_id=:cluster_id</code>
 
 Delete a role binding from a given [environment](#administration-environments).


### PR DESCRIPTION
### Fixes [MC-12541](https://cloud-ops.atlassian.net/browse/MC-12541)

#### Changes made
- Added docs for editing a role binding in k8

#### Related PRs
- [#214](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/214)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->