### PR TITLE
MC-12730: Added listing and get of brandings and knowledge bases

### DIFF
--- a/source/includes/administration/_branding.md
+++ b/source/includes/administration/_branding.md
@@ -52,10 +52,10 @@ Attributes | &nbsp;
 ---------- | -----------
 `id`<br/>*UUID* | The id of the branding.
 `organization.id`<br/>*UUID* | The organization id that the branding is linked to.
-`defaultLanguage`<br/>*String* | The default language.
-`activeLanguages`<br/>*Array[String]* | List of the possible languages.
-`defaultTimezone`<br/>*String* | The default timezone.
-`applicationName`<br/>*String* | The application name displayed to the user.
+`defaultLanguage`<br/>*string* | The default language.
+`activeLanguages`<br/>*Array[string]* | List of the possible languages.
+`defaultTimezone`<br/>*string* | The default timezone.
+`applicationName`<br/>*string* | The application name displayed to the user.
 `factory`<br/>*boolean* | If the branding is the factory branding.
 `artifacts`<br/>*Array[Object]* | The list of artifacts linked to the branding. This includes the custom css, colours css, logos, favicons.
 `artifacts.id`<br/>*UUID* | The artifact id.
@@ -113,10 +113,10 @@ Attributes | &nbsp;
 ---------- | -----------
 `id`<br/>*UUID* | The id of the branding.
 `organization.id`<br/>*UUID* | The organization id that the branding is linked to.
-`defaultLanguage`<br/>*String* | The default language.
-`activeLanguages`<br/>*Array[String]* | List of the possible languages.
-`defaultTimezone`<br/>*String* | The default timezone.
-`applicationName`<br/>*String* | The application name displayed to the user.
+`defaultLanguage`<br/>*string* | The default language.
+`activeLanguages`<br/>*Array[string]* | List of the possible languages.
+`defaultTimezone`<br/>*string* | The default timezone.
+`applicationName`<br/>*string* | The application name displayed to the user.
 `factory`<br/>*boolean* | If the branding is the factory branding.
 `artifacts`<br/>*Array[Object]* | The list of artifacts linked to the branding. This includes the custom css, colours css, logos, favicons.
 `artifacts.id`<br/>*UUID* | The artifact id.

