### PR TITLE
MC-12440

### DIFF
--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -169,6 +169,7 @@ curl -X POST \
   "shortZone": "northamerica-northeast1-a",
   "initialClusterVersion": "1.17.12-gke.500",
   "nodePools": {
+    "name": "default-pool"
     "initialNodeCount":"3",
     "nodeConfig":{
       "machineType":"e2-highcpu-16"


### PR DESCRIPTION
Added node pool name to documentation

### Fixes [MC-12440](https://cloud-ops.atlassian.net/browse/MC-12440)

#### Changes made
<!-- Changes should match the template provided below -->
Added field for the node pool name in the request template for the create cluster for gcp api documentation.