### PR TITLE
Feature/mc 12537 edit role

### DIFF
--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -168,3 +168,46 @@ Return value:
 | -------------------------- | -------------------------------------------- |
 | `taskId` <br/>_string_     | The id corresponding to the create role task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
+
+<!-------------------- REPLACE ROLE -------------------->
+
+#### Replace a role
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles/role-name/namespace-name?cluster_id=:cluster_id"
+  Content-Type: application/json
+  {
+    "metadata": {
+        "name": "role-name",
+        "namespace": "namespace-name"
+    }
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles/:id?cluster_id=:cluster_id</code>
+
+Replace a role in a given [environment](#administration-environments).
+
+| Required Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `metadata` <br/>_object_            | The metadata of the role.                                     |
+| `metadata.name` <br/>_string_       | The name of the role.                                         |
+| `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the update role task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -219,8 +219,10 @@ Replace a role in a given [environment](#administration-environments).
 | `metadata.name` <br/>_string_       | The name of the role.                                         |
 | `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
 | `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
-| `rules` <br/>_array_       | The array of rules associated with this role.|
 
+| Optional Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `rules` <br/>_array_       | The array of rules associated with this role.|
 
 Return value:
 

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -199,6 +199,7 @@ curl -X PUT \
       }
    ]
   }
+```
 
 > The above command returns a JSON structured like this:
 

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -157,7 +157,7 @@ Create a role in a given [environment](#administration-environments).
 | Attributes                 | &nbsp;                                            |
 | -------------------------- | ------------------------------------------------- |
 | `id` <br/>_string_         | The id of the role.                          |
-| `apiVersion` <br/>_string_ | The API vsersion used to create this role.  |
+| `apiVersion` <br/>_string_ | The API version used to create this role.  |
 | `metadata.name` <br/>_string_   | The name of the role.                    |
 | `metadata.namespace` <br/>_string_   | The namespace of the role.                    |
 | `rules` <br/>_array_       | The array of rules associated with this role.|

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -169,7 +169,6 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create role task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
-<<<<<<< HEAD
 <!-------------------- REPLACE ROLE -------------------->
 
 #### Replace a role
@@ -185,17 +184,6 @@ curl -X PUT \
         "namespace": "namespace-name"
     }
   }
-=======
-<!-------------------- DELETE A ROLE -------------------->
-
-#### Delete a role
-
-```shell
-curl -X DELETE \
-   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles/default-token-xxxmt/default"
->>>>>>> 5f9d830f05b3f09a2a4fd553a928946d28e0e7d3
-```
 
 > The above command returns a JSON structured like this:
 
@@ -206,7 +194,6 @@ curl -X DELETE \
 }
 ```
 
-<<<<<<< HEAD
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles/:id?cluster_id=:cluster_id</code>
 
 Replace a role in a given [environment](#administration-environments).
@@ -221,9 +208,29 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the update role task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace role operation. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
-=======
+
+
+<!-------------------- DELETE A ROLE -------------------->
+
+#### Delete a role
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles/default-token-xxxmt/default"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles/:id</code>
 
 Delete a roles from a given [environment](#administration-environments).
@@ -232,4 +239,3 @@ Delete a roles from a given [environment](#administration-environments).
 | -------------------------- | ----------------------------------------------- |
 | `taskId` <br/>_string_     | The id corresponding to the delete role task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                    |
->>>>>>> 5f9d830f05b3f09a2a4fd553a928946d28e0e7d3

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -183,6 +183,21 @@ curl -X PUT \
         "name": "role-name",
         "namespace": "namespace-name"
     }
+    "rules": [
+      {
+         "apiGroups": [
+            ""
+         ],
+         "resources": [
+            "resource"
+         ],
+         "verbs": [
+            "get",
+            "watch",
+            "..."
+         ]
+      }
+   ]
   }
 
 > The above command returns a JSON structured like this:

--- a/source/includes/kubernetes/_k8_roles.md
+++ b/source/includes/kubernetes/_k8_roles.md
@@ -157,7 +157,7 @@ Create a role in a given [environment](#administration-environments).
 | Attributes                 | &nbsp;                                            |
 | -------------------------- | ------------------------------------------------- |
 | `id` <br/>_string_         | The id of the role.                          |
-| `apiVersion` <br/>_string_ | The API version used to create this role.  |
+| `apiVersion` <br/>_string_ | The API vsersion used to create this role.  |
 | `metadata.name` <br/>_string_   | The name of the role.                    |
 | `metadata.namespace` <br/>_string_   | The namespace of the role.                    |
 | `rules` <br/>_array_       | The array of rules associated with this role.|
@@ -218,6 +218,9 @@ Replace a role in a given [environment](#administration-environments).
 | `metadata` <br/>_object_            | The metadata of the role.                                     |
 | `metadata.name` <br/>_string_       | The name of the role.                                         |
 | `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