--- a/source/includes/administration/_branding.md
+++ b/source/includes/administration/_branding.md
@@ -42,11 +42,11 @@ curl "https://cloudmc_endpoint/rest/brandings" \
 }
 ```
 
-List the branding configured on the system.
+List the branding configured for the organization.
 
 Query Params | &nbsp;
 ---- | -----------
-`organization_id`<br/>*UUID* | Return only branding for the provided organization id. If not provided, will default to the user organization.
+`organization_id`<br/>*UUID* | Return only the branding for the provided organization id. If not provided, will default to the user's organization.
 
 Attributes | &nbsp;
 ---------- | -----------
@@ -57,7 +57,7 @@ Attributes | &nbsp;
 `defaultTimezone`<br/>*String* | The default timezone.
 `applicationName`<br/>*String* | The application name displayed to the user.
 `factory`<br/>*boolean* | If the branding is the factory branding.
-`artifacts`<br/>*Array[Object]* | The list of artifacts link to the branding. This includes the custom css, colours css, logos, favicons.
+`artifacts`<br/>*Array[Object]* | The list of artifacts linked to the branding. This includes the custom css, colours css, logos, favicons.
 `artifacts.id`<br/>*UUID* | The artifact id.
 `artifacts.name`<br/>*string* | The artifact name.
 `artifacts.mimeType`<br/>*string* | The mime type of the artifact.
@@ -118,7 +118,7 @@ Attributes | &nbsp;
 `defaultTimezone`<br/>*String* | The default timezone.
 `applicationName`<br/>*String* | The application name displayed to the user.
 `factory`<br/>*boolean* | If the branding is the factory branding.
-`artifacts`<br/>*Array[Object]* | The list of artifacts link to the branding. This includes the custom css, colours css, logos, favicons.
+`artifacts`<br/>*Array[Object]* | The list of artifacts linked to the branding. This includes the custom css, colours css, logos, favicons.
 `artifacts.id`<br/>*UUID* | The artifact id.
 `artifacts.name`<br/>*string* | The artifact name.
 `artifacts.mimeType`<br/>*string* | The mime type of the artifact.

--- a/source/includes/administration/_branding.md
+++ b/source/includes/administration/_branding.md
@@ -1,0 +1,128 @@
+## Branding
+Manage branding.
+
+<!-------------------- LIST BRANDINGS -------------------->
+### List brandings
+
+`GET /brandings`
+
+```shell
+# Retrieve branding
+curl "https://cloudmc_endpoint/rest/brandings" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "671f113c-dbbb-4478-be9c-90765b3259e5",
+      "factory": false,
+      "defaultLanguage": "en",
+      "organization": {
+        "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+      },
+      "activeLanguages": "en,fr,es",
+      "defaultTimezone": "America/Montreal",
+      "applicationName": "CloudMC application",
+      "artifacts": [
+        {
+          "createdAt": "2020-09-14T11:42:52.000Z",
+          "name": "android-chrome-144x144.png",
+          "id": "642c73cf-d675-4b6f-826b-72d1a240542e",
+          "mimeType": "image/png",
+          "type": "FAVICON",
+          "content": "iVBOR...kJggg==",
+          "updatedAt": "2020-09-14T11:42:52.000Z"
+        }
+      ]
+    }
+  ]
+}
+```
+
+List the branding configured on the system.
+
+Query Params | &nbsp;
+---- | -----------
+`organization_id`<br/>*UUID* | Return only branding for the provided organization id. If not provided, will default to the user organization.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the branding.
+`organization.id`<br/>*UUID* | The organization id that the branding is linked to.
+`defaultLanguage`<br/>*String* | The default language.
+`activeLanguages`<br/>*Array[String]* | List of the possible languages.
+`defaultTimezone`<br/>*String* | The default timezone.
+`applicationName`<br/>*String* | The application name displayed to the user.
+`factory`<br/>*boolean* | If the branding is the factory branding.
+`artifacts`<br/>*Array[Object]* | The list of artifacts link to the branding. This includes the custom css, colours css, logos, favicons.
+`artifacts.id`<br/>*UUID* | The artifact id.
+`artifacts.name`<br/>*string* | The artifact name.
+`artifacts.mimeType`<br/>*string* | The mime type of the artifact.
+`artifacts.type`<br/>*string* | The artifact type. The possibles values are: LOGO, LOGO_SQUARE, FAVICON, CUSTOM_CSS, COLORS.
+`artifacts.content`<br/>*string* | The artifact content.
+`artifacts.createdAt`<br/>*string* | The artifact creation date.
+`artifacts.updatedAt`<br/>*string* | The artifact update date.
+
+
+
+<!-------------------- GET BRANDING -------------------->
+
+### Retrieve branding
+
+`GET /brandings/:id`
+
+```shell
+# Retrieve knowledge base
+curl "https://cloudmc_endpoint/rest/brandings/671f113c-dbbb-4478-be9c-90765b3259e5" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "671f113c-dbbb-4478-be9c-90765b3259e5",
+    "factory": false,
+    "defaultLanguage": "en",
+    "organization": {
+      "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+    },
+    "activeLanguages": "en,fr,es",
+    "defaultTimezone": "America/Montreal",
+    "applicationName": "CloudMC application",
+    "artifacts": [
+      {
+        "createdAt": "2020-09-14T11:42:52.000Z",
+        "name": "android-chrome-144x144.png",
+        "id": "642c73cf-d675-4b6f-826b-72d1a240542e",
+        "mimeType": "image/png",
+        "type": "FAVICON",
+        "content": "iVBOR...kJggg==",
+        "updatedAt": "2020-09-14T11:42:52.000Z"
+      }
+    ]
+  }
+}
+```
+Retrieve the branding associated to the id.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the branding.
+`organization.id`<br/>*UUID* | The organization id that the branding is linked to.
+`defaultLanguage`<br/>*String* | The default language.
+`activeLanguages`<br/>*Array[String]* | List of the possible languages.
+`defaultTimezone`<br/>*String* | The default timezone.
+`applicationName`<br/>*String* | The application name displayed to the user.
+`factory`<br/>*boolean* | If the branding is the factory branding.
+`artifacts`<br/>*Array[Object]* | The list of artifacts link to the branding. This includes the custom css, colours css, logos, favicons.
+`artifacts.id`<br/>*UUID* | The artifact id.
+`artifacts.name`<br/>*string* | The artifact name.
+`artifacts.mimeType`<br/>*string* | The mime type of the artifact.
+`artifacts.type`<br/>*string* | The artifact type. The possibles values are: LOGO, LOGO_SQUARE, FAVICON, CUSTOM_CSS, COLORS.
+`artifacts.content`<br/>*string* | The artifact content.
+`artifacts.createdAt`<br/>*string* | The artifact creation date.
+`artifacts.updatedAt`<br/>*string* | The artifact update date.

--- a/source/includes/administration/_knowledge_base.md
+++ b/source/includes/administration/_knowledge_base.md
@@ -94,11 +94,11 @@ curl "https://cloudmc_endpoint/rest/content/kb" \
 }
 ```
 
