### PR TITLE
MC-12515: Added documentation to mark organization as reseller

### DIFF
--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -25,6 +25,7 @@ curl "https://cloudmc_endpoint/v1/organizations" \
          "entryPoint": "umbrella",
          "billableStartDate": "2017-08-15T12:00:00.000Z",
          "isBillable": true,
+         "isReseller": false,
          "tags": ["a-tag"],
          "parent": {
             "id": "8e3393ce-ee63-4f32-9e0f-7b0200fa655a",
@@ -75,6 +76,7 @@ Attributes | &nbsp;
 `isDbAuthentication`<br/>*boolean* | Whether or not the organization supports database authentication.
 `isLdapAuthentication`<br/>*boolean* | Whether or not LDAP authentication is enabled on this organization.
 `isTrial`<br/>*boolean* | Whether or not this is a trial organization.
+`isReseller`<br/>*boolean* | Whether or not this organization is a reseller or not.
 `customDomain`<br/>*[VerifiedDomain](#administration-get-verified-domains)* | The custom domain for the organization.
 
 <!-------------------- FIND ORGANIZATION -------------------->
@@ -99,6 +101,7 @@ curl "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c
       "entryPoint": "nintendo-us",
       "billableStartDate": "2017-08-15T12:00:00.000Z",
       "isBillable": true,
+      "isReseller": false,
       "tags": ["a-tag"],
       "parent": {
          "id": "8e3393ce-ee63-4f32-9e0f-7b0200fa655a",
@@ -148,6 +151,7 @@ Attributes | &nbsp;
 `isDbAuthentication`<br/>*boolean* | Whether or not the organization supports database authentication.
 `isLdapAuthentication`<br/>*boolean* | Whether or not LDAP authentication is enabled on this organization.
 `isTrial`<br/>*boolean* | Whether or not this is a trial organization.
+`isReseller`<br/>*boolean* | Whether or not this organization is a reseller or not.
 `customDomain`<br/>*[VerifiedDomain](#administration-get-verified-domains)* | The custom domain for the organization.
 
 <!-------------------- CREATE ORGANIZATION -------------------->
@@ -455,3 +459,16 @@ Optional | &nbsp;
 `verifiedDomains`<br/>*Array[[verified domains](#administration-get-verified-domains)]*| A list of objects containing the ids of verified domains (with VERIFIED status) for which successful matching OIDC logins will create new users.
 
 Returns an HTTP status code 200, with an empty response body.
+
+
+<!-------------------- MARK AS RESELLER -------------------->
+### Mark organization as reseller
+`POST /organizations/:organization_id/mark_reseller`
+
+```shell
+# Mark an organization as reseller
+curl -X POST "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c0cb5/mark_reseller" \
+   -H "MC-Api-Key: your_api_key" \
+```
+
+Mark the organization as a reseller. Returns an HTTP status code 200, with an empty response body.


### PR DESCRIPTION
### Fixes [MC-12515](https://cloud-ops.atlassian.net/browse/MC-12515)

#### Changes made
<!-- Changes should match the template provided below -->
- Added the isReseller information in the responses
- Added the mark as reseller operation

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->