+| `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
+| `rules` <br/>_array_       | The array of rules associated with this role.|
+
 
 Return value:
 

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -219,6 +219,7 @@ Replace a role in a given [environment](#administration-environments).
 | `metadata` <br/>_object_            | The metadata of the role.                                     |
 | `metadata.name` <br/>_string_       | The name of the role.                                         |
 | `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
+| `rules` <br/>_array_       | The array of rules associated with this role.|
 
 Return value:
 

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -183,6 +183,21 @@ curl -X PUT \
         "name": "role-name",
         "namespace": "namespace-name"
     }
+    "rules": [
+      {
+         "apiGroups": [
+            ""
+         ],
+         "resources": [
+            "resource"
+         ],
+         "verbs": [
+            "get",
+            "watch",
+            "..."
+         ]
+      }
+   ]
   }
   ```
 

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -219,6 +219,10 @@ Replace a role in a given [environment](#administration-environments).
 | `metadata` <br/>_object_            | The metadata of the role.                                     |
 | `metadata.name` <br/>_string_       | The name of the role.                                         |
 | `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
+| `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
+
+| Optional Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
 | `rules` <br/>_array_       | The array of rules associated with this role.|
 
 Return value:

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -209,7 +209,7 @@ Return value:
 
 | Attributes                 | &nbsp;                                       |
 | -------------------------- | -------------------------------------------- |
-| `taskId` <br/>_string_     | The id corresponding to the update role task. |
+| `taskId` <br/>_string_     | The id corresponding to the replace role operation. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
 
 

--- a/source/includes/kubernetes_extension/_k8_roles.md
+++ b/source/includes/kubernetes_extension/_k8_roles.md
@@ -168,3 +168,46 @@ Return value:
 | -------------------------- | -------------------------------------------- |
 | `taskId` <br/>_string_     | The id corresponding to the create role task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                 |
+
+<!-------------------- REPLACE ROLE -------------------->
+
+##### Replace a role
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/roles/role-name/namespace-name?cluster_id=:cluster_id"
+  Content-Type: application/json
+  {
+    "metadata": {
+        "name": "role-name",
+        "namespace": "namespace-name"
+    }
+  }
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "1542bd45-4732-419b-87b6-4ea6ec695c2b",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/roles/:id?cluster_id=:cluster_id</code>
+
+Replace a role in a given [environment](#administration-environments).
+
+| Required Attributes                 | &nbsp;                                                      |
+| ----------------------------------- | ----------------------------------------------------------- |
+| `metadata` <br/>_object_            | The metadata of the role.                                     |
+| `metadata.name` <br/>_string_       | The name of the role.                                         |
+| `metadata.namespace` <br/>_string_       | The namespace of the role.                                         |
+
+Return value:
+
+| Attributes                 | &nbsp;                                       |
+| -------------------------- | -------------------------------------------- |
+| `taskId` <br/>_string_     | The id corresponding to the update role task. |
+| `taskStatus` <br/>_string_ | The status of the operation.                 |


### PR DESCRIPTION
### Fixes [MC-12537](https://cloud-ops.atlassian.net/browse/MC-12537)

#### Changes made
- Added Edit operation for Roles in Kubernetes and Kubernetes extension

#### Related PRs
- [PR#213](https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/213) in cloudmc-kubernetes-sdk

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->