-List the knowledge base configured on the system.
+List the knowledge base configured for the organization.
 
 Query Params | &nbsp;
 ---- | -----------
-`organization_id`<br/>*UUID* | Return only knowledge base for the provided organization id. If not provided, will default to the user organization.
+`organization_id`<br/>*UUID* | Return only the knowledge base for the provided organization id. If not provided, will default to the user's organization.
 
 Attributes | &nbsp;
 ---------- | -----------
@@ -122,7 +122,7 @@ Attributes | &nbsp;
 `categories.translations.id`<br/>*UUID* | The id of the translation.
 `categories.translations.language`<br/>*string* | The language of the translation.
 `categories.translations.text`<br/>*string* | The content of the translation.
-`categories.translations.type`<br/>*string* | The type of translation. Possible values are: title, body, description or url_slug.
+`categories.translations.type`<br/>*string* | The type of translation. Possible values are: title or url_slug.
 `categories.translations.version`<br/>*integer* | The version of the translation.
 `categories.articles`<br/>*Array[Object]* | The list of articles in the category.
 `categories.articles.id`<br/>*UUID* | The id of the article.
@@ -135,7 +135,7 @@ Attributes | &nbsp;
 `categories.articles.translations.id`<br/>*UUID* | The id of the translation.
 `categories.articles.translations.language`<br/>*string* | The language of the translation.
 `categories.articles.translations.text`<br/>*string* | The content of the translation.
-`categories.articles.translations.type`<br/>*string* | The type of translation. Possible values are: title, body, description or url_slug.
+`categories.articles.translations.type`<br/>*string* | The type of translation. Possible values are: title, body or url_slug.
 `categories.articles.translations.version`<br/>*integer* | The version of the translation.
 
 <!-------------------- GET KNOWLEDGE BASES -------------------->
@@ -253,7 +253,7 @@ Attributes | &nbsp;
 `categories.translations.id`<br/>*UUID* | The id of the translation.
 `categories.translations.language`<br/>*string* | The language of the translation.
 `categories.translations.text`<br/>*string* | The content of the translation.
-`categories.translations.type`<br/>*string* | The type of translation. Possible values are: title, body, description or url_slug.
+`categories.translations.type`<br/>*string* | The type of translation. Possible values are: title or url_slug.
 `categories.translations.version`<br/>*integer* | The version of the translation.
 `categories.articles`<br/>*Array[Object]* | The list of articles in the category.
 `categories.articles.id`<br/>*UUID* | The id of the article.
@@ -266,5 +266,5 @@ Attributes | &nbsp;
 `categories.articles.translations.id`<br/>*UUID* | The id of the translation.
 `categories.articles.translations.language`<br/>*string* | The language of the translation.
 `categories.articles.translations.text`<br/>*string* | The content of the translation.
-`categories.articles.translations.type`<br/>*string* | The type of translation. Possible values are: title, body, description or url_slug.
+`categories.articles.translations.type`<br/>*string* | The type of translation. Possible values are: title, body or url_slug.
 `categories.articles.translations.version`<br/>*integer* | The version of the translation.

