### PR TITLE
MC-12351: add Organization to product catalog

### DIFF
--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -27,6 +27,10 @@ curl "https://cloudmc_endpoint/rest/product_catalogs" \
         "en": "fgsfdg",
         "fr": "sfdg"
       },
+      "organization": {
+        "name": "myOrg",
+        "id": "23dbae5c-24fe-4391-a8ca-f5ec4a6c2948"
+      },
       "changes": [],
       "description": {
         "en": "sdfg",
@@ -75,6 +79,7 @@ Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the product catalog.
 `name`<br/>*Object* | The name object in each language for the product catalog.
+`organization`<br/>*Object* | The organization the product catalog is scoped to.
 `description`<br/>*string* | The description object in each language for the product catalog.
 `mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
 `serviceType`<br/>*Object* | The service connection type the product catalog is bound to.
@@ -131,6 +136,10 @@ curl "https://cloudmc_endpoint/rest/product_catalogs/03bc22bd-adc4-46b8-988d-afd
       "en": "fgsfdg",
       "fr": "sfdg"
     },
+    "organization": {
+        "name": "myOrg",
+        "id": "23dbae5c-24fe-4391-a8ca-f5ec4a6c2948"
+    },
     "changes": [],
     "description": {
       "en": "sdfg",
@@ -179,6 +188,7 @@ Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the product catalog.
 `name`<br/>*Object* | The name object in each language for the product catalog.
+`organization`<br/>*Object* | The organization the product catalog is scoped to.
 `description`<br/>*string* | The description object in each language for the product catalog.
 `mode`<br/>*string* | Identify the mode if it is for all service type or specific connections. Possible values: ALL_CONNECTIONS_OF_TYPE, SPECIFIC_CONNECTIONS.
 `serviceType`<br/>*Object* | The service connection type the product catalog is bound to.
@@ -236,6 +246,9 @@ curl -X POST "https://cloudmc_endpoint/rest/product_catalogs" \
         "fr": "name_fr",
         "es": "name_es"
       },
+      "organization": {
+        "id": "23dbae5c-24fe-4391-a8ca-f5ec4a6c2948"
+      },
       "description": {
         "en": "beep boop",
         "fr": "beep boop",
@@ -289,6 +302,10 @@ curl -X POST "https://cloudmc_endpoint/rest/product_catalogs" \
       "en": "madeInApi",
       "fr": "madeInApi",
       "es": "madeInApi"
+    },
+    "organization": {
+        "name": "myOrg",
+        "id": "23dbae5c-24fe-4391-a8ca-f5ec4a6c2948"
     },
     "description": {
       "en": "beep boop",
@@ -344,6 +361,7 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
+`organization`<br/>*string* | The orgnization the product catalog is scoped to. If no organization is provided, the user's organization is used by default.
 `connectionIds`<br/>*Array[UUID]* | Array of UUID for the service connections that the catalog is bound to.
 `categories`<br/>*Array[Object]* | The list of product categories object.
 `categories.id`<br/>*UUID* | The id of product category object. Required for each category object.
@@ -452,6 +470,10 @@ curl -X PUT "https://cloudmc_endpoint/rest/product_catalogs/b541a90b-afb6-44cf-8
       "en": "updated_en",
       "fr": "name_fr",
       "es": "name_es"
+    },
+    "organization": {
+        "name": "myOrg",
+        "id": "23dbae5c-24fe-4391-a8ca-f5ec4a6c2948"
     },
     "description": {
       "en": "beep boop",

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -13,7 +13,7 @@ Retrieves a list of product catalogs configured in the system.
 # Retrieve product catalog list
 curl "https://cloudmc_endpoint/rest/product_catalogs" \
    -H "MC-Api-Key: your_api_key"
-```s
+```
 > The above command returns a JSON structured like this:
 
 ```json
@@ -361,7 +361,7 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
-`organization`<br/>*string* | The orgnization the product catalog is scoped to. If no organization is provided, the user's organization is used by default.
+`organization`<br/>*Object* | The orgnization the product catalog is scoped to. If no organization is provided, the user's organization is used by default.
 `connectionIds`<br/>*Array[UUID]* | Array of UUID for the service connections that the catalog is bound to.
 `categories`<br/>*Array[Object]* | The list of product categories object.
 `categories.id`<br/>*UUID* | The id of product category object. Required for each category object.


### PR DESCRIPTION
### Fixes [MC-12351](https://cloud-ops.atlassian.net/browse/MC-12351)

#### Changes made
Added organization field to the product catalog as it is now always field when creating one. No more global scope for SAAS

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->