### PR TITLE
MC-12698: move billing day from applied pricing to organization

### DIFF
--- a/source/includes/administration/_applied_pricings.md
+++ b/source/includes/administration/_applied_pricings.md
@@ -42,7 +42,6 @@ curl "https://cloudmc_endpoint/rest/applied_pricings" \
         "name": "System",
         "id": "23910576-d29f-4c14-b663-31d728ff49a5"
       },
-      "billingDay": 5,
       "currency": "USD",
       "id": "47c4993a-a131-4365-a427-02de95bad85b",
       "creationDate": "2020-06-04T18:30:21.000Z",
@@ -70,7 +69,6 @@ Attributes | &nbsp;
 `startDate`<br/>*date* | The start date of the applied pricing.
 `endDate`<br/>*date* | The end date of the applied pricing. If it is not present, there is no end date defined.
 `currency`<br/>*string* | The currency associated to the applied pricing.
-`billingDay`<br/>*int* | The billing day that the applied pricing will be applied.
 `scopeQualifier`<br/>*string* | Scope qualifier of the applied pricing. Possible values are : GLOBAL, ORG_TOPLEVEL, ORG_SUBS, ORG_BASE, ORG_TREE.
 `scopeOrganization`<br/>*Object* | The organization to which the scope is applied to.
 `scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
@@ -118,7 +116,6 @@ curl "https://cloudmc_endpoint/rest/applied_pricings/03bc22bd-adc4-46b8-988d-afd
       "name": "System",
       "id": "23910576-d29f-4c14-b663-31d728ff49a5"
     },
-    "billingDay": 5,
     "currency": "USD",
     "id": "47c4993a-a131-4365-a427-02de95bad85b",
     "creationDate": "2020-06-04T18:30:21.000Z",
@@ -145,7 +142,6 @@ Attributes | &nbsp;
 `startDate`<br/>*date* | The start date of the applied pricing.
 `endDate`<br/>*date* | The end date of the applied pricing. If it is not present, there is no end date defined.
 `currency`<br/>*string* | The currency associated to the applied pricing.
-`billingDay`<br/>*int* | The billing day that the applied pricing will be applied.
 `scopeQualifier`<br/>*string* | Scope qualifier of the applied pricing. Possible values are : GLOBAL, ORG_TOPLEVEL, ORG_SUBS, ORG_BASE, ORG_TREE.
 `scopeOrganization`<br/>*Object* | The organization to which the scope is applied to.
 `scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
@@ -176,7 +172,6 @@ curl -X POST "https://cloudmc_endpoint/rest/applied_pricings" \
   "organization": {
     "id": "23910576-d29f-4c14-b663-31d728ff49a5"
   },
-  "billingDay": 5,
   "currency": "USD",
   "scopeQualifier": "GLOBAL",
   "startDate": "2020-06-05T00:00:00Z",
@@ -198,7 +193,6 @@ curl -X POST "https://cloudmc_endpoint/rest/applied_pricings" \
     "organization": {
       "id": "23910576-d29f-4c14-b663-31d728ff49a5"
     },
-    "billingDay": 5,
     "currency": "USD",
     "id": "8bb5e457-41c3-410b-aced-b9c694ff141a",
     "creationDate": "2020-06-04T19:31:31.178Z",
@@ -215,7 +209,6 @@ Required | &nbsp;
 `scopeQualifier` <br/>*string* | The scope qualifier for the applied pricing. Possible values are : ORG_BASE, ORG_TREE, ORG_SUB, ORG_TOPLEVEL, GLOBAL.
 `currency` <br/>*String* | The currency used for the applied pricing. The value is a ISO 4217 currency code that is part of the pricing selected. 
 `startDate` <br/>*Date* | The start date for the applied pricing.
-`billingDay` <br/>*int*| The billing day that the applied pricing will be applied.
 
 Optional | &nbsp;
 ------- | -----------
@@ -246,7 +239,6 @@ curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/8bb5e457-41c3-410b-a
   "organization": {
     "id": "23910576-d29f-4c14-b663-31d728ff49a5"
   },
-  "billingDay": 5,
   "currency": "USD",
   "scopeQualifier": "ORG_BASE",
   "scopeOrganization": {
@@ -284,7 +276,6 @@ curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/8bb5e457-41c3-410b-a
       "name": "Systemer",
       "id": "52fd201e-aa82-4a27-86b3-ea9650a7fb1e"
     },
-    "billingDay": 3,
     "currency": "CAD",
     "id": "d08b9332-d26e-42fe-b272-3071f2d64839",
     "creationDate": "2020-09-08T17:44:18.000Z",
@@ -305,7 +296,6 @@ Required | &nbsp;
 `scopeQualifier` <br/>*string* | The scope qualifier for the applied pricing. Possible values are : ORG_BASE, ORG_TREE, ORG_SUB, ORG_TOPLEVEL, GLOBAL.
 `currency` <br/>*String* | The currency used for the applied pricing. The value is a ISO 4217 currency code that is part of the pricing selected. 
 `startDate` <br/>*Date* | The start date for the applied pricing.