--- a/source/includes/administration/_knowledge_base.md
+++ b/source/includes/administration/_knowledge_base.md
@@ -1,0 +1,270 @@
+## Knowledge Base
+Manage knowledge base.
+
+<!-------------------- LIST KNOWLEDGE BASES -------------------->
+### List knowledge base
+
+`GET /content/kb`
+
+```shell
+# Retrieve branding
+curl "https://cloudmc_endpoint/rest/content/kb" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "organizationId": "23910576-d29f-4c14-b663-31d728ff49a5",
+      "sources": [
+        {
+          "createdDate": "2020-07-27T15:46:58Z",
+          "lastSyncDate": "2020-09-24T15:54:32Z",
+          "id": "585bd805-5b85-44af-9800-a9e55b2f619c",
+          "branch": "master",
+          "url": "https://github.com/cloudops/cloudmc-standard-kb"
+        }
+      ],
+      "id": "1de30074-dac8-4c8b-8eda-585f9fad9c49",
+      "state": "READY",
+      "categories": [
+        {
+          "createdAt": "2020-07-27T15:46:59.000Z",
+          "featured": false,
+          "translations": [
+            {
+              "language": "en",
+              "id": "35b2b5e0-4944-4f92-9ddb-68eb980a31b2",
+              "text": "CloudStack Service",
+              "type": "title",
+              "version": 1
+            },
+            {
+              "language": "en",
+              "id": "27cb1d2d-d624-4fe7-b0d1-8677c5f3200a",
+              "text": "cloudstack-compute-service",
+              "type": "url_slug",
+              "version": 1
+            }
+          ],
+          "icon": "fa fa-cloud",
+          "rank": 2,
+          "id": "47789e16-ef75-4cf8-82f7-747098533e63",
+          "gitKey": "cloudstack-compute-service",
+          "articles": [
+            {
+              "createdAt": "2020-07-27T15:47:01.000Z",
+              "translations": [
+                {
+                  "language": "fr",
+                  "id": "83297d87-e984-42b8-9356-2edef188b6c5",
+                  "text": "Gestion des modèles",
+                  "type": "title",
+                  "version": 1
+                },
+                {
+                  "language": "fr",
+                  "id": "07bec89a-870e-4506-9d45-8ea977b2f9f2",
+                  "text": "gestion-des-modeles",
+                  "type": "url_slug",
+                  "version": 1
+                },
+                {
+                  "language": "fr",
+                  "id": "aa2deeee-39a6-40f8-886b-1779c8bdbfa0",
+                  "text": "\n\n### Créer un modèle à partir d'une instance existante...",
+                  "type": "body",
+                  "version": 2
+                }
+              ],
+              "rank": 9,
+              "id": "05353b4b-5675-4631-b91a-6872f385c3b5",
+              "published": true,
+              "gitKey": "cloudstack-compute-service/working-with-instance-templates",
+              "updatedAt": "2020-09-24T15:54:36.000Z"
+            }
+          ],
+          "updatedAt": "2020-09-24T15:54:34.000Z"
+        }
+      ]
+    }
+  ]
+}
+```
+
+List the knowledge base configured on the system.
+
+Query Params | &nbsp;
+---- | -----------
+`organization_id`<br/>*UUID* | Return only knowledge base for the provided organization id. If not provided, will default to the user organization.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the knowledge base.
+`organization.id`<br/>*UUID* | The organization id that the knowledge base is linked to.
+`state`<br/>*String* | The source state. Possible values:  IMPORTING, SYNCHING, READY, ERROR.
+`sources`<br/>*Array[Object]* | List of sources associated to the knowledge base
+`sources.id`<br/>*UUID* | The source id.
+`sources.url`<br/>*string* | The source URL.
+`sources.branch`<br/>*string* | The source branch.
+`sources.createdDate`<br/>*String* | The date the source was created.
+`sources.lastSyncDate`<br/>*String* | The last date the source was synchronized.
+`categories.id`<br/>*UUID* | The category id.
+`categories.gitKey`<br/>*string* | The category git key.
+`categories.rank`<br/>*integer* | The category rank.
+`categories.icon`<br/>*string* | The category icon.
+`categories.createdAt`<br/>*string* | The creation date.
+`categories.updatedAt`<br/>*string* | The update date.
+`categories.featured`<br/>*boolean* | If the category needs to be displayed.
+`categories.translations`<br/>*Array[Object]* | The translation objects for the category.
+`categories.translations.id`<br/>*UUID* | The id of the translation.
+`categories.translations.language`<br/>*string* | The language of the translation.
+`categories.translations.text`<br/>*string* | The content of the translation.
+`categories.translations.type`<br/>*string* | The type of translation. Possible values are: title, body, description or url_slug.
+`categories.translations.version`<br/>*integer* | The version of the translation.
+`categories.articles`<br/>*Array[Object]* | The list of articles in the category.
+`categories.articles.id`<br/>*UUID* | The id of the article.
+`categories.articles.published`<br/>*boolean* | If the article is published.
+`categories.articles.rank`<br/>*integer* | The article rank.
+`categories.articles.gitKey`<br/>*string* | The article git key.
+`categories.articles.createdAt`<br/>*string* | The creation date.
+`categories.articles.updatedAt`<br/>*string* | The update date.
+`categories.articles.translations`<br/>*Array[Object]* | The translation objects for the article.
+`categories.articles.translations.id`<br/>*UUID* | The id of the translation.
+`categories.articles.translations.language`<br/>*string* | The language of the translation.
+`categories.articles.translations.text`<br/>*string* | The content of the translation.
+`categories.articles.translations.type`<br/>*string* | The type of translation. Possible values are: title, body, description or url_slug.
+`categories.articles.translations.version`<br/>*integer* | The version of the translation.
+
+<!-------------------- GET KNOWLEDGE BASES -------------------->
+
+### Retrieve knowledge base
+
+`GET /content/kb/:id`
+
+```shell
+# Retrieve trial settings
+curl "https://cloudmc_endpoint/rest/content/kb/671f113c-dbbb-4478-be9c-90765b3259e5" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "organizationId": "23910576-d29f-4c14-b663-31d728ff49a5",
+    "sources": [
+      {
+        "createdDate": "2020-07-27T15:46:58Z",
+        "lastSyncDate": "2020-09-24T15:54:32Z",
+        "id": "585bd805-5b85-44af-9800-a9e55b2f619c",
+        "branch": "master",
+        "url": "https://github.com/cloudops/cloudmc-standard-kb"
+      }
+    ],
+    "id": "1de30074-dac8-4c8b-8eda-585f9fad9c49",
+    "state": "READY",
+    "categories": [
+      {
+        "createdAt": "2020-07-27T15:46:59.000Z",
+        "featured": false,
+        "translations": [
+          {
+           "language": "en",
+           "id": "35b2b5e0-4944-4f92-9ddb-68eb980a31b2",
+           "text": "CloudStack Service",
+           "type": "title",
+           "version": 1
+          },
+          {
+            "language": "en",
+            "id": "27cb1d2d-d624-4fe7-b0d1-8677c5f3200a",
+            "text": "cloudstack-compute-service",
+            "type": "url_slug",
+            "version": 1
+          }
+        ],
+        "icon": "fa fa-cloud",
+        "rank": 2,
+        "id": "47789e16-ef75-4cf8-82f7-747098533e63",
+        "gitKey": "cloudstack-compute-service",
+        "articles": [
+          {
+            "createdAt": "2020-07-27T15:47:01.000Z",
+            "translations": [
+              {
+                "language": "fr",
+                "id": "83297d87-e984-42b8-9356-2edef188b6c5",
+                "text": "Gestion des modèles",
+                "type": "title",
+                "version": 1
+              },
+              {
+                "language": "fr",
+                "id": "07bec89a-870e-4506-9d45-8ea977b2f9f2",
+                "text": "gestion-des-modeles",
+                "type": "url_slug",
+                "version": 1
+              },
+              {
+                "language": "fr",
+                "id": "aa2deeee-39a6-40f8-886b-1779c8bdbfa0",
+                "text": "\n\n### Créer un modèle à partir d'une instance existante...",
+                "type": "body",
+                "version": 2
+              }
+            ],
+            "rank": 9,
+            "id": "05353b4b-5675-4631-b91a-6872f385c3b5",
+            "published": true,
+            "gitKey": "cloudstack-compute-service/working-with-instance-templates",
+            "updatedAt": "2020-09-24T15:54:36.000Z"
+          }
+        ],
+        "updatedAt": "2020-09-24T15:54:34.000Z"
+      }
+    ]
+  }
+}
+```
+Retrieve the branding associated to the id.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the knowledge base.
+`organization.id`<br/>*UUID* | The organization id that the knowledge base is linked to.
+`state`<br/>*String* | The source state. Possible values:  IMPORTING, SYNCHING, READY, ERROR.
+`sources`<br/>*Array[Object]* | List of sources associated to the knowledge base
+`sources.id`<br/>*UUID* | The source id.
+`sources.url`<br/>*string* | The source URL.
+`sources.branch`<br/>*string* | The source branch.
+`sources.createdDate`<br/>*String* | The date the source was created.
+`sources.lastSyncDate`<br/>*String* | The last date the source was synchronized.
+`categories.id`<br/>*UUID* | The category id.
+`categories.gitKey`<br/>*string* | The category git key.
+`categories.rank`<br/>*integer* | The category rank.
+`categories.icon`<br/>*string* | The category icon.
+`categories.createdAt`<br/>*string* | The creation date.
+`categories.updatedAt`<br/>*string* | The update date.
+`categories.featured`<br/>*boolean* | If the category needs to be displayed.
+`categories.translations`<br/>*Array[Object]* | The translation objects for the category.
+`categories.translations.id`<br/>*UUID* | The id of the translation.
+`categories.translations.language`<br/>*string* | The language of the translation.
+`categories.translations.text`<br/>*string* | The content of the translation.
+`categories.translations.type`<br/>*string* | The type of translation. Possible values are: title, body, description or url_slug.
+`categories.translations.version`<br/>*integer* | The version of the translation.
+`categories.articles`<br/>*Array[Object]* | The list of articles in the category.
+`categories.articles.id`<br/>*UUID* | The id of the article.
+`categories.articles.published`<br/>*boolean* | If the article is published.
+`categories.articles.rank`<br/>*integer* | The article rank.
+`categories.articles.gitKey`<br/>*string* | The article git key.
+`categories.articles.createdAt`<br/>*string* | The creation date.
+`categories.articles.updatedAt`<br/>*string* | The update date.
+`categories.articles.translations`<br/>*Array[Object]* | The translation objects for the article.
+`categories.articles.translations.id`<br/>*UUID* | The id of the translation.
+`categories.articles.translations.language`<br/>*string* | The language of the translation.
+`categories.articles.translations.text`<br/>*string* | The content of the translation.
+`categories.articles.translations.type`<br/>*string* | The type of translation. Possible values are: title, body, description or url_slug.
+`categories.articles.translations.version`<br/>*integer* | The version of the translation.

