### PR TITLE
MC-12631: Add delete cluster API documentation

### DIFF
--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -208,7 +208,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters/:id</code>
 
-Delete a cluster. A cluster can only be deleted if it is in RUNNING or ERROR states.
+Delete a cluster. A cluster can only be deleted if it is in RUNNING or ERROR state.
 
 > The above command returns a JSON structured like this:
 

--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -196,3 +196,17 @@ Required | &nbsp;
 `network`<br/>*string* | The network that the Kubernetes cluster is in.
 `subnetwork`<br/>*string* | Subnetwork to which the cluster will belong. The subnetwork specified must belong the network specified.
 
+<!-------------------- DELETE A CLUSTER -------------------->
+
+#### Delete a cluster
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/gcp/test-area/clusters/projects/cmc-test-area-ugx/locations/us-central1-c/clusters/cluster-1"
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters/:id</code>
+
+Delete a cluster. A cluster can only be deleted if it is in RUNNING or ERROR states.
+

--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -210,3 +210,11 @@ curl -X DELETE \
 
 Delete a cluster. A cluster can only be deleted if it is in RUNNING or ERROR states.
 
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "3e4d4466-ce4b-404b-ada5-ee5a3fb76f4e",
+  "taskStatus": "PENDING"
+}
+```


### PR DESCRIPTION
### Fixes [MC-12631](https://cloud-ops.atlassian.net/browse/MC-12631)

#### Changes made
<!-- Changes should match the template provided below -->
- Update documentation with Delete Cluster operation

#### Related PRs
- [#357](https://github.com/cloudops/cloudmc-gcp-plugin/pull/357)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->