### PR TITLE
MC-12541: fixing rebase errors

### DIFF
--- a/source/includes/kubernetes/_k8_rolebindings.md
+++ b/source/includes/kubernetes/_k8_rolebindings.md
@@ -256,7 +256,12 @@ curl -X DELETE \
 ```
 
 > The above command returns a JSON structured like this:
-
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id</code>
 
 Delete a role binding from a given [environment](#administration-environments).
@@ -265,5 +270,3 @@ Delete a role binding from a given [environment](#administration-environments).
 | -------------------------- | ----------------------------------------------- |
 | `taskId` <br/>_string_     | The id corresponding to the delete role binding task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                    |
-| `taskId` <br/>_string_     | The id corresponding to the replace role binding operation. |
-| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes_extension/_k8_rolebindings.md
+++ b/source/includes/kubernetes_extension/_k8_rolebindings.md
@@ -257,6 +257,12 @@ curl -X DELETE \
 ```
 
 > The above command returns a JSON structured like this:
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/rolebindings/:id?cluster_id=:cluster_id</code>
 
 Delete a role binding from a given [environment](#administration-environments).


### PR DESCRIPTION
### Fixes [MC-12541](https://cloud-ops.atlassian.net/browse/MC-12541)

#### Changes made
- Fixing errors in role binding k8 docs made when I rebased.

#### Related PRs
- [#247](https://github.com/cloudops/cloudmc-api-docs/pull/247)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->