--- a/source/includes/administration/_knowledge_base.md
+++ b/source/includes/administration/_knowledge_base.md
@@ -104,13 +104,13 @@ Attributes | &nbsp;
 ---------- | -----------
 `id`<br/>*UUID* | The id of the knowledge base.
 `organization.id`<br/>*UUID* | The organization id that the knowledge base is linked to.
-`state`<br/>*String* | The source state. Possible values:  IMPORTING, SYNCHING, READY, ERROR.
+`state`<br/>*string* | The source state. Possible values:  IMPORTING, SYNCHING, READY, ERROR.
 `sources`<br/>*Array[Object]* | List of sources associated to the knowledge base
 `sources.id`<br/>*UUID* | The source id.
 `sources.url`<br/>*string* | The source URL.
 `sources.branch`<br/>*string* | The source branch.
-`sources.createdDate`<br/>*String* | The date the source was created.
-`sources.lastSyncDate`<br/>*String* | The last date the source was synchronized.
+`sources.createdDate`<br/>*string* | The date the source was created.
+`sources.lastSyncDate`<br/>*string* | The last date the source was synchronized.
 `categories.id`<br/>*UUID* | The category id.
 `categories.gitKey`<br/>*string* | The category git key.
 `categories.rank`<br/>*integer* | The category rank.