-`billingDay` <br/>*int*| The billing day that the applied pricing will be applied.
 
 Optional | &nbsp;
 ------- | -----------

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -199,7 +199,7 @@ Optional | &nbsp;
 ---- | ----
 `serviceConnections`<br/>Array[[ServiceConnection](#administration-service-connections)] | A list of service connections for which the organization may provision resources.<br/>*required :*`id`
 `parent`<br/>[Organization](#administration-organization) | The organization that will be the parent of the new organization. By default, it will default to the caller's organization.<br/>*required :*`id`
-`billingDay`<br/>*int* | The billing day of the organization. Must be between 1 and 28, the default value is 1.
+`billingDay`<br/>*int* | The billing day of the organization. Must be between 1 and 28 (inclusive), the default value is 1.
 
 The responses' `data` field contains the created [organization](#administration-organizations) with its `id`.
 
@@ -242,7 +242,7 @@ Optional | &nbsp;
 `isDbAuthentication`<br/>*boolean* | Whether or not the organization supports database authentication.
 `isLdapAuthentication`<br/>*boolean* | Whether or not LDAP authentication is enabled on this organization.
 `customDomain`<br/>*[VerifiedDomain](#administration-get-verified-domains)* | An object describing a verified domain. Must have the `Organization: Manage reseller features` permission. <br/>*required* : `id`
-`billingDay`<br/>*int* | The billing day of the organization. Must be between 1 and 28, the default value is 1.
+`billingDay`<br/>*int* | The billing day of the organization. Must be between 1 and 28 (inclusive), the default value is 1.
 
 The responses' `data` field contains the updated [organization](#administration-organizations).
 

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -24,6 +24,7 @@ curl "https://cloudmc_endpoint/v1/organizations" \
          "name": "Umbrella Corporation",
          "entryPoint": "umbrella",
          "billableStartDate": "2017-08-15T12:00:00.000Z",
+         "billingDay": 5,
          "isBillable": true,
          "isReseller": false,
          "tags": ["a-tag"],
@@ -64,6 +65,7 @@ Attributes | &nbsp;
 `name`<br/>*string* | The name of the organization.
 `entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL : `[entryPoint].CloudMC`.
 `billableStartDate`<br/>*string* | The billable start date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) of the organization.
+`billingDay`<br/>*int* | The billing day of the organization. Default value is 1.
 `isBillable`<br/>*boolean* | If the organization is billable this values is true, false otherwise.
 `tags`<br/>*Array[string]* | Tags associated to the organization.
 `parent`<br/>*[Organization](#administration-organizations)* | If the organization is a sub-organization, it will have its `parent` organization. *includes*:`id`,`name`.
@@ -100,6 +102,7 @@ curl "https://cloudmc_endpoint/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c
       "name": "Nintendo US",
       "entryPoint": "nintendo-us",
       "billableStartDate": "2017-08-15T12:00:00.000Z",
+      "billingDay": 5,
       "isBillable": true,
       "isReseller": false,
       "tags": ["a-tag"],
@@ -139,6 +142,7 @@ Attributes | &nbsp;
 `name`<br/>*string* | The name of the organization.
 `entryPoint`<br/>*string* | The entry point of the organization is the subdomain of the organization in the CloudMC URL :<br/>`[entryPoint].CloudMC`.
 `billableStartDate`<br/>*string* | The billable start date in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) of the organization.
+`billingDay`<br/>*int* | The billing day of the organization. Default value is 1.
 `isBillable`<br/>*boolean* | If the organization is billable this values is true, false otherwise.
 `tags`<br/>*Array[string]* | Tags associated to the organization.
 `parent`<br/>*[Organization](#administration-organizations)* | If the organization is a sub-organization, it will have its `parent` organization. *includes*:`id`,`name`.
@@ -195,6 +199,7 @@ Optional | &nbsp;
 ---- | ----
 `serviceConnections`<br/>Array[[ServiceConnection](#administration-service-connections)] | A list of service connections for which the organization may provision resources.<br/>*required :*`id`
 `parent`<br/>[Organization](#administration-organization) | The organization that will be the parent of the new organization. By default, it will default to the caller's organization.<br/>*required :*`id`
+`billingDay`<br/>*int* | The billing day of the organization. Must be between 1 and 28, the default value is 1.
 
 The responses' `data` field contains the created [organization](#administration-organizations) with its `id`.
 
@@ -237,6 +242,7 @@ Optional | &nbsp;
 `isDbAuthentication`<br/>*boolean* | Whether or not the organization supports database authentication.
 `isLdapAuthentication`<br/>*boolean* | Whether or not LDAP authentication is enabled on this organization.
 `customDomain`<br/>*[VerifiedDomain](#administration-get-verified-domains)* | An object describing a verified domain. Must have the `Organization: Manage reseller features` permission. <br/>*required* : `id`
+`billingDay`<br/>*int* | The billing day of the organization. Must be between 1 and 28, the default value is 1.
 
 The responses' `data` field contains the updated [organization](#administration-organizations).
 


### PR DESCRIPTION
### Fixes [MC-12698](https://cloud-ops.atlassian.net/browse/MC-12698)

#### Changes made
Move the billingDay field from the applied pricing to the organization entity.