@@ -235,13 +235,13 @@ Attributes | &nbsp;
 ---------- | -----------
 `id`<br/>*UUID* | The id of the knowledge base.
 `organization.id`<br/>*UUID* | The organization id that the knowledge base is linked to.
-`state`<br/>*String* | The source state. Possible values:  IMPORTING, SYNCHING, READY, ERROR.
+`state`<br/>*string* | The source state. Possible values:  IMPORTING, SYNCHING, READY, ERROR.
 `sources`<br/>*Array[Object]* | List of sources associated to the knowledge base
 `sources.id`<br/>*UUID* | The source id.
 `sources.url`<br/>*string* | The source URL.
 `sources.branch`<br/>*string* | The source branch.
-`sources.createdDate`<br/>*String* | The date the source was created.
-`sources.lastSyncDate`<br/>*String* | The last date the source was synchronized.
+`sources.createdDate`<br/>*string* | The date the source was created.
+`sources.lastSyncDate`<br/>*string* | The last date the source was synchronized.
 `categories.id`<br/>*UUID* | The category id.
 `categories.gitKey`<br/>*string* | The category git key.
 `categories.rank`<br/>*integer* | The category rank.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -23,6 +23,8 @@ includes:
   - administration/identity_providers
   - administration/service_providers
   - administration/saml_settings
+  - administration/branding
+  - administration/knowledge_base
   - administration/trials
   - cloudstack
   - cloudstack/compute # Compute section


### PR DESCRIPTION
### Fixes [MC-12730](https://cloud-ops.atlassian.net/browse/MC-12730)

#### Changes made
<!-- Changes should match the template provided below -->
- Added documentation for the branding list and get
- Added documentation for the knowledge base list and get

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->