### PR TITLE
MC-12789: Adapt chart and release docs to helmet changes (ksdk and k8-extension)

### DIFF
--- a/source/includes/administration/_identity_providers.md
+++ b/source/includes/administration/_identity_providers.md
@@ -61,7 +61,7 @@ Attributes | &nbsp;
 `id`<br/>*UUID* | The id of the identity provider.
 `provider`<br/>*string* | The name of the provider. Possible values include the default providers (e.g GOOGLE), or CUSTOM for a custom user-defined provider.
 `displayName`<br/>*string* | The display name of the identity provider that will appear on the login screen.
-`logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen.
+`logo`<br/>*string* | A base64 encoded data URL or URL to an image for the logo to display on the login screen.
 `css`<br/>*string* | Custom css for the login button of the identity provider.
 `identityProviderUsers`<br/>*Array* | A list of objects containing the ids of users associated with the identity provider, and their subject ids.
 `connectionName`<br/>*string* | The connection name of the identity provider.
@@ -145,7 +145,7 @@ Required | &nbsp;
 `provider`<br/>*string* | The name of the provider. Possible values include the default providers (e.g GOOGLE), or CUSTOM for a custom user-defined provider.
 `displayName`<br/>*string* | The display name of the identity provider that will appear on the login screen. If of a default provider type, this will be set with a default if not passed.
 `connectionName`<br/>*string* | The connection name of the identity provider. If of a default provider type, this will be set with a default if not passed.
-`logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
+`logo`<br/>*string* | A base64 encoded data URL or URL to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider. The issuerURL will be set if of a default provider type.
 `rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.
@@ -232,7 +232,7 @@ Required | &nbsp;
 `provider`<br/>*string* | The name of the provider. Possible values include the default providers (e.g GOOGLE), or CUSTOM for a custom user-defined provider.
 `displayName`<br/>*string* | The display name of the identity provider that will appear on the login screen. If of a default provider type, this will be set with a default if not passed.
 `connectionName`<br/>*string* | The connection name of the identity provider. If of a default provider type, this will be set with a default if not passed.
-`logo`<br/>*string* | A base64 encoded data url or url to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
+`logo`<br/>*string* | A base64 encoded data URL or URL to an image for the logo to display on the login screen. If of a default provider type, this will be set with a default if not passed.
 `type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
 `parameters`<br/>*Array* | A list of parameters associated with the identity provider. The issuerURL will be set if of a default provider type.
 `rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.

--- a/source/includes/kubernetes/_k8_charts.md
+++ b/source/includes/kubernetes/_k8_charts.md
@@ -62,7 +62,7 @@ Retrieve a list of all charts in a given [environment](#administration-environme
 | `license` <br/>_string_                            | The chart's license.                                                                                       |
 | `deprecated` <br/>_boolean_                        | True if the chart is deprecated.                                                                           |
 | `repository` <br/>_object_                         | The chart's parent repository.                                                                             |
-| `repoository.url` <br/>_string_                    | The repository url.                                                                                        |
+| `repoository.url` <br/>_string_                    | The repository URL.                                                                                        |
 | `repository.name` <br/>_string_                    | The repository name.                                                                                       |
 | `repository.kind` <br/>_integer_                   | The repository kind, where `{0: Helm chart, 1: Falco rule, 2: OPA policy, 3: OLM operator }`.              |
 | `repository.official` <br/>_boolean_               | True if it is an official repository. That is, if the publisher owns the software deployed by the package. |
@@ -165,7 +165,7 @@ Retrieve a specific chart in a given [environment](#administration-environments)
 | `license` <br/>_string_                            | The chart's license.                                                                                       |
 | `deprecated` <br/>_boolean_                        | True if the chart is deprecated.                                                                           |
 | `repository` <br/>_object_                         | The chart's parent repository.                                                                             |
-| `repoository.url` <br/>_string_                    | The repository url.                                                                                        |
+| `repoository.url` <br/>_string_                    | The repository URL.                                                                                        |
 | `repository.name` <br/>_string_                    | The repository name.                                                                                       |
 | `repository.kind` <br/>_integer_                   | The repository kind, where `{0: Helm chart, 1: Falco rule, 2: OPA policy, 3: OLM operator }`.              |
 | `repository.official` <br/>_boolean_               | True if it is an official repository. That is, if the publisher owns the software deployed by the package. |
@@ -218,13 +218,16 @@ curl --request POST \
 
 Install a chart in a given [environment](#administration-environments).
 
-| Attributes                      | &nbsp;                                                                           |
-|---------------------------------|----------------------------------------------------------------------------------|
-| `namespace` <br/>_string_       | The namespace in which the chart will be installed.                              |
-| `releaseName` <br/>_string_     | The desired release name.                                                        |
-| `name` <br/>_string_            | The chart name.                                                                  |
-| `version` <br/>_string_         | The chart version to be installed. Defaults to the latest version if left blank. |
-| `values` <br/>_string_          | The values to use to install the chart. It must be a valid Yaml format.          |
-| `repository` <br/>_object_      | The chart's parent repository from which it should be installed.                 |
-| `repoository.url` <br/>_string_ | The repository url.                                                              |
-| `insecureServer`<br/>_boolean_  | True if accessing the chart requires an unsecured connection.                    |
+| Required                        | &nbsp;                                                           |
+|---------------------------------|------------------------------------------------------------------|
+| `namespace` <br/>_string_       | The namespace in which the chart will be installed.              |
+| `releaseName` <br/>_string_     | The desired release name.                                        |
+| `name` <br/>_string_            | The chart name.                                                  |
+| `repository` <br/>_object_      | The chart's parent repository from which it should be installed. |
+| `repoository.url` <br/>_string_ | The repository URL.                                              |
+
+| Optional                       | &nbsp;                                                                                                                       |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `version` <br/>_string_        | The chart version to be installed. Defaults to the latest version if left blank.                                             |
+| `values` <br/>_string_         | The values used to install the chart. Must be a valid Yaml format. If not provided, the chart's default values will be used. |
+| `insecureServer`<br/>_boolean_ | True if accessing the chart requires an unsecured connection.                                                                |

--- a/source/includes/kubernetes/_k8_charts.md
+++ b/source/includes/kubernetes/_k8_charts.md
@@ -51,7 +51,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts</code>
 
-Retrieve a list of all charts in a given [environment](#administration-environments). To get more chart details, such as available versions, the chart's readme and list of maintainers, see <a href="#kubernetes-get-chart">Get chart</a>.
+Retrieve a list of all charts in a given [environment](#administration-environments). To get more chart details, such as available versions, the chart's readme and list of maintainers, see the GET request for an individual chart.
 
 | Attributes                                         | &nbsp;                                                                                                     |
 |----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
@@ -192,6 +192,7 @@ Retrieve a specific chart in a given [environment](#administration-environments)
 ```shell
 curl --request POST \
   --url https://cloudmc_endpoint/v1/services/a_service/an_environment/charts \
+  --header 'MC-Api-Key: your_api_key' \
   --data '{
 	"namespace": "my-namespace",
 	"releaseName": "my-aerospike",

--- a/source/includes/kubernetes/_k8_charts.md
+++ b/source/includes/kubernetes/_k8_charts.md
@@ -16,86 +16,67 @@ curl -X GET \
 {
   "data": [
     {
-      "id": "stable/aerospike",
-      "type": "chart",
-      "attributes": {
-        "name": "aerospike",
-        "repo": {
-          "name": "stable",
-          "url": "https://kubernetes-charts.storage.googleapis.com"
-        },
-        "repoUrl": "https://hub.helm.sh/api/chartsvc",
-        "description": "A Helm chart for Aerospike in Kubernetes",
-        "home": "http://aerospike.com",
-        "keywords": ["aerospike", "big-data"],
-        "maintainers": [
-          {
-            "name": "kavehmz",
-            "email": "kavehmz@gmail.com"
-          },
-          {
-            "name": "okgolove",
-            "email": "okgolove@markeloff.net"
-          }
-        ],
-        "sources": ["https://github.com/aerospike/aerospike-server"],
-        "icon": "/v1/assets/stable/aerospike/logo"
+      "id": "helm-stable/aerospike",
+      "name": "aerospike",
+      "description": "A Helm chart for Aerospike in Kubernetes",
+      "version": "0.3.3",
+      "license": "",
+      "deprecated": false,
+      "repository": {
+        "url": "https://kubernetes-charts.storage.googleapis.com",
+        "name": "helm-stable",
+        "kind": 0,
+        "official": false,
+        "displayName": "Stable",
+        "repositoryId": "3cc327ae-9403-4521-9b71-f9a41d5f86c8",
+        "organizationName": "helm",
+        "verifiedPublisher": false,
+        "organizationDisplayName": "Helm"
       },
-      "links": {
-        "self": "/v1/charts/stable/aerospike"
-      },
-      "relationships": {
-        "latestChartVersion": {
-          "data": {
-            "version": "0.3.2",
-            "digest": "97cfd56a20129d65b30de9d77267bf30f7b5f2d28565285282e16b26678a4ce3",
-            "urls": [
-              "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
-            ],
-            "readme": "/v1/assets/stable/aerospike/versions/0.3.2/README.md",
-            "values": "/v1/assets/stable/aerospike/versions/0.3.2/values.yaml"
-          },
-          "links": {
-            "self": "/v1/charts/stable/aerospike/versions/0.3.2"
-          }
-        }
-      },
-      "insecureServer": false
+      "packageId": "c4b6ad70-898d-4093-bec8-089d5f48daeb",
+      "displayName": "",
+      "normalizedName": "aerospike",
+      "appVersion": "v4.5.0.5",
+      "logoImageId": "50bcf132-ff98-4f9a-9e6a-0c0b06649e48",
+      "logoImageUrl": "https://artifacthub.io/image/50bcf132-ff98-4f9a-9e6a-0c0b06649e48"
     }
   ],
   "metadata": {
-    "recordCount": 1
+    "pageSize": 50,
+    "pageCurrent": 1,
+    "recordCount": 148
   }
 }
 ```
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts</code>
 
-Retrieve a list of all charts in a given [environment](#administration-environments).
+Retrieve a list of all charts in a given [environment](#administration-environments). To get more chart details, such as available versions, the chart's readme and list of maintainers, see <a href="#kubernetes-get-chart">Get chart</a>.
 
-| Attributes                                                    | &nbsp;                                                             |
-| ------------------------------------------------------------- | ------------------------------------------------------------------ |
-| `id` <br/>_string_                                            | The id for the chart.                                              |
-| `type` <br/>_string_                                          | The type of chart                                                  |
-| `attributes` <br/>_object_                                    | The annotations of the pod                                         |
-| `attributes.name` <br/>_string_                               | The name of the chart                                              |
-| `attributes.repo` <br/>_map_                                  | The repository information where this chart was fetched (name,url) |
-| `attributes.repoUrl` <br/>_string_                            | The url of the source of the chart                                 |
-| `attributes.description` <br/>_string_                        | The chart description                                              |
-| `attributes.home` <br/>_string_                               | The home url for the chart                                         |
-| `attributes.keywords` <br/>_string_                           | The keywords linked to the chart                                   |
-| `attributes.maintainers` <br/>_object_                        | The maintainers of the charts and their information                |
-| `attributes.sources` <br/>_list_                              | The sources for the chart                                          |
-| `attributes.icon` <br/>_string_                               | The icon for the chart                                             |
-| `relationships` <br/>_objection_                              | The relationship information for the chart                         |
-| `relationships.latestChartVersion` <br/>_object_              | The lastest version chart information                              |
-| `relationships.latestChartVersion.data.version` <br/>_string_ | The digest validating the chart                                    |
-| `relationships.latestChartVersion.data.digest` <br/>_string_  | The name of the chart                                              |
-| `relationships.latestChartVersion.data.urls` <br/>_string_    | The URLs for the package to download                               |
-| `relationships.latestChartVersion.data.readme` <br/>_string_  | The readme file location                                           |
-| `relationships.latestChartVersion.data.values` <br/>_string_  | The values file location                                           |
-| `version`<br/>_string_                                        | The revision of the release                                        |
-| `insecureServer`<br/>_boolean_                                | Specify if to access the chart we need an unsecure connection      |
+| Attributes                                         | &nbsp;                                                                                                     |
+|----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `id` <br/>_string_                                 | The id for the chart, of the form `repositoryName/chartName`.                                              |
+| `name` <br/>_st                                    | The chart name.                                                                                            |
+| `description` <br/>_string_                        | The chart description.                                                                                     |
+| `version` <br/>_string_                            | The latest chart version.                                                                                  |
+| `license` <br/>_string_                            | The chart's license.                                                                                       |
+| `deprecated` <br/>_boolean_                        | True if the chart is deprecated.                                                                           |
+| `repository` <br/>_object_                         | The chart's parent repository.                                                                             |
+| `repoository.url` <br/>_string_                    | The repository url.                                                                                        |
+| `repository.name` <br/>_string_                    | The repository name.                                                                                       |
+| `repository.kind` <br/>_integer_                   | The repository kind, where `{0: Helm chart, 1: Falco rule, 2: OPA policy, 3: OLM operator }`.              |
+| `repository.official` <br/>_boolean_               | True if it is an official repository. That is, if the publisher owns the software deployed by the package. |
+| `repository.displayName` <br/>_string_             | The repository's display name.                                                                             |
+| `repository.repositoryId` <br/>_UUID_              | The UUID of the repository.                                                                                |
+| `repository.organizationName` <br/>_string_        | The name of the organization that owns the repository.                                                     |
+| `repository.organizationDisplayName` <br/>_string_ | The display name of the organization that owns the repository.                                             |
+| `repository.verifiedPublisher` <br/>_boolean_      | True if the publisher owns the repository.                                                                 |
+| `packageId` <br/>_UUID_                            | The UUID of the package, given by ArtifactHub.                                                             |
+| `displayName` <br/>_string_                        | The chart's display name.                                                                                  |
+| `normalizedName` <br/>_string_                     | The chart's normalized name.                                                                               |
+| `appVersion` <br/>_string_                         | The chart's app version.                                                                                   |
+| `logoImageId` <br/>_UUID_                          | The UUID of the package's logo, given by ArtifactHub.                                                      |
+| `logoImageUrl` <br/>_string_                       | The URL for the chart's logo.                                                                              |
 
 <!-------------------- GET CHART -------------------->
 
@@ -104,7 +85,7 @@ Retrieve a list of all charts in a given [environment](#administration-environme
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/charts/stable/aerospike"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/charts/k8s-at-home/cloudflare-dyndns"
 ```
 
 > The above command returns a JSON structured like this:
@@ -112,51 +93,61 @@ curl -X GET \
 ```json
 {
   "data": {
-    "id": "stable/aerospike",
-    "type": "chart",
-    "attributes": {
-      "name": "aerospike",
-      "repo": {
-        "name": "stable",
-        "url": "https://kubernetes-charts.storage.googleapis.com"
-      },
-      "repoUrl": "https://hub.helm.sh/api/chartsvc",
-      "description": "A Helm chart for Aerospike in Kubernetes",
-      "home": "http://aerospike.com",
-      "keywords": ["aerospike", "big-data"],
-      "maintainers": [
-        {
-          "name": "kavehmz",
-          "email": "kavehmz@gmail.com"
-        },
-        {
-          "name": "okgolove",
-          "email": "okgolove@markeloff.net"
-        }
-      ],
-      "sources": ["https://github.com/aerospike/aerospike-server"],
-      "icon": "/v1/assets/stable/aerospike/logo"
-    },
-    "links": {
-      "self": "/v1/charts/stable/aerospike"
-    },
-    "relationships": {
-      "latestChartVersion": {
-        "data": {
-          "version": "0.3.2",
-          "digest": "97cfd56a20129d65b30de9d77267bf30f7b5f2d28565285282e16b26678a4ce3",
-          "urls": [
-            "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
-          ],
-          "readme": "/v1/assets/stable/aerospike/versions/0.3.2/README.md",
-          "values": "/v1/assets/stable/aerospike/versions/0.3.2/values.yaml"
-        },
-        "links": {
-          "self": "/v1/charts/stable/aerospike/versions/0.3.2"
-        }
+    "keywords": [
+      "cloudflare",
+      "dynamicdns"
+    ],
+    "maintainers": [
+      {
+        "name": "billimek",
+        "email": "jeff@billimek.com"
       }
+    ],
+    "links": [
+      {
+        "url": "https://github.com/hotio/docker-cloudflare-ddns/",
+        "name": "source"
+      },
+      {
+        "url": "https://github.com/billimek/billimek-charts",
+        "name": "source"
+      }
+    ],
+    "homeUrl": "https://github.com/billimek/billimek-charts/tree/master/charts/cloudflare-dyndns",
+    "availableVersions": [
+      {
+        "version": "1.0.0",
+        "createdAt": 1576998322
+      },
+      {
+        "version": "2.0.0",
+        "createdAt": 1578688072
+      }
+    ],
+    "readMe": "# Dynamic DNS using Cloudflare's DNS Services\n...",
+    "id": "k8s-at-home/cloudflare-dyndns",
+    "name": "cloudflare-dyndns",
+    "description": "Dynamic DNS using Cloudflare's DNS Services",
+    "version": "2.0.0",
+    "license": "",
+    "deprecated": false,
+    "repository": {
+      "url": "https://k8s-at-home.com/charts/",
+      "name": "k8s-at-home",
+      "kind": 0,
+      "official": false,
+      "displayName": "charts",
+      "repositoryId": "9b40a3b3-ed2a-405f-8919-3b824d4f661d",
+      "organizationName": "k8s-at-home",
+      "verifiedPublisher": true,
+      "organizationDisplayName": "k8s@home"
     },
-    "insecureServer": false
+    "packageId": "a6cd6148-977a-4852-8761-80234f39d90b",
+    "displayName": "",
+    "normalizedName": "cloudflare-dyndns",
+    "appVersion": "1.0",
+    "logoImageId": "3a0eac41-21b4-4a1b-b127-c7e70123eda8",
+    "logoImageUrl": "https://artifacthub.io/image/3a0eac41-21b4-4a1b-b127-c7e70123eda8"
   }
 }
 ```
@@ -165,57 +156,60 @@ curl -X GET \
 
 Retrieve a specific chart in a given [environment](#administration-environments).
 
-| Attributes                                                    | &nbsp;                                                             |
-| ------------------------------------------------------------- | ------------------------------------------------------------------ |
-| `id` <br/>_string_                                            | The id for the chart.                                              |
-| `type` <br/>_string_                                          | The type of chart                                                  |
-| `attributes` <br/>_object_                                    | The annotations of the pod                                         |
-| `attributes.name` <br/>_string_                               | The name of the chart                                              |
-| `attributes.repo` <br/>_map_                                  | The repository information where this chart was fetched (name,url) |
-| `attributes.repoUrl` <br/>_string_                            | The url of the source of the chart                                 |
-| `attributes.description` <br/>_string_                        | The chart description                                              |
-| `attributes.home` <br/>_string_                               | The home url for the chart                                         |
-| `attributes.keywords` <br/>_string_                           | The keywords linked to the chart                                   |
-| `attributes.maintainers` <br/>_object_                        | The maintainers of the charts and their information                |
-| `attributes.sources` <br/>_list_                              | The sources for the chart                                          |
-| `attributes.icon` <br/>_string_                               | The icon for the chart                                             |
-| `relationships` <br/>_objection_                              | The relationship information for the chart                         |
-| `relationships.latestChartVersion` <br/>_object_              | The lastest version chart information                              |
-| `relationships.latestChartVersion.data.version` <br/>_string_ | The digest validating the chart                                    |
-| `relationships.latestChartVersion.data.digest` <br/>_string_  | The name of the chart                                              |
-| `relationships.latestChartVersion.data.urls` <br/>_string_    | The URLs for the package to download                               |
-| `relationships.latestChartVersion.data.readme` <br/>_string_  | The readme file location                                           |
-| `relationships.latestChartVersion.data.values` <br/>_string_  | The values file location                                           |
-| `version`<br/>_string_                                        | The revision of the release                                        |
-| `insecureServer`<br/>_boolean_                                | Specify if to access the chart we need an unsecure connection      |
+| Attributes                                         | &nbsp;                                                                                                     |
+|----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `id` <br/>_string_                                 | The id for the chart, of the form `repositoryName/chartName`.                                              |
+| `name` <br/>_st                                    | The chart name.                                                                                            |
+| `description` <br/>_string_                        | The chart description.                                                                                     |
+| `version` <br/>_string_                            | The latest chart version.                                                                                  |
+| `license` <br/>_string_                            | The chart's license.                                                                                       |
+| `deprecated` <br/>_boolean_                        | True if the chart is deprecated.                                                                           |
+| `repository` <br/>_object_                         | The chart's parent repository.                                                                             |
+| `repoository.url` <br/>_string_                    | The repository url.                                                                                        |
+| `repository.name` <br/>_string_                    | The repository name.                                                                                       |
+| `repository.kind` <br/>_integer_                   | The repository kind, where `{0: Helm chart, 1: Falco rule, 2: OPA policy, 3: OLM operator }`.              |
+| `repository.official` <br/>_boolean_               | True if it is an official repository. That is, if the publisher owns the software deployed by the package. |
+| `repository.displayName` <br/>_string_             | The repository's display name.                                                                             |
+| `repository.repositoryId` <br/>_UUID_              | The UUID of the repository.                                                                                |
+| `repository.organizationName` <br/>_string_        | The name of the organization that owns the repository.                                                     |
+| `repository.organizationDisplayName` <br/>_string_ | The display name of the organization that owns the repository.                                             |
+| `repository.verifiedPublisher` <br/>_boolean_      | True if the publisher owns the repository.                                                                 |
+| `packageId` <br/>_UUID_                            | The UUID of the package, given by ArtifactHub.                                                             |
+| `displayName` <br/>_string_                        | The chart's display name.                                                                                  |
+| `normalizedName` <br/>_string_                     | The chart's normalized name.                                                                               |
+| `appVersion` <br/>_string_                         | The chart's app version.                                                                                   |
+| `logoImageId` <br/>_UUID_                          | The UUID of the package's logo, given by ArtifactHub.                                                      |
+| `logoImageUrl` <br/>_string_                       | The URL for the chart's logo.                                                                              |
+| `keywords` <br/>_Array[string]_                    | The chart's keywords.                                                                                      |
+| `maintainers` <br/>_Array[Object]_                 | The names and emails of chart maintainers.                                                                 |
+| `homeUrl` <br/>_Array[Object]_                     | The chart's home URL.                                                                                      |
+| `availableVersions` <br/>_Array[Object]_           | The available chart versions and their created dates.                                                      |
 
 <!-------------------- INSTALL CHART -------------------->
 
 ### Install chart
 
 ```shell
-curl -X POST \
-   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/charts"
+curl --request POST \
+  --url https://cloudmc_endpoint/v1/services/a_service/an_environment/charts \
+  --data '{
+	"namespace": "my-namespace",
+	"releaseName": "my-aerospike",
+	"name": "aerospike",
+	"version": "5.0.0",
+  "values": ""
+	"repository": {
+		"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
+	}
+}'
 ```
 
 > The above command returns a JSON structured like this:
 
 ```json
 {
-  "relationships": {
-    "latestChartVersion": {
-      "data": {
-        "urls": [
-          "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
-        ]
-      }
-    }
-  },
-  "insecureServer": false,
-  "passedValues": "# Default values for aerospike.\nterminationGracePeriodSeconds: 30\nreplicaCount: 1\nnodeSelector: {}\nimage:\n  repository: aerospike/aerospike-server\n  tag: 4.5.0.5\n  pullPolicy: IfNotPresent\n\n# pass custom command. This is equivalent of Entrypoint in docker\ncommand: []\n\n# pass custom args. This is equivalent of Cmd in docker\nargs: []\n\n# Set as empty object {} if no volumes need to be created\n# See confFile below\npersistentVolume: {}\n  # - mountPath: /opt/aerospike/data\n  #   name: aerospike-data\n  #   template:\n  #     accessModes: [ \"ReadWriteOnce\" ]\n  #     # storageClassName:  \"standard\"\n  #     resources:\n  #       requests:\n  #         storage: \"36G\"\n  #     selector:\n  #       matchLabels:\n  #         diskname: \"aerospike-data\"\n\nservice:\n  type: ClusterIP\n  # Provide any additional annotations which may be required.\n  # The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart\n  annotations: {}\n  loadBalancerIP:\n  clusterIP: None\n  # This field takes a list of IP CIDR ranges, which Kubernetes will use to configure firewall exceptions\n  # loadBalancerSourceRanges:\n  # - 10.0.0.0/8\n  nodePort: {}\n\n# turns on a sidecar that scrapes 'localhost:3000' and exposes to port 9134\n# a docker image built from this repo works well: https://github.com/alicebob/asprom\n# but you will need to build/host it yourself\nmetrics:\n  serviceMonitor: {}\n\nlabels: {}\nannotations: {}\n\ntolerations: []\n\nresources: {}\n  # We usually recommend not to specify default resources and to leave this as a conscious\n  # choice for the user. This also increases chances charts run on environments with little\n  # resources, such as Minikube. If you do want to specify resources, uncomment the following\n  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.\n  # limits:\n  #  cpu: 100m\n  #  memory: 128Mi\n  # requests:\n  #  cpu: 100m\n  #  memory: 128Mi\n\nconfFile: |-\n  #default config file\n  service {\n      user root\n      group root\n      paxos-protocol v5\n      paxos-single-replica-limit 1\n      pidfile /var/run/aerospike/asd.pid\n      service-threads 4\n      transaction-queues 4\n      transaction-threads-per-queue 4\n      proto-fd-max 15000\n  }\n\n  logging {\n      file /var/log/aerospike/aerospike.log {\n          context any info\n      }\n\n      console {\n          context any info\n      }\n  }\n\n  network {\n      service {\n          address any\n          port 3000\n      }\n\n      heartbeat {\n          address any\n          interval 150\n          #REPLACE_THIS_LINE_WITH_MESH_CONFIG\n          mode mesh\n          port 3002\n          timeout 20\n          protocol v3\n      }\n\n      fabric {\n          port 3001\n      }\n\n      info {\n          port 3003\n      }\n  }\n\n  namespace test {\n      replication-factor 2\n      memory-size 1G\n      default-ttl 5d\n      storage-engine device {\n          file /opt/aerospike/data/test.dat\n          filesize 4G\n      }\n  }\n",
-  "namespace": "default",
-  "releaseName": "test1"
+  "taskId": "ef70cafa-0544-4709-a66a-c68595ee105a",
+  "taskStatus": "SUCCESS"
 }
 ```
 
@@ -223,12 +217,13 @@ curl -X POST \
 
 Install a chart in a given [environment](#administration-environments).
 
-| Attributes                                                 | &nbsp;                                                                 |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `relationships` <br/>_objection_                           | The relationship information for the chart                             |
-| `relationships.latestChartVersion` <br/>_object_           | The lastest version chart information                                  |
-| `relationships.latestChartVersion.data.urls` <br/>_string_ | The URLs for the package to download                                   |
-| `insecureServer`<br/>_boolean_                             | Specify if to access the chart we need an unsecure connection          |
-| `passedValues` <br/>_string_                               | The values to use to install the chart. It must be a valid Yaml format |
-| `namespace` <br/>_map_                                     | The namespace in which the chart will be installed                     |
-| `releaseName` <br/>_string_                                | The name under which the chart will be known.                          |
+| Attributes                      | &nbsp;                                                                           |
+|---------------------------------|----------------------------------------------------------------------------------|
+| `namespace` <br/>_string_       | The namespace in which the chart will be installed.                              |
+| `releaseName` <br/>_string_     | The desired release name.                                                        |
+| `name` <br/>_string_            | The chart name.                                                                  |
+| `version` <br/>_string_         | The chart version to be installed. Defaults to the latest version if left blank. |
+| `values` <br/>_string_          | The values to use to install the chart. It must be a valid Yaml format.          |
+| `repository` <br/>_object_      | The chart's parent repository from which it should be installed.                 |
+| `repoository.url` <br/>_string_ | The repository url.                                                              |
+| `insecureServer`<br/>_boolean_  | True if accessing the chart requires an unsecured connection.                    |

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -16,68 +16,90 @@ curl -X GET \
 {
   "data": [
     {
-      "name": "my-aerospike",
+      "id": "my-namespace/my-cloudflare",
+      "name": "my-cloudflare",
       "info": {
-        "first_deployed": "2020-01-20T09:35:02.267449-05:00",
-        "last_deployed": "2020-01-20T09:35:02.267449-05:00",
+        "first_deployed": "2020-11-03T09:48:49.301166-05:00",
+        "last_deployed": "2020-11-05T11:24:37.096888-05:00",
         "deleted": "",
-        "description": "Install complete",
+        "description": "Upgrade complete",
         "status": "installed",
-        "notes": "The Aerospike can be accessed via port 3000 on the following DNS name from within your cluster:\n\n  my-aerospike.default.svc.cluster.local\n\nYou can connect to aeropike in your local machine using port-forwarding:\n\n  export POD_NAME=$(kubectl get pods --namespace default -l \"app=aerospike,release=my-aerospike\" -o jsonpath=\"{.items[0].metadata.name}\")\n  kubectl  --namespace default port-forward $POD_NAME 3000:3000\n"
+        "notes": "You can connect to the container running cloudflare-dyndns. To open a shell session in the pod run the following:\n\n- kubectl exec -i -t --namespace my-namespace $(kubectl get pods --namespace my-namespace -l app=my-cloudflare-cloudflare-dyndns -o jsonpath='{.items[0].metadata.name}') /bin/sh\n\nTo trail the logs for the cloudflare-dyndns pod run the following:\n\n- kubectl logs -f --namespace my-namespace $(kubectl get pods --namespace my-namespace -l app=my-cloudflare-cloudflare-dyndns -o jsonpath='{ .items[0].metadata.name }')"
       },
       "chart": {
         "metadata": {
-          "name": "aerospike",
-          "home": "http://aerospike.com",
-          "sources": ["https://github.com/aerospike/aerospike-server"],
-          "version": "0.3.2",
-          "description": "A Helm chart for Aerospike in Kubernetes",
-          "keywords": ["aerospike", "big-data"],
+          "name": "cloudflare-dyndns",
+          "home": "https://github.com/billimek/billimek-charts/tree/master/charts/cloudflare-dyndns",
+          "sources": [
+            "https://github.com/hotio/docker-cloudflare-ddns/",
+            "https://github.com/billimek/billimek-charts"
+          ],
+          "version": "2.0.0",
+          "description": "Dynamic DNS using Cloudflare's DNS Services",
+          "keywords": [
+            "cloudflare",
+            "dynamicdns"
+          ],
           "maintainers": [
             {
-              "name": "kavehmz",
-              "email": "kavehmz@gmail.com"
-            },
-            {
-              "name": "okgolove",
-              "email": "okgolove@markeloff.net"
+              "name": "billimek",
+              "email": "jeff@billimek.com"
             }
           ],
-          "icon": "https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png",
+          "icon": "https://www.cloudflare.com/img/cf-facebook-card.png",
           "apiVersion": "v1",
-          "appVersion": "v4.5.0.5",
+          "appVersion": "1.0",
           "deprecated": false
         },
         "values": {
-          "annotations": {},
-          "args": [],
-          "command": [],
-          "confFile": "#default config file\nservice {\n    user root\n    group root\n    paxos-protocol v5\n    paxos-single-replica-limit 1\n    pidfile /var/run/aerospike/asd.pid\n    service-threads 4\n    transaction-queues 4\n    transaction-threads-per-queue 4\n    proto-fd-max 15000\n}\n\nlogging {\n    file /var/log/aerospike/aerospike.log {\n        context any info\n    }\n\n    console {\n        context any info\n    }\n}\n\nnetwork {\n    service {\n        address any\n        port 3000\n    }\n\n    heartbeat {\n        address any\n        interval 150\n        #REPLACE_THIS_LINE_WITH_MESH_CONFIG\n        mode mesh\n        port 3002\n        timeout 20\n        protocol v3\n    }\n\n    fabric {\n        port 3001\n    }\n\n    info {\n        port 3003\n    }\n}\n\nnamespace test {\n    replication-factor 2\n    memory-size 1G\n    default-ttl 5d\n    storage-engine device {\n        file /opt/aerospike/data/test.dat\n        filesize 4G\n    }\n}",
-          "image": {
-            "pullPolicy": "IfNotPresent",
-            "repository": "aerospike/aerospike-server",
-            "tag": "4.5.0.5"
+          "affinity": {},
+          "cloudflare": {
+            "detection_mode": "dig-google.com",
+            "hosts": "somehosts",
+            "log_level": 1.0,
+            "record_types": "somerecordtypes",
+            "sleep_interval": 300.0,
+            "token": "sometoken",
+            "user": "someuser",
+            "zones": "somezones"
           },
-          "labels": {},
-          "metrics": {
-            "serviceMonitor": {}
+          "image": {
+            "pullPolicy": "Always",
+            "repository": "hotio/cloudflare-ddns",
+            "tag": "latest"
           },
           "nodeSelector": {},
-          "persistentVolume": {},
           "replicaCount": 1.0,
           "resources": {},
-          "service": {
-            "annotations": {},
-            "clusterIP": "None",
-            "nodePort": {},
-            "type": "ClusterIP"
-          },
-          "terminationGracePeriodSeconds": 30.0,
           "tolerations": []
         }
       },
-      "version": 1,
-      "namespace": "default"
+      "config": {
+        "affinity": {},
+        "cloudflare": {
+          "detection_mode": "dig-google.com",
+          "hosts": "somehosts",
+          "log_level": 1.0,
+          "record_types": "somerecordtypes",
+          "sleep_interval": 300.0,
+          "token": "sometoken",
+          "user": "someuser",
+          "zones": "somezones"
+        },
+        "image": {
+          "pullPolicy": "Always",
+          "repository": "hotio/cloudflare-ddns",
+          "tag": "latest"
+        },
+        "nodeSelector": {},
+        "replicaCount": 1.0,
+        "resources": {},
+        "tolerations": []
+      },
+      "version": 10,
+      "namespace": "my-namespace",
+      "keepHistory": false,
+      "chartVersion": "cloudflare-dyndns / 2.0.0"
     }
   ],
   "metadata": {
@@ -85,7 +107,6 @@ curl -X GET \
   }
 }
 ```
-
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases</code>
 
 Or
@@ -99,31 +120,32 @@ Retrieve a list of all releases in a given [environment](#administration-environ
 | `namespace` <br/>_string_ | The namespace to list the release. This needs the exact value. |
 
 | Attributes                                 | &nbsp;                                                                                                                                                               |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id` <br/>_string_                         | The release id, of the form `namespace/releaseName`. |
 | `name` <br/>_string_                       | The name of the release.                                                                                                                                             |
-| `info` <br/>_object_                       | The information about the release                                                                                                                                    |
-| `info.first_deployed` <br/>_string_        | The annotations of the pod                                                                                                                                           |
-| `info.last_deployed` <br/>_string_         | The date of creation of the pod as a string                                                                                                                          |
-| `info.deleted` <br/>_string_               | The labels associated to the pod                                                                                                                                     |
-| `info.description` <br/>_string_           | The name of the pod                                                                                                                                                  |
-| `info.status` <br/>_string_                | The status of the release. Possible values are unknown, installed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade, pending-rollback |
-| `info.notes` <br/>_string_                 | The notes linked to the release                                                                                                                                      |
-| `chart`<br/>_object_                       | The information related to the chart of used in the release                                                                                                          |
-| `chart.version` <br/>_string_              | The version of the chart                                                                                                                                             |
-| `chart.metadata` <br/>_object_             | The metadata associated to the chart                                                                                                                                 |
-| `chart.metadata.name` <br/>_string_        | The name of the chart                                                                                                                                                |
-| `chart.metadata.home` <br/>_string_        | The home URL for the chart                                                                                                                                           |
-| `chart.metadata.sources` <br/>_list_       | The list of source of the charts                                                                                                                                     |
-| `chart.metadata.version` <br/>_string_     | The version of the chart                                                                                                                                             |
-| `chart.metadata.description` <br/>_string_ | The description of the chart                                                                                                                                         |
-| `chart.metadata.keywords` <br/>_list_      | The list of keywords linked to the chart                                                                                                                             |
-| `chart.metadata.maintainers` <br/>_list_   | The list of the maintainer contact information                                                                                                                       |
-| `chart.metadata.icon` <br/>_string_        | The icon URL for the chart                                                                                                                                           |
-| `chart.metadata.appVersion` <br/>_string_  | The version of the application                                                                                                                                       |
-| `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application                                                                                                                 |
-| `values` <br/>_object_                     | All values that were used to install the release                                                                                                                     |
-| `version`<br/>_string_                     | The revision of the release                                                                                                                                          |
-| `namespace`<br/>_string_                   | The namespace to which the release is installed                                                                                                                      |
+| `info` <br/>_object_                       | The information about the release.                                                                                                                                    |
+| `info.first_deployed` <br/>_string_        | The annotations of the pod.                                                                                                                                           |
+| `info.last_deployed` <br/>_string_         | The date of creation of the pod as a string.                                                                                                                          |
+| `info.deleted` <br/>_string_               | The labels associated to the pod.                                                                                                                                     |
+| `info.description` <br/>_string_           | The name of the pod.                                                                                                                                                  |
+| `info.status` <br/>_string_                | The status of the release. Possible values are `unknown`, `installed`, `uninstalled`, `superseded`, `failed`, `uninstalling`, `pending-install`, `pending-upgrade`, `pending-rollback`. |
+| `info.notes` <br/>_string_                 | The notes linked to the release.                                                                                                                                      |
+| `chart`<br/>_object_                       | The information related to the chart of used in the release.                                                                                                          |
+| `chart.version` <br/>_string_              | The version of the chart.                                                                                                                                             |
+| `chart.metadata` <br/>_object_             | The metadata associated to the chart.                                                                                                                                 |
+| `chart.metadata.name` <br/>_string_        | The name of the chart.                                                                                                                                                |
+| `chart.metadata.home` <br/>_string_        | The home URL for the chart.                                                                                                                                           |
+| `chart.metadata.sources` <br/>_list_       | The list of source of the charts.                                                                                                                                     |
+| `chart.metadata.version` <br/>_string_     | The version of the chart.                                                                                                                                             |
+| `chart.metadata.description` <br/>_string_ | The description of the chart.                                                                                                                                         |
+| `chart.metadata.keywords` <br/>_list_      | The list of keywords linked to the chart.                                                                                                                             |
+| `chart.metadata.maintainers` <br/>_list_   | The list of the maintainer contact information.                                                                                                                       |
+| `chart.metadata.icon` <br/>_string_        | The icon URL for the chart.                                                                                                                                           |
+| `chart.metadata.appVersion` <br/>_string_  | The version of the application.                                                                                                                                       |
+| `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application.                                                                                                                 |
+| `config` <br/>_object_                     | All values that were used to install the release.                                                                                                                     |
+| `version`<br/>_string_                     | The revision of the release.                                                                                                                                          |
+| `namespace`<br/>_string_                   | The namespace to which the release is installed.                                                                                                                      |
 
 The information is not totally returned in the list. We filter out the manifest portion. We also filter out the files and the templates of the chart details. This information will be present in the GET request for an individual release.
 
@@ -137,159 +159,170 @@ curl -X GET \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/pspensieri/aerospike-1579797954"
 ```
 
+```shell
+curl --request GET \
+  --url https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/my-namespace/my-cloudflare \
+  --header 'mc-api-key: 21z5eXOKfSIHYsUNduyXNw=='
+```
+
 > The above command returns a JSON structured like this:
 
 ```json
 {
   "data": {
-    "id": "pspensieri/aerospike-1579797954",
-    "name": "aerospike-1579797954",
+    "id": "my-namespace/my-cloudflare",
+    "name": "my-cloudflare",
     "info": {
-      "first_deployed": "2020-01-23T11:45:57.255189-05:00",
-      "last_deployed": "2020-01-24T19:06:12.956425-05:00",
+      "first_deployed": "2020-11-03T09:48:49.301166-05:00",
+      "last_deployed": "2020-11-05T19:44:46.775668959Z",
       "deleted": "",
-      "description": "Rollback to 2",
+      "description": "Upgrade complete",
       "status": "installed",
-      "notes": "The Aerospike can be accessed via port 3000 on the following DNS name from within your cluster:\n\n  aerospike-1579797954.pspensieri.svc.cluster.local\n\nYou can connect to aeropike in your local machine using port-forwarding:\n\n  export POD_NAME=$(kubectl get pods --namespace pspensieri -l \"app=aerospike,release=aerospike-1579797954\" -o jsonpath=\"{.items[0].metadata.name}\")\n  kubectl  --namespace pspensieri port-forward $POD_NAME 3000:3000\n"
+      "notes": "You can connect to the container running cloudflare-dyndns. To open a shell session in the pod run the following:\n..."
     },
     "chart": {
       "metadata": {
-        "name": "aerospike",
-        "home": "http://aerospike.com",
-        "sources": ["https://github.com/aerospike/aerospike-server"],
-        "version": "0.3.2",
-        "description": "A Helm chart for Aerospike in Kubernetes",
-        "keywords": ["aerospike", "big-data"],
+        "name": "cloudflare-dyndns",
+        "home": "https://github.com/billimek/billimek-charts/tree/master/charts/cloudflare-dyndns",
+        "sources": [
+          "https://github.com/hotio/docker-cloudflare-ddns/",
+          "https://github.com/billimek/billimek-charts"
+        ],
+        "version": "2.0.0",
+        "description": "Dynamic DNS using Cloudflare's DNS Services",
+        "keywords": [
+          "cloudflare",
+          "dynamicdns"
+        ],
         "maintainers": [
           {
-            "name": "kavehmz",
-            "email": "kavehmz@gmail.com"
-          },
-          {
-            "name": "okgolove",
-            "email": "okgolove@markeloff.net"
+            "name": "billimek",
+            "email": "jeff@billimek.com"
           }
         ],
-        "icon": "https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png",
+        "icon": "https://www.cloudflare.com/img/cf-facebook-card.png",
         "apiVersion": "v1",
-        "appVersion": "v4.5.0.5",
+        "appVersion": "1.0",
         "deprecated": false
       },
       "templates": [
         {
           "name": "templates/NOTES.txt",
-          "data": "VGhlIEFlcm9zcGlr"
+          "data": "WW91I...fScp"
         },
         {
           "name": "templates/_helpers.tpl",
-          "data": "e3svKiB2aW06IHNl"
+          "data": "e3svKi...9Cg=="
         },
         {
-          "name": "templates/configmap.yaml",
-          "data": "YXBpVmVyc2lvbjogdjE"
+          "name": "templates/deployment.yaml",
+          "data": "YXBpVm...9Cg=="
         },
         {
-          "name": "templates/nodeport.yaml",
-          "data": "e3stIGlmIC5WYWx1Z"
-        },
-        {
-          "name": "templates/service.yaml",
-          "data": "YXBpVmVyc2lvbjogd"
-        },
-        {
-          "name": "templates/servicemonitor.yaml",
-          "data": "e3stIGlmIGFuZCAoLlZh"
-        },
-        {
-          "name": "templates/statefulset.yaml",
-          "data": "YXBpVmVyc2lvbjogYXBwcy92M"
+          "name": "templates/secret.yaml",
+          "data": "YXBpVmVy...X0="
         }
       ],
       "values": {
-        "annotations": {},
-        "args": [],
-        "command": [],
-        "confFile": "#default config file\nservice {\n    user root\n    group root\n    paxos-protocol v5\n    paxos-single-replica-limit 1\n    pidfile /var/run/aerospike/asd.pid\n    service-threads 4\n    transaction-queues 4\n    transaction-threads-per-queue 4\n    proto-fd-max 15000\n}\n\nlogging {\n    file /var/log/aerospike/aerospike.log {\n        context any info\n    }\n\n    console {\n        context any info\n    }\n}\n\nnetwork {\n    service {\n        address any\n        port 3000\n    }\n\n    heartbeat {\n        address any\n        interval 150\n        #REPLACE_THIS_LINE_WITH_MESH_CONFIG\n        mode mesh\n        port 3002\n        timeout 20\n        protocol v3\n    }\n\n    fabric {\n        port 3001\n    }\n\n    info {\n        port 3003\n    }\n}\n\nnamespace test {\n    replication-factor 2\n    memory-size 1G\n    default-ttl 5d\n    storage-engine device {\n        file /opt/aerospike/data/test.dat\n        filesize 4G\n    }\n}",
-        "image": {
-          "pullPolicy": "IfNotPresent",
-          "repository": "aerospike/aerospike-server",
-          "tag": "4.5.0.5"
+        "affinity": {},
+        "cloudflare": {
+          "detection_mode": "dig-google.com",
+          "hosts": "somehosts",
+          "log_level": 1.0,
+          "record_types": "somerecordtypes",
+          "sleep_interval": 300.0,
+          "token": "sometoken",
+          "user": "someuser",
+          "zones": "somezones"
         },
-        "labels": {},
-        "metrics": {
-          "serviceMonitor": {}
+        "image": {
+          "pullPolicy": "Always",
+          "repository": "hotio/cloudflare-ddns",
+          "tag": "latest"
         },
         "nodeSelector": {},
-        "persistentVolume": {},
         "replicaCount": 1.0,
         "resources": {},
-        "service": {
-          "annotations": {},
-          "clusterIP": "None",
-          "nodePort": {},
-          "type": "ClusterIP"
-        },
-        "terminationGracePeriodSeconds": 30.0,
         "tolerations": []
       },
       "files": [
         {
           "name": ".helmignore",
-          "data": "IyBQYXR0ZXJucyB0b"
-        },
-        {
-          "name": "OWNERS",
-          "data": "YXBwcm92ZXJzOgotIG9rZ29sb3ZlCnJldmlld2VyczoKLSBva2dvbG92ZQo="
+          "data": "IyBQYX...b2oK"
         },
         {
           "name": "README.md",
-          "data": "IyBBZXJvc3Bpa2UgSGVsbSBDaGFydAoK"
+          "data": "IyBE..4K"
         }
       ]
     },
-    "manifest": "---\n# Source: aerospike/templates/configmap.yaml\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: aerospike-1579797954\n  labels:\n    app: aerospike\n    chart: aerospike-0.3.2\n    release: aerospike-1579797954\n    heritage: Helm\ndata:\n  aerospike.conf: |\n    # aerospike configuration\n        #default config file\n    service {\n        user root\n        group root\n        paxos-protocol v5\n        paxos-single-replica-limit 1\n        pidfile /var/run/aerospike/asd.pid\n        # HERE UPDATE changed service threads from 4 to 3\n        service-threads 3\n        transaction-queues 4\n        transaction-threads-per-queue 4\n        proto-fd-max 15000\n    }\n    \n    logging {\n        file /var/log/aerospike/aerospike.log {\n            context any info\n        }\n    \n        console {\n            context any info\n        }\n    }\n    \n    network {\n        service {\n            address any\n            port 3000\n        }\n    \n        heartbeat {\n            address any\n            interval 150\n            \n        mesh-seed-address-port aerospike-1579797954-0.aerospike-1579797954 3002\n            mode mesh\n            port 3002\n            timeout 20\n            protocol v3\n        }\n    \n        fabric {\n            port 3001\n        }\n    \n        info {\n            port 3003\n        }\n    }\n    \n    namespace test {\n        replication-factor 2\n        memory-size 1G\n        default-ttl 5d\n        storage-engine device {\n            file /opt/aerospike/data/test.dat\n            filesize 4G\n        }\n    }\n---\n# Source: aerospike/templates/service.yaml\napiVersion: v1\nkind: Service\nmetadata:\n  name: aerospike-1579797954\n  labels:\n    app: aerospike\n    chart: aerospike-0.3.2\n    release: aerospike-1579797954\n    heritage: Helm\n  annotations:\nspec:\n  # so the mesh peer-finder works\n  publishNotReadyAddresses: true\n  \n  clusterIP: \"None\"\n  \n  type: ClusterIP\n  ports:\n    - port: 3000\n      protocol: TCP\n      name: client\n    - port: 3002\n      protocol: TCP\n      name: mesh\n    \n  selector:\n    app: aerospike\n    release: aerospike-1579797954\n---\n# Source: aerospike/templates/statefulset.yaml\napiVersion: apps/v1\nkind: StatefulSet\nmetadata:\n  name: aerospike-1579797954\n  labels:\n    app: aerospike\n    chart: aerospike-0.3.2\n    release: aerospike-1579797954\n    heritage: Helm\nspec:\n  serviceName: aerospike-1579797954\n  replicas: 1\n  selector:\n    matchLabels:\n      app: aerospike\n      release: aerospike-1579797954\n  template:\n    metadata:\n      labels:\n        app: aerospike\n        release: aerospike-1579797954\n      annotations:\n        checksum/config: a070d13fbcb5b721657425639577690b36bcd60897798a9e979ea6c2a2fa24c2\n    spec:\n      terminationGracePeriodSeconds: 30\n      containers:\n      - name: aerospike-1579797954\n        image: \"aerospike/aerospike-server:4.5.0.5\"\n        imagePullPolicy: IfNotPresent\n        \n        \n        ports:\n        - containerPort: 3000\n          name: clients\n        - containerPort: 3002\n          name: mesh\n        - containerPort: 3003\n          name: info\n        readinessProbe:\n          tcpSocket:\n              port: 3000\n          initialDelaySeconds: 15\n          timeoutSeconds: 1\n        volumeMounts:\n        - name: config-volume\n          mountPath: /etc/aerospike\n        resources:\n          \n          {}\n      \n      volumes:\n      - name: config-volume\n        configMap:\n          name: aerospike-1579797954\n          items:\n          - key: aerospike.conf\n            path: aerospike.conf\n      \n  volumeClaimTemplates:\n",
-    "version": 4,
-    "namespace": "pspensieri",
-    "chartVersion": "aerospike / 0.3.2"
+    "manifest": "---\n# Source: cloudflare-dyndns/templates/secret.yaml\napiVersion: v1\n...",
+    "config": {
+      "affinity": {},
+      "cloudflare": {
+        "detection_mode": "dig-google.com",
+        "hosts": "somehosts",
+        "log_level": 1.0,
+        "record_types": "somerecordtypes",
+        "sleep_interval": 300.0,
+        "token": "sometoken",
+        "user": "someuser",
+        "zones": "somezones"
+      },
+      "image": {
+        "pullPolicy": "Always",
+        "repository": "hotio/cloudflare-ddns",
+        "tag": "latest"
+      },
+      "nodeSelector": {},
+      "replicaCount": 1.0,
+      "resources": {},
+      "tolerations": []
+    },
+    "version": 11,
+    "namespace": "my-namespace",
+    "keepHistory": false,
+    "chartVersion": "cloudflare-dyndns / 2.0.0"
   }
 }
 ```
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id</code>
 
-| Attributes                                 | &nbsp;                                                                                                                                                               |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name` <br/>_string_                       | The name of the release.                                                                                                                                             |
-| `info` <br/>_object_                       | The information about the release                                                                                                                                    |
-| `info.first_deployed` <br/>_string_        | The annotations of the pod                                                                                                                                           |
-| `info.last_deployed` <br/>_string_         | The date of creation of the pod as a string                                                                                                                          |
-| `info.deleted` <br/>_string_               | The labels associated to the pod                                                                                                                                     |
-| `info.description` <br/>_string_           | The name of the pod                                                                                                                                                  |
-| `info.status` <br/>_string_                | The status of the release. Possible values are unknown, installed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade, pending-rollback |
-| `info.notes` <br/>_string_                 | The notes linked to the release                                                                                                                                      |
-| `chart`<br/>_object_                       | The information related to the chart of used in the release                                                                                                          |
-| `chart.version` <br/>_string_              | The version of the chart                                                                                                                                             |
-| `chart.metadata` <br/>_object_             | The metadata associated to the chart                                                                                                                                 |
-| `chart.metadata.name` <br/>_string_        | The name of the chart                                                                                                                                                |
-| `chart.metadata.home` <br/>_string_        | The home URL for the chart                                                                                                                                           |
-| `chart.metadata.sources` <br/>_list_       | The list of source of the charts                                                                                                                                     |
-| `chart.metadata.version` <br/>_string_     | The version of the chart                                                                                                                                             |
-| `chart.metadata.description` <br/>_string_ | The description of the chart                                                                                                                                         |
-| `chart.metadata.keywords` <br/>_list_      | The list of keywords linked to the chart                                                                                                                             |
-| `chart.metadata.maintainers` <br/>_list_   | The list of the maintainer contact information                                                                                                                       |
-| `chart.metadata.icon` <br/>_string_        | The icon URL for the chart                                                                                                                                           |
-| `chart.metadata.appVersion` <br/>_string_  | The version of the application                                                                                                                                       |
-| `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application                                                                                                                 |
-| `chart.templates` <br/> _list_             | The list of templates contained inside the chart.                                                                                                                    |
-| `chart.templates.name` <br/> _string_      | The path name of the template inside the chart.                                                                                                                      |
-| `chart.templates.data` <br/> _string_      | The contents of the template. This is a base64 encode string.                                                                                                        |
-| `chart.files` <br/> _list_                 | The list of files contained inside the chart. These are not YAML files unlike the templates.                                                                         |
-| `chart.files.name` <br/> _string_          | The path name of the file inside the chart.                                                                                                                          |
-| `chart.files.data` <br/> _string_          | The contents of the file. This is a base64 encode string.                                                                                                            |
-| `manifest` <br/> _string_                  | The YAML Kubernetes resources created by the Helm templating.                                                                                                        |
-| `values` <br/>_object_                     | All values that were used to install the release                                                                                                                     |
-| `version`<br/>_string_                     | The revision of the release                                                                                                                                          |
-| `namespace`<br/>_string_                   | The namespace to which the release is installed                                                                                                                      |
+| Attributes                                 | &nbsp;                                                                                                                                                                                  |
+|--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id` <br/>_string_                         | The release id, of the form `namespace/releaseName`.                                                                                                                                    |
+| `name` <br/>_string_                       | The name of the release.                                                                                                                                                                |
+| `info` <br/>_object_                       | The information about the release.                                                                                                                                                      |
+| `info.first_deployed` <br/>_string_        | The date the release was created.                                                                                                                                                       |
+| `info.last_deployed` <br/>_string_         | The date the release was last updated.                                                                                                                                                  |
+| `info.deleted` <br/>_string_               | The labels associated to the pod                                                                                                                                                        |
+| `info.description` <br/>_string_           | Description of the release's status.                                                                                                                                                    |
+| `info.status` <br/>_string_                | The status of the release. Possible values are `unknown`, `installed`, `uninstalled`, `superseded`, `failed`, `uninstalling`, `pending-install`, `pending-upgrade`, `pending-rollback`. |
+| `info.notes` <br/>_string_                 | The notes linked to the release.                                                                                                                                                        |
+| `chart`<br/>_object_                       | The information related to the chart used to install the release.                                                                                                                       |
+| `chart.version` <br/>_string_              | The version of the chart.                                                                                                                                                               |
+| `chart.metadata` <br/>_object_             | The metadata associated to the chart.                                                                                                                                                   |
+| `chart.metadata.name` <br/>_string_        | The name of the chart.                                                                                                                                                                  |
+| `chart.metadata.home` <br/>_string_        | The home URL for the chart.                                                                                                                                                             |
+| `chart.metadata.sources` <br/>_list_       | The list of source of the charts.                                                                                                                                                       |
+| `chart.metadata.version` <br/>_string_     | The version of the chart.                                                                                                                                                               |
+| `chart.metadata.description` <br/>_string_ | The description of the chart.                                                                                                                                                           |
+| `chart.metadata.keywords` <br/>_list_      | The list of keywords linked to the chart.                                                                                                                                               |
+| `chart.metadata.maintainers` <br/>_list_   | The list of the maintainer contact information.                                                                                                                                         |
+| `chart.metadata.icon` <br/>_string_        | The icon URL for the chart.                                                                                                                                                             |
+| `chart.metadata.appVersion` <br/>_string_  | The version of the application.                                                                                                                                                         |
+| `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application.                                                                                                                                   |
+| `chart.templates` <br/> _list_             | The list of templates contained inside the chart.                                                                                                                                       |
+| `chart.templates.name` <br/> _string_      | The path name of the template inside the chart.                                                                                                                                         |
+| `chart.templates.data` <br/> _string_      | The contents of the template. This is a base64 encode string.                                                                                                                           |
+| `chart.files` <br/> _list_                 | The list of files contained inside the chart. These are not YAML files unlike the templates.                                                                                            |
+| `chart.files.name` <br/> _string_          | The path name of the file inside the chart.                                                                                                                                             |
+| `chart.files.data` <br/> _string_          | The contents of the file. This is a base64 encode string.                                                                                                                               |
+| `manifest` <br/> _string_                  | The YAML Kubernetes resources created by the Helm templating.                                                                                                                           |
+| `config` <br/>_object_                     | All values that were used to install the release.                                                                                                                                       |
+| `version`<br/>_string_                     | The revision of the release.                                                                                                                                                            |
+| `namespace`<br/>_string_                   | The namespace to which the release is installed.                                                                                                                                        |
 
 <!-- ROLLBACK RELEASE -->
 
@@ -335,6 +368,12 @@ Rollback a release in a given [environment](#administration-environments) to the
 ### Upgrade release
 
 ```shell
+curl --request POST \
+  --url 'https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/my-namespcea/my-aerospike?operation=upgrade' \
+  --data 'request_body'
+```
+
+```shell
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/pspensieri/aerospike-1579797954?operation=upgrade"
@@ -346,19 +385,34 @@ curl -X POST \
 ```js
 // Change to the latest version of a chart
 {
-  "upgradeChart":  "stable/aerospike",
-  "upgradeChart":  1
+	"upgradeChart": {
+		"name": "aerospike",
+		"repository": {
+			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
+		}
+	}
 }
 
 // Change to a specific version of a chart
 {
-  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
+  "upgradeChart": {
+		"name": "aerospike",
+    "version": "4.9.0",
+		"repository": {
+			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
+		}
+	}
 }
 
 // Change the values for the latest version
 {
-  "upgradeChart" : "stable/aerospike",
-  "values": "---\n\"replicaCount\": 3\n"
+  "upgradeChart": {
+		"name": "aerospike",
+		"repository": {
+			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
+		}
+	}
+  "upgradeValues": "\"replicaCount\": 3"
 }
 ```
 
@@ -375,13 +429,17 @@ curl -X POST \
 
 Upgrade a release in a given [environment](#administration-environments).
 
-| Required                     | &nbsp;                                                                                    |
-| ---------------------------- | ----------------------------------------------------------------------------------------- |
-| `upgradeChart` <br/>_string_ | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use. |
+| Required                          | &nbsp;                                                       |
+|-----------------------------------|--------------------------------------------------------------|
+| `upgradeChart` <br/>_Object_      | The chart object that should be used to ugprade the release. |
+| `upgradeChart.name` <br/>_string_ | The chart name.                                              |
+| `repository` <br/>_Object_        | The repository object to which the chart belongs.            |
+| `repository.url` <br/>_string_    | The repository's URL.                                        |
 
-| Optional               | &nbsp;                                                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------------------------------ |
-| `values` <br/>_string_ | YAML structured text that will overwrite the default values for the upgrade/installation of the chart. |
+| Optional                             | &nbsp;                                                                                                 |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `upgradeChart.version` <br/>_string_ | The chart version that should be used to upgrade the chart. If none is provided, the latest is used.   |
+| `upgradeChart.values` <br/>_string_  | YAML structured text that will overwrite the default values for the upgrade/installation of the chart. |
 
 | Attributes                 | &nbsp;                                  |
 | -------------------------- | --------------------------------------- |

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -310,10 +310,10 @@ curl -X GET \
 | `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application.                                                                                                                                   |
 | `chart.templates` <br/> _list_             | The list of templates contained inside the chart.                                                                                                                                       |
 | `chart.templates.name` <br/> _string_      | The path name of the template inside the chart.                                                                                                                                         |
-| `chart.templates.data` <br/> _string_      | The contents of the template. This is a base64 encode string.                                                                                                                           |
+| `chart.templates.data` <br/> _string_      | The contents of the template. This is a base64 encoded string.                                                                                                                           |
 | `chart.files` <br/> _list_                 | The list of files contained inside the chart. These are not YAML files unlike the templates.                                                                                            |
 | `chart.files.name` <br/> _string_          | The path name of the file inside the chart.                                                                                                                                             |
-| `chart.files.data` <br/> _string_          | The contents of the file. This is a base64 encode string.                                                                                                                               |
+| `chart.files.data` <br/> _string_          | The contents of the file. This is a base64 encoded string.                                                                                                                               |
 | `manifest` <br/> _string_                  | The YAML Kubernetes resources created by the Helm templating.                                                                                                                           |
 | `config` <br/>_object_                     | All values that were used to install the release.                                                                                                                                       |
 | `version`<br/>_string_                     | The revision of the release.                                                                                                                                                            |
@@ -384,8 +384,8 @@ curl -X POST \
 
 // Change to a specific version of a chart
 {
-  "upgradeChart": {
-		"name": "aerospike",
+	"upgradeChart": {
+    "name": "aerospike",
     "version": "4.9.0",
 		"repository": {
 			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
@@ -395,12 +395,12 @@ curl -X POST \
 
 // Change the values for the latest version
 {
-  "upgradeChart": {
-		"name": "aerospike",
+	"upgradeChart": {
+    "name": "aerospike",
 		"repository": {
 			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
 		}
-	}
+  },
   "upgradeValues": "\"replicaCount\": 3"
 }
 ```

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -385,8 +385,8 @@ curl -X POST \
 // Change to a specific version of a chart
 {
 	"upgradeChart": {
-    "name": "aerospike",
-    "version": "4.9.0",
+		"name": "aerospike",
+		"version": "4.9.0",
 		"repository": {
 			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
 		}
@@ -396,12 +396,12 @@ curl -X POST \
 // Change the values for the latest version
 {
 	"upgradeChart": {
-    "name": "aerospike",
+		"name": "aerospike",
 		"repository": {
 			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
 		}
-  },
-  "upgradeValues": "\"replicaCount\": 3"
+	},
+	"upgradeValues": "\"replicaCount\": 3"
 }
 ```
 

--- a/source/includes/kubernetes/_k8_releases.md
+++ b/source/includes/kubernetes/_k8_releases.md
@@ -24,7 +24,7 @@ curl -X GET \
         "deleted": "",
         "description": "Upgrade complete",
         "status": "installed",
-        "notes": "You can connect to the container running cloudflare-dyndns. To open a shell session in the pod run the following:\n\n- kubectl exec -i -t --namespace my-namespace $(kubectl get pods --namespace my-namespace -l app=my-cloudflare-cloudflare-dyndns -o jsonpath='{.items[0].metadata.name}') /bin/sh\n\nTo trail the logs for the cloudflare-dyndns pod run the following:\n\n- kubectl logs -f --namespace my-namespace $(kubectl get pods --namespace my-namespace -l app=my-cloudflare-cloudflare-dyndns -o jsonpath='{ .items[0].metadata.name }')"
+        "notes": "You can connect to the container running cloudflare-dyndns. To open a shell session in the pod run the following:\n..."
       },
       "chart": {
         "metadata": {
@@ -107,6 +107,7 @@ curl -X GET \
   }
 }
 ```
+
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases</code>
 
 Or
@@ -156,13 +157,7 @@ The information is not totally returned in the list. We filter out the manifest 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/pspensieri/aerospike-1579797954"
-```
-
-```shell
-curl --request GET \
-  --url https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/my-namespace/my-cloudflare \
-  --header 'mc-api-key: 21z5eXOKfSIHYsUNduyXNw=='
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/my-namespace/my-cloudflare"
 ```
 
 > The above command returns a JSON structured like this:
@@ -368,15 +363,9 @@ Rollback a release in a given [environment](#administration-environments) to the
 ### Upgrade release
 
 ```shell
-curl --request POST \
-  --url 'https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/my-namespcea/my-aerospike?operation=upgrade' \
-  --data 'request_body'
-```
-
-```shell
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/pspensieri/aerospike-1579797954?operation=upgrade"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/my-namespace/my-aerospike?operation=upgrade"
    -d "request_body"
 ```
 

--- a/source/includes/kubernetes_extension/_k8_charts.md
+++ b/source/includes/kubernetes_extension/_k8_charts.md
@@ -16,69 +16,42 @@ curl -X GET \
 {
   "data": [
     {
-      "id": "stable/aerospike",
-      "type": "chart",
-      "attributes": {
-        "name": "aerospike",
-        "repo": {
-          "name": "stable",
-          "url": "https://kubernetes-charts.storage.googleapis.com"
-        },
-        "repoUrl": "https://hub.helm.sh/api/chartsvc",
-        "description": "A Helm chart for Aerospike in Kubernetes",
-        "home": "http://aerospike.com",
-        "keywords": [
-          "aerospike",
-          "big-data"
-        ],
-        "maintainers": [
-          {
-            "name": "kavehmz",
-            "email": "kavehmz@gmail.com"
-          },
-          {
-            "name": "okgolove",
-            "email": "okgolove@markeloff.net"
-          }
-        ],
-        "sources": [
-          "https://github.com/aerospike/aerospike-server"
-        ],
-        "icon": "/v1/assets/stable/aerospike/logo"
+      "id": "helm-stable/aerospike",
+      "name": "aerospike",
+      "description": "A Helm chart for Aerospike in Kubernetes",
+      "version": "0.3.3",
+      "license": "",
+      "deprecated": false,
+      "repository": {
+        "url": "https://kubernetes-charts.storage.googleapis.com",
+        "name": "helm-stable",
+        "kind": 0,
+        "official": false,
+        "displayName": "Stable",
+        "repositoryId": "3cc327ae-9403-4521-9b71-f9a41d5f86c8",
+        "organizationName": "helm",
+        "verifiedPublisher": false,
+        "organizationDisplayName": "Helm"
       },
-      "links": {
-        "self": "/v1/charts/stable/aerospike"
-      },
-      "relationships": {
-        "latestChartVersion": {
-          "data": {
-            "version": "0.3.2",
-            "digest": "97cfd56a20129d65b30de9d77267bf30f7b5f2d28565285282e16b26678a4ce3",
-            "urls": [
-              "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
-            ],
-            "readme": "/v1/assets/stable/aerospike/versions/0.3.2/README.md",
-            "values": "/v1/assets/stable/aerospike/versions/0.3.2/values.yaml"
-          },
-          "links": {
-            "self": "/v1/charts/stable/aerospike/versions/0.3.2"
-          }
-        }
-      },
-      "insecureServer": false
+      "packageId": "c4b6ad70-898d-4093-bec8-089d5f48daeb",
+      "displayName": "",
+      "normalizedName": "aerospike",
+      "appVersion": "v4.5.0.5",
+      "logoImageId": "50bcf132-ff98-4f9a-9e6a-0c0b06649e48",
+      "logoImageUrl": "https://artifacthub.io/image/50bcf132-ff98-4f9a-9e6a-0c0b06649e48"
     }
   ],
   "metadata": {
-    "recordCount": 1
+    "pageSize": 50,
+    "pageCurrent": 1,
+    "recordCount": 148
   }
 }
 ```
 
-
-
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts?cluster_id=:cluster_id</code>
 
-Retrieve a list of all charts in a given [environment](#administration-environments).
+Retrieve a list of all charts in a given [environment](#administration-environments). To get more chart details, such as available versions, the chart's readme and list of maintainers, see the GET request for an individual chart.
 
 Required | &nbsp;
 ------- | -----------
@@ -87,28 +60,30 @@ Required | &nbsp;
 
 Attributes | &nbsp;
 ------- | -----------
-`id` <br/>*string* | The id for the chart.  
-`type` <br/>*string* | The type of chart.
-`attributes` <br/>*object* | The annotations of the pod.
-`attributes.name` <br/>*string* | The name of the chart.
-`attributes.repo` <br/>*map* | The repository information where this chart was fetched (name,url).
-`attributes.repoUrl` <br/>*string* | The url of the source of the chart.
-`attributes.description` <br/>*string* | The chart description.
-`attributes.home` <br/>*string* | The home url for the chart.
-`attributes.keywords` <br/>*string* | The keywords linked to the chart.
-`attributes.maintainers` <br/>*object* | The maintainers of the charts and their information.
-`attributes.sources` <br/>*list* | The sources for the chart.
-`attributes.icon` <br/>*string* | The icon for the chart.
-`relationships` <br/>*objection* | The relationship information for the chart.
-`relationships.latestChartVersion` <br/>*object* | The lastest version chart information.
-`relationships.latestChartVersion.data.version` <br/>*string* | The digest validating the chart.
-`relationships.latestChartVersion.data.digest` <br/>*string* | The name of the chart.
-`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download.
-`relationships.latestChartVersion.data.readme` <br/>*string* | The readme file location.
-`relationships.latestChartVersion.data.values` <br/>*string* | The values file location.
-`version`<br/>*string* | The revision of the release.
-`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection.
-
+| Attributes                                         | &nbsp;                                                                                                     |
+|----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `id` <br/>_string_                                 | The id for the chart, of the form `repositoryName/chartName`.                                              |
+| `name` <br/>_st                                    | The chart name.                                                                                            |
+| `description` <br/>_string_                        | The chart description.                                                                                     |
+| `version` <br/>_string_                            | The latest chart version.                                                                                  |
+| `license` <br/>_string_                            | The chart's license.                                                                                       |
+| `deprecated` <br/>_boolean_                        | True if the chart is deprecated.                                                                           |
+| `repository` <br/>_object_                         | The chart's parent repository.                                                                             |
+| `repoository.url` <br/>_string_                    | The repository url.                                                                                        |
+| `repository.name` <br/>_string_                    | The repository name.                                                                                       |
+| `repository.kind` <br/>_integer_                   | The repository kind, where `{0: Helm chart, 1: Falco rule, 2: OPA policy, 3: OLM operator }`.              |
+| `repository.official` <br/>_boolean_               | True if it is an official repository. That is, if the publisher owns the software deployed by the package. |
+| `repository.displayName` <br/>_string_             | The repository's display name.                                                                             |
+| `repository.repositoryId` <br/>_UUID_              | The UUID of the repository.                                                                                |
+| `repository.organizationName` <br/>_string_        | The name of the organization that owns the repository.                                                     |
+| `repository.organizationDisplayName` <br/>_string_ | The display name of the organization that owns the repository.                                             |
+| `repository.verifiedPublisher` <br/>_boolean_      | True if the publisher owns the repository.                                                                 |
+| `packageId` <br/>_UUID_                            | The UUID of the package, given by ArtifactHub.                                                             |
+| `displayName` <br/>_string_                        | The chart's display name.                                                                                  |
+| `normalizedName` <br/>_string_                     | The chart's normalized name.                                                                               |
+| `appVersion` <br/>_string_                         | The chart's app version.                                                                                   |
+| `logoImageId` <br/>_UUID_                          | The UUID of the package's logo, given by ArtifactHub.                                                      |
+| `logoImageUrl` <br/>_string_                       | The URL for the chart's logo.                                                                              |
 
 
 <!-------------------- GET CHART -------------------->
@@ -118,63 +93,68 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/charts/stable/aerospike?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/charts/k8s-at-home/cloudflare-dyndns?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
 ```
 > The above command returns a JSON structured like this:
 
 ```json
 {
   "data": {
-    "id": "stable/aerospike",
-    "type": "chart",
-    "attributes": {
-      "name": "aerospike",
-      "repo": {
-        "name": "stable",
-        "url": "https://kubernetes-charts.storage.googleapis.com"
-      },
-      "repoUrl": "https://hub.helm.sh/api/chartsvc",
-      "description": "A Helm chart for Aerospike in Kubernetes",
-      "home": "http://aerospike.com",
-      "keywords": [
-        "aerospike",
-        "big-data"
-      ],
-      "maintainers": [
-        {
-          "name": "kavehmz",
-          "email": "kavehmz@gmail.com"
-        },
-        {
-          "name": "okgolove",
-          "email": "okgolove@markeloff.net"
-        }
-      ],
-      "sources": [
-        "https://github.com/aerospike/aerospike-server"
-      ],
-      "icon": "/v1/assets/stable/aerospike/logo"
-    },
-    "links": {
-      "self": "/v1/charts/stable/aerospike"
-    },
-    "relationships": {
-      "latestChartVersion": {
-        "data": {
-          "version": "0.3.2",
-          "digest": "97cfd56a20129d65b30de9d77267bf30f7b5f2d28565285282e16b26678a4ce3",
-          "urls": [
-            "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
-          ],
-          "readme": "/v1/assets/stable/aerospike/versions/0.3.2/README.md",
-          "values": "/v1/assets/stable/aerospike/versions/0.3.2/values.yaml"
-        },
-        "links": {
-          "self": "/v1/charts/stable/aerospike/versions/0.3.2"
-        }
+    "keywords": [
+      "cloudflare",
+      "dynamicdns"
+    ],
+    "maintainers": [
+      {
+        "name": "billimek",
+        "email": "jeff@billimek.com"
       }
+    ],
+    "links": [
+      {
+        "url": "https://github.com/hotio/docker-cloudflare-ddns/",
+        "name": "source"
+      },
+      {
+        "url": "https://github.com/billimek/billimek-charts",
+        "name": "source"
+      }
+    ],
+    "homeUrl": "https://github.com/billimek/billimek-charts/tree/master/charts/cloudflare-dyndns",
+    "availableVersions": [
+      {
+        "version": "1.0.0",
+        "createdAt": 1576998322
+      },
+      {
+        "version": "2.0.0",
+        "createdAt": 1578688072
+      }
+    ],
+    "readMe": "# Dynamic DNS using Cloudflare's DNS Services\n...",
+    "id": "k8s-at-home/cloudflare-dyndns",
+    "name": "cloudflare-dyndns",
+    "description": "Dynamic DNS using Cloudflare's DNS Services",
+    "version": "2.0.0",
+    "license": "",
+    "deprecated": false,
+    "repository": {
+      "url": "https://k8s-at-home.com/charts/",
+      "name": "k8s-at-home",
+      "kind": 0,
+      "official": false,
+      "displayName": "charts",
+      "repositoryId": "9b40a3b3-ed2a-405f-8919-3b824d4f661d",
+      "organizationName": "k8s-at-home",
+      "verifiedPublisher": true,
+      "organizationDisplayName": "k8s@home"
     },
-    "insecureServer": false
+    "packageId": "a6cd6148-977a-4852-8761-80234f39d90b",
+    "displayName": "",
+    "normalizedName": "cloudflare-dyndns",
+    "appVersion": "1.0",
+    "logoImageId": "3a0eac41-21b4-4a1b-b127-c7e70123eda8",
+    "logoImageUrl": "https://artifacthub.io/image/3a0eac41-21b4-4a1b-b127-c7e70123eda8"
   }
 }
 ```
@@ -190,29 +170,34 @@ Required | &nbsp;
 `cluster_id` <br/>*string* | The id of the cluster in which to get the chart. 
 
 
-Attributes | &nbsp;
-------- | -----------
-`id` <br/>*string* | The id for the chart.  
-`type` <br/>*string* | The type of chart.
-`attributes` <br/>*object* | The annotations of the pod.
-`attributes.name` <br/>*string* | The name of the chart.
-`attributes.repo` <br/>*map* | The repository information where this chart was fetched (name,url).
-`attributes.repoUrl` <br/>*string* | The url of the source of the chart.
-`attributes.description` <br/>*string* | The chart description.
-`attributes.home` <br/>*string* | The home url for the chart.
-`attributes.keywords` <br/>*string* | The keywords linked to the chart.
-`attributes.maintainers` <br/>*object* | The maintainers of the charts and their information.
-`attributes.sources` <br/>*list* | The sources for the chart.
-`attributes.icon` <br/>*string* | The icon for the chart.
-`relationships` <br/>*objection* | The relationship information for the chart.
-`relationships.latestChartVersion` <br/>*object* | The lastest version chart information.
-`relationships.latestChartVersion.data.version` <br/>*string* | The digest validating the chart.
-`relationships.latestChartVersion.data.digest` <br/>*string* | The name of the chart.
-`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download.
-`relationships.latestChartVersion.data.readme` <br/>*string* | The readme file location.
-`relationships.latestChartVersion.data.values` <br/>*string* | The values file location.
-`version`<br/>*string* | The revision of the release.
-`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection.
+| Attributes                                         | &nbsp;                                                                                                     |
+|----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `id` <br/>_string_                                 | The id for the chart, of the form `repositoryName/chartName`.                                              |
+| `name` <br/>_st                                    | The chart name.                                                                                            |
+| `description` <br/>_string_                        | The chart description.                                                                                     |
+| `version` <br/>_string_                            | The latest chart version.                                                                                  |
+| `license` <br/>_string_                            | The chart's license.                                                                                       |
+| `deprecated` <br/>_boolean_                        | True if the chart is deprecated.                                                                           |
+| `repository` <br/>_object_                         | The chart's parent repository.                                                                             |
+| `repoository.url` <br/>_string_                    | The repository url.                                                                                        |
+| `repository.name` <br/>_string_                    | The repository name.                                                                                       |
+| `repository.kind` <br/>_integer_                   | The repository kind, where `{0: Helm chart, 1: Falco rule, 2: OPA policy, 3: OLM operator }`.              |
+| `repository.official` <br/>_boolean_               | True if it is an official repository. That is, if the publisher owns the software deployed by the package. |
+| `repository.displayName` <br/>_string_             | The repository's display name.                                                                             |
+| `repository.repositoryId` <br/>_UUID_              | The UUID of the repository.                                                                                |
+| `repository.organizationName` <br/>_string_        | The name of the organization that owns the repository.                                                     |
+| `repository.organizationDisplayName` <br/>_string_ | The display name of the organization that owns the repository.                                             |
+| `repository.verifiedPublisher` <br/>_boolean_      | True if the publisher owns the repository.                                                                 |
+| `packageId` <br/>_UUID_                            | The UUID of the package, given by ArtifactHub.                                                             |
+| `displayName` <br/>_string_                        | The chart's display name.                                                                                  |
+| `normalizedName` <br/>_string_                     | The chart's normalized name.                                                                               |
+| `appVersion` <br/>_string_                         | The chart's app version.                                                                                   |
+| `logoImageId` <br/>_UUID_                          | The UUID of the package's logo, given by ArtifactHub.                                                      |
+| `logoImageUrl` <br/>_string_                       | The URL for the chart's logo.                                                                              |
+| `keywords` <br/>_Array[string]_                    | The chart's keywords.                                                                                      |
+| `maintainers` <br/>_Array[Object]_                 | The names and emails of chart maintainers.                                                                 |
+| `homeUrl` <br/>_Array[Object]_                     | The chart's home URL.                                                                                      |
+| `availableVersions` <br/>_Array[Object]_           | The available chart versions and their created dates.                                                      |
 
 
 
@@ -222,27 +207,26 @@ Attributes | &nbsp;
 #### Install chart
 
 ```shell
-curl -X POST \
-   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/charts?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+curl --request POST \
+  --url https://cloudmc_endpoint/v1/services/a_service/an_environment/charts?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1 \
+  --header 'MC-Api-Key: your_api_key' \
+  --data '{
+	"namespace": "my-namespace",
+	"releaseName": "my-aerospike",
+	"name": "aerospike",
+	"version": "5.0.0",
+  "values": ""
+	"repository": {
+		"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
+	}
+}'
 ```
 > The above command returns a JSON structured like this:
 
 ```json
 {
-	"relationships": {
-		 "latestChartVersion": {
-        "data": {
-          "urls": [
-						"https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
-					]
-				}
-		 }
-	},
-	"insecureServer": false,
-	"passedValues": "# Default values for aerospike.\nterminationGracePeriodSeconds: 30\nreplicaCount: 1\nnodeSelector: {}\nimage:\n  repository: aerospike/aerospike-server\n  tag: 4.5.0.5\n  pullPolicy: IfNotPresent\n\n# pass custom command. This is equivalent of Entrypoint in docker\ncommand: []\n\n# pass custom args. This is equivalent of Cmd in docker\nargs: []\n\n# Set as empty object {} if no volumes need to be created\n# See confFile below\npersistentVolume: {}\n  # - mountPath: /opt/aerospike/data\n  #   name: aerospike-data\n  #   template:\n  #     accessModes: [ \"ReadWriteOnce\" ]\n  #     # storageClassName:  \"standard\"\n  #     resources:\n  #       requests:\n  #         storage: \"36G\"\n  #     selector:\n  #       matchLabels:\n  #         diskname: \"aerospike-data\"\n\nservice:\n  type: ClusterIP\n  # Provide any additional annotations which may be required.\n  # The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart\n  annotations: {}\n  loadBalancerIP:\n  clusterIP: None\n  # This field takes a list of IP CIDR ranges, which Kubernetes will use to configure firewall exceptions\n  # loadBalancerSourceRanges:\n  # - 10.0.0.0/8\n  nodePort: {}\n\n# turns on a sidecar that scrapes 'localhost:3000' and exposes to port 9134\n# a docker image built from this repo works well: https://github.com/alicebob/asprom\n# but you will need to build/host it yourself\nmetrics:\n  serviceMonitor: {}\n\nlabels: {}\nannotations: {}\n\ntolerations: []\n\nresources: {}\n  # We usually recommend not to specify default resources and to leave this as a conscious\n  # choice for the user. This also increases chances charts run on environments with little\n  # resources, such as Minikube. If you do want to specify resources, uncomment the following\n  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.\n  # limits:\n  #  cpu: 100m\n  #  memory: 128Mi\n  # requests:\n  #  cpu: 100m\n  #  memory: 128Mi\n\nconfFile: |-\n  #default config file\n  service {\n      user root\n      group root\n      paxos-protocol v5\n      paxos-single-replica-limit 1\n      pidfile /var/run/aerospike/asd.pid\n      service-threads 4\n      transaction-queues 4\n      transaction-threads-per-queue 4\n      proto-fd-max 15000\n  }\n\n  logging {\n      file /var/log/aerospike/aerospike.log {\n          context any info\n      }\n\n      console {\n          context any info\n      }\n  }\n\n  network {\n      service {\n          address any\n          port 3000\n      }\n\n      heartbeat {\n          address any\n          interval 150\n          #REPLACE_THIS_LINE_WITH_MESH_CONFIG\n          mode mesh\n          port 3002\n          timeout 20\n          protocol v3\n      }\n\n      fabric {\n          port 3001\n      }\n\n      info {\n          port 3003\n      }\n  }\n\n  namespace test {\n      replication-factor 2\n      memory-size 1G\n      default-ttl 5d\n      storage-engine device {\n          file /opt/aerospike/data/test.dat\n          filesize 4G\n      }\n  }\n",
-	"namespace": "default",
-	"releaseName": "test1"
+  "taskId": "ef70cafa-0544-4709-a66a-c68595ee105a",
+  "taskStatus": "SUCCESS"
 }
 ```
 
@@ -258,10 +242,13 @@ Required | &nbsp;
 
 Attributes | &nbsp;
 ------- | -----------
-`relationships` <br/>*objection* | The relationship information for the chart.
-`relationships.latestChartVersion` <br/>*object* | The lastest version chart information.
-`relationships.latestChartVersion.data.urls` <br/>*string* | The URLs for the package to download.
-`insecureServer`<br/>*boolean* | Specify if to access the chart we need an unsecure connection.
-`passedValues` <br/>*string* | The values to use to install the chart. It must be a valid Yaml format.
-`namespace` <br/>*map* | The namespace in which the chart will be installed.
-`releaseName` <br/>*string* | The name under which the chart will be known.
+| Attributes                      | &nbsp;                                                                           |
+|---------------------------------|----------------------------------------------------------------------------------|
+| `namespace` <br/>_string_       | The namespace in which the chart will be installed.                              |
+| `releaseName` <br/>_string_     | The desired release name.                                                        |
+| `name` <br/>_string_            | The chart name.                                                                  |
+| `version` <br/>_string_         | The chart version to be installed. Defaults to the latest version if left blank. |
+| `values` <br/>_string_          | The values to use to install the chart. It must be a valid Yaml format.          |
+| `repository` <br/>_object_      | The chart's parent repository from which it should be installed.                 |
+| `repoository.url` <br/>_string_ | The repository url.                                                              |
+| `insecureServer`<br/>_boolean_  | True if accessing the chart requires an unsecured connection.                    |

--- a/source/includes/kubernetes_extension/_k8_charts.md
+++ b/source/includes/kubernetes_extension/_k8_charts.md
@@ -69,7 +69,7 @@ Attributes | &nbsp;
 | `license` <br/>_string_                            | The chart's license.                                                                                       |
 | `deprecated` <br/>_boolean_                        | True if the chart is deprecated.                                                                           |
 | `repository` <br/>_object_                         | The chart's parent repository.                                                                             |
-| `repoository.url` <br/>_string_                    | The repository url.                                                                                        |
+| `repoository.url` <br/>_string_                    | The repository URL.                                                                                        |
 | `repository.name` <br/>_string_                    | The repository name.                                                                                       |
 | `repository.kind` <br/>_integer_                   | The repository kind, where `{0: Helm chart, 1: Falco rule, 2: OPA policy, 3: OLM operator }`.              |
 | `repository.official` <br/>_boolean_               | True if it is an official repository. That is, if the publisher owns the software deployed by the package. |
@@ -179,7 +179,7 @@ Required | &nbsp;
 | `license` <br/>_string_                            | The chart's license.                                                                                       |
 | `deprecated` <br/>_boolean_                        | True if the chart is deprecated.                                                                           |
 | `repository` <br/>_object_                         | The chart's parent repository.                                                                             |
-| `repoository.url` <br/>_string_                    | The repository url.                                                                                        |
+| `repoository.url` <br/>_string_                    | The repository URL.                                                                                        |
 | `repository.name` <br/>_string_                    | The repository name.                                                                                       |
 | `repository.kind` <br/>_integer_                   | The repository kind, where `{0: Helm chart, 1: Falco rule, 2: OPA policy, 3: OLM operator }`.              |
 | `repository.official` <br/>_boolean_               | True if it is an official repository. That is, if the publisher owns the software deployed by the package. |
@@ -230,25 +230,25 @@ curl --request POST \
 }
 ```
 
-
-
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/charts?cluster_id=:cluster_id</code>
 
 Install a chart in a given [environment](#administration-environments).
 
-Required | &nbsp;
-------- | -----------
-`cluster_id` <br/>*string* | The id of the cluster in which to install the chart. 
+| Required Query Parameters  | &nbsp;                                               |
+|----------------------------|------------------------------------------------------|
+| `cluster_id` <br/>*string* | The id of the cluster in which to install the chart. |
 
-Attributes | &nbsp;
-------- | -----------
-| Attributes                      | &nbsp;                                                                           |
-|---------------------------------|----------------------------------------------------------------------------------|
-| `namespace` <br/>_string_       | The namespace in which the chart will be installed.                              |
-| `releaseName` <br/>_string_     | The desired release name.                                                        |
-| `name` <br/>_string_            | The chart name.                                                                  |
-| `version` <br/>_string_         | The chart version to be installed. Defaults to the latest version if left blank. |
-| `values` <br/>_string_          | The values to use to install the chart. It must be a valid Yaml format.          |
-| `repository` <br/>_object_      | The chart's parent repository from which it should be installed.                 |
-| `repoository.url` <br/>_string_ | The repository url.                                                              |
-| `insecureServer`<br/>_boolean_  | True if accessing the chart requires an unsecured connection.                    |
+| Required Attributes             | &nbsp;                                                           |
+|---------------------------------|------------------------------------------------------------------|
+| `cluster_id` <br/>*string*      | The id of the cluster in which to install the chart.             |
+| `namespace` <br/>_string_       | The namespace in which the chart will be installed.              |
+| `releaseName` <br/>_string_     | The desired release name.                                        |
+| `name` <br/>_string_            | The chart name.                                                  |
+| `repository` <br/>_object_      | The chart's parent repository from which it should be installed. |
+| `repoository.url` <br/>_string_ | The repository URL.                                              |
+
+| Optional Attributes            | &nbsp;                                                                                                                       |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `version` <br/>_string_        | The chart version to be installed. Defaults to the latest version if left blank.                                             |
+| `values` <br/>_string_         | The values used to install the chart. Must be a valid Yaml format. If not provided, the chart's default values will be used. |
+| `insecureServer`<br/>_boolean_ | True if accessing the chart requires an unsecured connection.                                                                |

--- a/source/includes/kubernetes_extension/_k8_releases.md
+++ b/source/includes/kubernetes_extension/_k8_releases.md
@@ -16,68 +16,90 @@ curl -X GET \
 {
   "data": [
     {
-      "name": "my-aerospike",
+      "id": "my-namespace/my-cloudflare",
+      "name": "my-cloudflare",
       "info": {
-        "first_deployed": "2020-01-20T09:35:02.267449-05:00",
-        "last_deployed": "2020-01-20T09:35:02.267449-05:00",
+        "first_deployed": "2020-11-03T09:48:49.301166-05:00",
+        "last_deployed": "2020-11-05T11:24:37.096888-05:00",
         "deleted": "",
-        "description": "Install complete",
+        "description": "Upgrade complete",
         "status": "installed",
-        "notes": "The Aerospike can be accessed via port 3000 on the following DNS name from within your cluster:\n\n  my-aerospike.default.svc.cluster.local\n\nYou can connect to aeropike in your local machine using port-forwarding:\n\n  export POD_NAME=$(kubectl get pods --namespace default -l \"app=aerospike,release=my-aerospike\" -o jsonpath=\"{.items[0].metadata.name}\")\n  kubectl  --namespace default port-forward $POD_NAME 3000:3000\n"
+        "notes": "You can connect to the container running cloudflare-dyndns. To open a shell session in the pod run the following:\n..."
       },
       "chart": {
         "metadata": {
-          "name": "aerospike",
-          "home": "http://aerospike.com",
-          "sources": ["https://github.com/aerospike/aerospike-server"],
-          "version": "0.3.2",
-          "description": "A Helm chart for Aerospike in Kubernetes",
-          "keywords": ["aerospike", "big-data"],
+          "name": "cloudflare-dyndns",
+          "home": "https://github.com/billimek/billimek-charts/tree/master/charts/cloudflare-dyndns",
+          "sources": [
+            "https://github.com/hotio/docker-cloudflare-ddns/",
+            "https://github.com/billimek/billimek-charts"
+          ],
+          "version": "2.0.0",
+          "description": "Dynamic DNS using Cloudflare's DNS Services",
+          "keywords": [
+            "cloudflare",
+            "dynamicdns"
+          ],
           "maintainers": [
             {
-              "name": "kavehmz",
-              "email": "kavehmz@gmail.com"
-            },
-            {
-              "name": "okgolove",
-              "email": "okgolove@markeloff.net"
+              "name": "billimek",
+              "email": "jeff@billimek.com"
             }
           ],
-          "icon": "https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png",
+          "icon": "https://www.cloudflare.com/img/cf-facebook-card.png",
           "apiVersion": "v1",
-          "appVersion": "v4.5.0.5",
+          "appVersion": "1.0",
           "deprecated": false
         },
         "values": {
-          "annotations": {},
-          "args": [],
-          "command": [],
-          "confFile": "#default config file\nservice {\n    user root\n    group root\n    paxos-protocol v5\n    paxos-single-replica-limit 1\n    pidfile /var/run/aerospike/asd.pid\n    service-threads 4\n    transaction-queues 4\n    transaction-threads-per-queue 4\n    proto-fd-max 15000\n}\n\nlogging {\n    file /var/log/aerospike/aerospike.log {\n        context any info\n    }\n\n    console {\n        context any info\n    }\n}\n\nnetwork {\n    service {\n        address any\n        port 3000\n    }\n\n    heartbeat {\n        address any\n        interval 150\n        #REPLACE_THIS_LINE_WITH_MESH_CONFIG\n        mode mesh\n        port 3002\n        timeout 20\n        protocol v3\n    }\n\n    fabric {\n        port 3001\n    }\n\n    info {\n        port 3003\n    }\n}\n\nnamespace test {\n    replication-factor 2\n    memory-size 1G\n    default-ttl 5d\n    storage-engine device {\n        file /opt/aerospike/data/test.dat\n        filesize 4G\n    }\n}",
-          "image": {
-            "pullPolicy": "IfNotPresent",
-            "repository": "aerospike/aerospike-server",
-            "tag": "4.5.0.5"
+          "affinity": {},
+          "cloudflare": {
+            "detection_mode": "dig-google.com",
+            "hosts": "somehosts",
+            "log_level": 1.0,
+            "record_types": "somerecordtypes",
+            "sleep_interval": 300.0,
+            "token": "sometoken",
+            "user": "someuser",
+            "zones": "somezones"
           },
-          "labels": {},
-          "metrics": {
-            "serviceMonitor": {}
+          "image": {
+            "pullPolicy": "Always",
+            "repository": "hotio/cloudflare-ddns",
+            "tag": "latest"
           },
           "nodeSelector": {},
-          "persistentVolume": {},
           "replicaCount": 1.0,
           "resources": {},
-          "service": {
-            "annotations": {},
-            "clusterIP": "None",
-            "nodePort": {},
-            "type": "ClusterIP"
-          },
-          "terminationGracePeriodSeconds": 30.0,
           "tolerations": []
         }
       },
-      "version": 1,
-      "namespace": "default"
+      "config": {
+        "affinity": {},
+        "cloudflare": {
+          "detection_mode": "dig-google.com",
+          "hosts": "somehosts",
+          "log_level": 1.0,
+          "record_types": "somerecordtypes",
+          "sleep_interval": 300.0,
+          "token": "sometoken",
+          "user": "someuser",
+          "zones": "somezones"
+        },
+        "image": {
+          "pullPolicy": "Always",
+          "repository": "hotio/cloudflare-ddns",
+          "tag": "latest"
+        },
+        "nodeSelector": {},
+        "replicaCount": 1.0,
+        "resources": {},
+        "tolerations": []
+      },
+      "version": 10,
+      "namespace": "my-namespace",
+      "keepHistory": false,
+      "chartVersion": "cloudflare-dyndns / 2.0.0"
     }
   ],
   "metadata": {
@@ -102,15 +124,16 @@ Retrieve a list of all releases in a given [environment](#administration-environ
 | ------------------------- | -------------------------------------------------------------- |
 | `namespace` <br/>_string_ | The namespace to list the release. This needs the exact value. |
 
-| Attributes                                 | &nbsp;                                                                                                                                                                |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name` <br/>_string_                       | The name of the release.                                                                                                                                              |
+| Attributes                                 | &nbsp;                                                                                                                                                               |
+|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id` <br/>_string_                         | The release id, of the form `namespace/releaseName`. |
+| `name` <br/>_string_                       | The name of the release.                                                                                                                                             |
 | `info` <br/>_object_                       | The information about the release.                                                                                                                                    |
 | `info.first_deployed` <br/>_string_        | The annotations of the pod.                                                                                                                                           |
 | `info.last_deployed` <br/>_string_         | The date of creation of the pod as a string.                                                                                                                          |
 | `info.deleted` <br/>_string_               | The labels associated to the pod.                                                                                                                                     |
 | `info.description` <br/>_string_           | The name of the pod.                                                                                                                                                  |
-| `info.status` <br/>_string_                | The status of the release. Possible values are unknown, installed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade, pending-rollback. |
+| `info.status` <br/>_string_                | The status of the release. Possible values are `unknown`, `installed`, `uninstalled`, `superseded`, `failed`, `uninstalling`, `pending-install`, `pending-upgrade`, `pending-rollback`. |
 | `info.notes` <br/>_string_                 | The notes linked to the release.                                                                                                                                      |
 | `chart`<br/>_object_                       | The information related to the chart of used in the release.                                                                                                          |
 | `chart.version` <br/>_string_              | The version of the chart.                                                                                                                                             |
@@ -125,7 +148,7 @@ Retrieve a list of all releases in a given [environment](#administration-environ
 | `chart.metadata.icon` <br/>_string_        | The icon URL for the chart.                                                                                                                                           |
 | `chart.metadata.appVersion` <br/>_string_  | The version of the application.                                                                                                                                       |
 | `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application.                                                                                                                 |
-| `values` <br/>_object_                     | All values that were used to install the release.                                                                                                                     |
+| `config` <br/>_object_                     | All values that were used to install the release.                                                                                                                     |
 | `version`<br/>_string_                     | The revision of the release.                                                                                                                                          |
 | `namespace`<br/>_string_                   | The namespace to which the release is installed.                                                                                                                      |
 
@@ -138,7 +161,7 @@ The information is not totally returned in the list. We filter out the manifest 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/pspensieri/aerospike-1579797954?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/my-namespace/my-cloudflare?cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
 ```
 
 > The above command returns a JSON structured like this:
@@ -146,115 +169,119 @@ curl -X GET \
 ```json
 {
   "data": {
-    "id": "pspensieri/aerospike-1579797954",
-    "name": "aerospike-1579797954",
+    "id": "my-namespace/my-cloudflare",
+    "name": "my-cloudflare",
     "info": {
-      "first_deployed": "2020-01-23T11:45:57.255189-05:00",
-      "last_deployed": "2020-01-24T19:06:12.956425-05:00",
+      "first_deployed": "2020-11-03T09:48:49.301166-05:00",
+      "last_deployed": "2020-11-05T19:44:46.775668959Z",
       "deleted": "",
-      "description": "Rollback to 2",
+      "description": "Upgrade complete",
       "status": "installed",
-      "notes": "The Aerospike can be accessed via port 3000 on the following DNS name from within your cluster:\n\n  aerospike-1579797954.pspensieri.svc.cluster.local\n\nYou can connect to aeropike in your local machine using port-forwarding:\n\n  export POD_NAME=$(kubectl get pods --namespace pspensieri -l \"app=aerospike,release=aerospike-1579797954\" -o jsonpath=\"{.items[0].metadata.name}\")\n  kubectl  --namespace pspensieri port-forward $POD_NAME 3000:3000\n"
+      "notes": "You can connect to the container running cloudflare-dyndns. To open a shell session in the pod run the following:\n..."
     },
     "chart": {
       "metadata": {
-        "name": "aerospike",
-        "home": "http://aerospike.com",
-        "sources": ["https://github.com/aerospike/aerospike-server"],
-        "version": "0.3.2",
-        "description": "A Helm chart for Aerospike in Kubernetes",
-        "keywords": ["aerospike", "big-data"],
+        "name": "cloudflare-dyndns",
+        "home": "https://github.com/billimek/billimek-charts/tree/master/charts/cloudflare-dyndns",
+        "sources": [
+          "https://github.com/hotio/docker-cloudflare-ddns/",
+          "https://github.com/billimek/billimek-charts"
+        ],
+        "version": "2.0.0",
+        "description": "Dynamic DNS using Cloudflare's DNS Services",
+        "keywords": [
+          "cloudflare",
+          "dynamicdns"
+        ],
         "maintainers": [
           {
-            "name": "kavehmz",
-            "email": "kavehmz@gmail.com"
-          },
-          {
-            "name": "okgolove",
-            "email": "okgolove@markeloff.net"
+            "name": "billimek",
+            "email": "jeff@billimek.com"
           }
         ],
-        "icon": "https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png",
+        "icon": "https://www.cloudflare.com/img/cf-facebook-card.png",
         "apiVersion": "v1",
-        "appVersion": "v4.5.0.5",
+        "appVersion": "1.0",
         "deprecated": false
       },
       "templates": [
         {
           "name": "templates/NOTES.txt",
-          "data": "VGhlIEFlcm9zcGlrZSBjYW4"
+          "data": "WW91I...fScp"
         },
         {
           "name": "templates/_helpers.tpl",
-          "data": "e3svKiB2aW06IHNldCBmaW"
+          "data": "e3svKi...9Cg=="
         },
         {
-          "name": "templates/configmap.yaml",
-          "data": "YXBpVmVyc2lvbjogdjEKa2lu"
+          "name": "templates/deployment.yaml",
+          "data": "YXBpVm...9Cg=="
         },
         {
-          "name": "templates/nodeport.yaml",
-          "data": "e3stIGlmIC5WYWx1ZXMuc"
-        },
-        {
-          "name": "templates/service.yaml",
-          "data": "YXBpVmVyc2lvbjogdjEKa"
-        },
-        {
-          "name": "templates/servicemonitor.yaml",
-          "data": "e3stIGlmIGFuZCAoLlZ"
-        },
-        {
-          "name": "templates/statefulset.yaml",
-          "data": "YXBpVmVyc2lvbjogYXBwcy92MQpra"
+          "name": "templates/secret.yaml",
+          "data": "YXBpVmVy...X0="
         }
       ],
       "values": {
-        "annotations": {},
-        "args": [],
-        "command": [],
-        "confFile": "#default config file\nservice {\n    user root\n    group root\n    paxos-protocol v5\n    paxos-single-replica-limit 1\n    pidfile /var/run/aerospike/asd.pid\n    service-threads 4\n    transaction-queues 4\n    transaction-threads-per-queue 4\n    proto-fd-max 15000\n}\n\nlogging {\n    file /var/log/aerospike/aerospike.log {\n        context any info\n    }\n\n    console {\n        context any info\n    }\n}\n\nnetwork {\n    service {\n        address any\n        port 3000\n    }\n\n    heartbeat {\n        address any\n        interval 150\n        #REPLACE_THIS_LINE_WITH_MESH_CONFIG\n        mode mesh\n        port 3002\n        timeout 20\n        protocol v3\n    }\n\n    fabric {\n        port 3001\n    }\n\n    info {\n        port 3003\n    }\n}\n\nnamespace test {\n    replication-factor 2\n    memory-size 1G\n    default-ttl 5d\n    storage-engine device {\n        file /opt/aerospike/data/test.dat\n        filesize 4G\n    }\n}",
-        "image": {
-          "pullPolicy": "IfNotPresent",
-          "repository": "aerospike/aerospike-server",
-          "tag": "4.5.0.5"
+        "affinity": {},
+        "cloudflare": {
+          "detection_mode": "dig-google.com",
+          "hosts": "somehosts",
+          "log_level": 1.0,
+          "record_types": "somerecordtypes",
+          "sleep_interval": 300.0,
+          "token": "sometoken",
+          "user": "someuser",
+          "zones": "somezones"
         },
-        "labels": {},
-        "metrics": {
-          "serviceMonitor": {}
+        "image": {
+          "pullPolicy": "Always",
+          "repository": "hotio/cloudflare-ddns",
+          "tag": "latest"
         },
         "nodeSelector": {},
-        "persistentVolume": {},
         "replicaCount": 1.0,
         "resources": {},
-        "service": {
-          "annotations": {},
-          "clusterIP": "None",
-          "nodePort": {},
-          "type": "ClusterIP"
-        },
-        "terminationGracePeriodSeconds": 30.0,
         "tolerations": []
       },
       "files": [
         {
           "name": ".helmignore",
-          "data": "IyBQYXR0ZXJucyB0by"
-        },
-        {
-          "name": "OWNERS",
-          "data": "YXBwcm92ZXJzOgotIG9rZ29sb3ZlCnJldmlld2VyczoKLSBva2dvbG92ZQo="
+          "data": "IyBQYX...b2oK"
         },
         {
           "name": "README.md",
-          "data": "IyBBZXJvc3Bpa2UgSGVsbSBDa"
+          "data": "IyBE..4K"
         }
       ]
     },
-    "manifest": "---\n# Source: aerospike/templates/configmap.yaml\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: aerospike-1579797954\n  labels:\n    app: aerospike\n    chart: aerospike-0.3.2\n    release: aerospike-1579797954\n    heritage: Helm\ndata:\n  aerospike.conf: |\n    # aerospike configuration\n        #default config file\n    service {\n        user root\n        group root\n        paxos-protocol v5\n        paxos-single-replica-limit 1\n        pidfile /var/run/aerospike/asd.pid\n        # HERE UPDATE changed service threads from 4 to 3\n        service-threads 3\n        transaction-queues 4\n        transaction-threads-per-queue 4\n        proto-fd-max 15000\n    }\n    \n    logging {\n        file /var/log/aerospike/aerospike.log {\n            context any info\n        }\n    \n        console {\n            context any info\n        }\n    }\n    \n    network {\n        service {\n            address any\n            port 3000\n        }\n    \n        heartbeat {\n            address any\n            interval 150\n            \n        mesh-seed-address-port aerospike-1579797954-0.aerospike-1579797954 3002\n            mode mesh\n            port 3002\n            timeout 20\n            protocol v3\n        }\n    \n        fabric {\n            port 3001\n        }\n    \n        info {\n            port 3003\n        }\n    }\n    \n    namespace test {\n        replication-factor 2\n        memory-size 1G\n        default-ttl 5d\n        storage-engine device {\n            file /opt/aerospike/data/test.dat\n            filesize 4G\n        }\n    }\n---\n# Source: aerospike/templates/service.yaml\napiVersion: v1\nkind: Service\nmetadata:\n  name: aerospike-1579797954\n  labels:\n    app: aerospike\n    chart: aerospike-0.3.2\n    release: aerospike-1579797954\n    heritage: Helm\n  annotations:\nspec:\n  # so the mesh peer-finder works\n  publishNotReadyAddresses: true\n  \n  clusterIP: \"None\"\n  \n  type: ClusterIP\n  ports:\n    - port: 3000\n      protocol: TCP\n      name: client\n    - port: 3002\n      protocol: TCP\n      name: mesh\n    \n  selector:\n    app: aerospike\n    release: aerospike-1579797954\n---\n# Source: aerospike/templates/statefulset.yaml\napiVersion: apps/v1\nkind: StatefulSet\nmetadata:\n  name: aerospike-1579797954\n  labels:\n    app: aerospike\n    chart: aerospike-0.3.2\n    release: aerospike-1579797954\n    heritage: Helm\nspec:\n  serviceName: aerospike-1579797954\n  replicas: 1\n  selector:\n    matchLabels:\n      app: aerospike\n      release: aerospike-1579797954\n  template:\n    metadata:\n      labels:\n        app: aerospike\n        release: aerospike-1579797954\n      annotations:\n        checksum/config: a070d13fbcb5b721657425639577690b36bcd60897798a9e979ea6c2a2fa24c2\n    spec:\n      terminationGracePeriodSeconds: 30\n      containers:\n      - name: aerospike-1579797954\n        image: \"aerospike/aerospike-server:4.5.0.5\"\n        imagePullPolicy: IfNotPresent\n        \n        \n        ports:\n        - containerPort: 3000\n          name: clients\n        - containerPort: 3002\n          name: mesh\n        - containerPort: 3003\n          name: info\n        readinessProbe:\n          tcpSocket:\n              port: 3000\n          initialDelaySeconds: 15\n          timeoutSeconds: 1\n        volumeMounts:\n        - name: config-volume\n          mountPath: /etc/aerospike\n        resources:\n          \n          {}\n      \n      volumes:\n      - name: config-volume\n        configMap:\n          name: aerospike-1579797954\n          items:\n          - key: aerospike.conf\n            path: aerospike.conf\n      \n  volumeClaimTemplates:\n",
-    "version": 4,
-    "namespace": "pspensieri",
-    "chartVersion": "aerospike / 0.3.2"
+    "manifest": "---\n# Source: cloudflare-dyndns/templates/secret.yaml\napiVersion: v1\n...",
+    "config": {
+      "affinity": {},
+      "cloudflare": {
+        "detection_mode": "dig-google.com",
+        "hosts": "somehosts",
+        "log_level": 1.0,
+        "record_types": "somerecordtypes",
+        "sleep_interval": 300.0,
+        "token": "sometoken",
+        "user": "someuser",
+        "zones": "somezones"
+      },
+      "image": {
+        "pullPolicy": "Always",
+        "repository": "hotio/cloudflare-ddns",
+        "tag": "latest"
+      },
+      "nodeSelector": {},
+      "replicaCount": 1.0,
+      "resources": {},
+      "tolerations": []
+    },
+    "version": 11,
+    "namespace": "my-namespace",
+    "keepHistory": false,
+    "chartVersion": "cloudflare-dyndns / 2.0.0"
   }
 }
 ```
@@ -267,39 +294,40 @@ Retrieve a release in a given [environment](#administration-environments).
 | -------------------------- | ---------------------------------------------------- |
 | `cluster_id` <br/>_string_ | The id of the cluster in which to list the releases. |
 
-| Attributes                                 | &nbsp;                                                                                                                                                                |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name` <br/>_string_                       | The name of the release.                                                                                                                                              |
-| `info` <br/>_object_                       | The information about the release.                                                                                                                                    |
-| `info.first_deployed` <br/>_string_        | The annotations of the pod.                                                                                                                                           |
-| `info.last_deployed` <br/>_string_         | The date of creation of the pod as a string.                                                                                                                          |
-| `info.deleted` <br/>_string_               | The labels associated to the pod.                                                                                                                                     |
-| `info.description` <br/>_string_           | The name of the pod.                                                                                                                                                  |
-| `info.status` <br/>_string_                | The status of the release. Possible values are unknown, installed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade, pending-rollback. |
-| `info.notes` <br/>_string_                 | The notes linked to the release.                                                                                                                                      |
-| `chart`<br/>_object_                       | The information related to the chart of used in the release.                                                                                                          |
-| `chart.version` <br/>_string_              | The version of the chart.                                                                                                                                             |
-| `chart.metadata` <br/>_object_             | The metadata associated to the chart.                                                                                                                                 |
-| `chart.metadata.name` <br/>_string_        | The name of the chart.                                                                                                                                                |
-| `chart.metadata.home` <br/>_string_        | The home URL for the chart.                                                                                                                                           |
-| `chart.metadata.sources` <br/>_list_       | The list of source of the charts.                                                                                                                                     |
-| `chart.metadata.version` <br/>_string_     | The version of the chart.                                                                                                                                             |
-| `chart.metadata.description` <br/>_string_ | The description of the chart.                                                                                                                                         |
-| `chart.metadata.keywords` <br/>_list_      | The list of keywords linked to the chart.                                                                                                                             |
-| `chart.metadata.maintainers` <br/>_list_   | The list of the maintainer contact information.                                                                                                                       |
-| `chart.metadata.icon` <br/>_string_        | The icon URL for the chart.                                                                                                                                           |
-| `chart.metadata.appVersion` <br/>_string_  | The version of the application.                                                                                                                                       |
-| `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application.                                                                                                                 |
-| `chart.templates` <br/> _list_             | The list of templates contained inside the chart.                                                                                                                     |
-| `chart.templates.name` <br/> _string_      | The path name of the template inside the chart.                                                                                                                       |
-| `chart.templates.data` <br/> _string_      | The contents of the template. This is a base64 encode string.                                                                                                         |
-| `chart.files` <br/> _list_                 | The list of files contained inside the chart. These are not YAML files unlike the templates.                                                                          |
-| `chart.files.name` <br/> _string_          | The path name of the file inside the chart.                                                                                                                           |
-| `chart.files.data` <br/> _string_          | The contents of the file. This is a base64 encode string.                                                                                                             |
-| `manifest` <br/> _string_                  | The YAML Kubernetes resources created by the Helm templating.                                                                                                         |
-| `values` <br/>_object_                     | All values that were used to install the release.                                                                                                                     |
-| `version`<br/>_string_                     | The revision of the release.                                                                                                                                          |
-| `namespace`<br/>_string_                   | The namespace to which the release is installed.                                                                                                                      |
+| Attributes                                 | &nbsp;                                                                                                                                                                                  |
+|--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id` <br/>_string_                         | The release id, of the form `namespace/releaseName`.                                                                                                                                    |
+| `name` <br/>_string_                       | The name of the release.                                                                                                                                                                |
+| `info` <br/>_object_                       | The information about the release.                                                                                                                                                      |
+| `info.first_deployed` <br/>_string_        | The date the release was created.                                                                                                                                                       |
+| `info.last_deployed` <br/>_string_         | The date the release was last updated.                                                                                                                                                  |
+| `info.deleted` <br/>_string_               | The labels associated to the pod                                                                                                                                                        |
+| `info.description` <br/>_string_           | Description of the release's status.                                                                                                                                                    |
+| `info.status` <br/>_string_                | The status of the release. Possible values are `unknown`, `installed`, `uninstalled`, `superseded`, `failed`, `uninstalling`, `pending-install`, `pending-upgrade`, `pending-rollback`. |
+| `info.notes` <br/>_string_                 | The notes linked to the release.                                                                                                                                                        |
+| `chart`<br/>_object_                       | The information related to the chart used to install the release.                                                                                                                       |
+| `chart.version` <br/>_string_              | The version of the chart.                                                                                                                                                               |
+| `chart.metadata` <br/>_object_             | The metadata associated to the chart.                                                                                                                                                   |
+| `chart.metadata.name` <br/>_string_        | The name of the chart.                                                                                                                                                                  |
+| `chart.metadata.home` <br/>_string_        | The home URL for the chart.                                                                                                                                                             |
+| `chart.metadata.sources` <br/>_list_       | The list of source of the charts.                                                                                                                                                       |
+| `chart.metadata.version` <br/>_string_     | The version of the chart.                                                                                                                                                               |
+| `chart.metadata.description` <br/>_string_ | The description of the chart.                                                                                                                                                           |
+| `chart.metadata.keywords` <br/>_list_      | The list of keywords linked to the chart.                                                                                                                                               |
+| `chart.metadata.maintainers` <br/>_list_   | The list of the maintainer contact information.                                                                                                                                         |
+| `chart.metadata.icon` <br/>_string_        | The icon URL for the chart.                                                                                                                                                             |
+| `chart.metadata.appVersion` <br/>_string_  | The version of the application.                                                                                                                                                         |
+| `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application.                                                                                                                                   |
+| `chart.templates` <br/> _list_             | The list of templates contained inside the chart.                                                                                                                                       |
+| `chart.templates.name` <br/> _string_      | The path name of the template inside the chart.                                                                                                                                         |
+| `chart.templates.data` <br/> _string_      | The contents of the template. This is a base64 encode string.                                                                                                                           |
+| `chart.files` <br/> _list_                 | The list of files contained inside the chart. These are not YAML files unlike the templates.                                                                                            |
+| `chart.files.name` <br/> _string_          | The path name of the file inside the chart.                                                                                                                                             |
+| `chart.files.data` <br/> _string_          | The contents of the file. This is a base64 encode string.                                                                                                                               |
+| `manifest` <br/> _string_                  | The YAML Kubernetes resources created by the Helm templating.                                                                                                                           |
+| `config` <br/>_object_                     | All values that were used to install the release.                                                                                                                                       |
+| `version`<br/>_string_                     | The revision of the release.                                                                                                                                                            |
+| `namespace`<br/>_string_                   | The namespace to which the release is installed.                                                                                                                                        |
 
 <!-- ROLLBACK RELEASE -->
 
@@ -351,7 +379,7 @@ Rollback a release in a given [environment](#administration-environments) to the
 ```shell
 curl -X POST \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/pspensieri/aerospike-1579797954?operation=upgrade&cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
+   "https://cloudmc_endpoint/v1/services/a_service/an_environment/releases/my-namespace/my-aerospike?operation=upgrade&cluster_id=projects/cmc-k8s-enabled-llb/locations/us-central1-a/clusters/standard-cluster-1"
    -d "request_body"
 ```
 
@@ -360,18 +388,34 @@ curl -X POST \
 ```js
 // Change to the latest version of a chart
 {
-  "upgradeChart":  "stable/aerospike"
+	"upgradeChart": {
+		"name": "aerospike",
+		"repository": {
+			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
+		}
+	}
 }
 
 // Change to a specific version of a chart
 {
-  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
+  "upgradeChart": {
+		"name": "aerospike",
+    "version": "4.9.0",
+		"repository": {
+			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
+		}
+	}
 }
 
 // Change the values for the latest version
 {
-  "upgradeChart" : "stable/aerospike",
-  "values": "---\n\"replicaCount\": 3\n"
+  "upgradeChart": {
+		"name": "aerospike",
+		"repository": {
+			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
+		}
+	}
+  "upgradeValues": "\"replicaCount\": 3"
 }
 ```
 
@@ -388,14 +432,17 @@ curl -X POST \
 
 Upgrade a release in a given [environment](#administration-environments).
 
-| Required                     | &nbsp;                                                                                    |
-| ---------------------------- | ----------------------------------------------------------------------------------------- |
-| `cluster_id` <br/>_string_   | The id of the cluster in which to upgrade the release.                                    |
-| `upgradeChart` <br/>_string_ | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use. |
+| Required                          | &nbsp;                                                       |
+|-----------------------------------|--------------------------------------------------------------|
+| `upgradeChart` <br/>_Object_      | The chart object that should be used to ugprade the release. |
+| `upgradeChart.name` <br/>_string_ | The chart name.                                              |
+| `repository` <br/>_Object_        | The repository object to which the chart belongs.            |
+| `repository.url` <br/>_string_    | The repository's URL.                                        |
 
-| Optional               | &nbsp;                                                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------------------------------ |
-| `values` <br/>_string_ | YAML structured text that will overwrite the default values for the upgrade/installation of the chart. |
+| Optional                             | &nbsp;                                                                                                 |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `upgradeChart.version` <br/>_string_ | The chart version that should be used to upgrade the chart. If none is provided, the latest is used.   |
+| `upgradeChart.values` <br/>_string_  | YAML structured text that will overwrite the default values for the upgrade/installation of the chart. |
 
 | Attributes                 | &nbsp;                                  |
 | -------------------------- | --------------------------------------- |

--- a/source/includes/kubernetes_extension/_k8_releases.md
+++ b/source/includes/kubernetes_extension/_k8_releases.md
@@ -320,10 +320,10 @@ Retrieve a release in a given [environment](#administration-environments).
 | `chart.metadata.deprecate` <br/>_bool_     | If the chart is deprecated or not of the application.                                                                                                                                   |
 | `chart.templates` <br/> _list_             | The list of templates contained inside the chart.                                                                                                                                       |
 | `chart.templates.name` <br/> _string_      | The path name of the template inside the chart.                                                                                                                                         |
-| `chart.templates.data` <br/> _string_      | The contents of the template. This is a base64 encode string.                                                                                                                           |
+| `chart.templates.data` <br/> _string_      | The contents of the template. This is a base64 encoded string.                                                                                                                           |
 | `chart.files` <br/> _list_                 | The list of files contained inside the chart. These are not YAML files unlike the templates.                                                                                            |
 | `chart.files.name` <br/> _string_          | The path name of the file inside the chart.                                                                                                                                             |
-| `chart.files.data` <br/> _string_          | The contents of the file. This is a base64 encode string.                                                                                                                               |
+| `chart.files.data` <br/> _string_          | The contents of the file. This is a base64 encoded string.                                                                                                                               |
 | `manifest` <br/> _string_                  | The YAML Kubernetes resources created by the Helm templating.                                                                                                                           |
 | `config` <br/>_object_                     | All values that were used to install the release.                                                                                                                                       |
 | `version`<br/>_string_                     | The revision of the release.                                                                                                                                                            |
@@ -398,8 +398,8 @@ curl -X POST \
 
 // Change to a specific version of a chart
 {
-  "upgradeChart": {
-		"name": "aerospike",
+	"upgradeChart": {
+    "name": "aerospike",
     "version": "4.9.0",
 		"repository": {
 			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
@@ -409,12 +409,12 @@ curl -X POST \
 
 // Change the values for the latest version
 {
-  "upgradeChart": {
-		"name": "aerospike",
+	"upgradeChart": {
+    "name": "aerospike",
 		"repository": {
 			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
 		}
-	}
+  },
   "upgradeValues": "\"replicaCount\": 3"
 }
 ```

--- a/source/includes/kubernetes_extension/_k8_releases.md
+++ b/source/includes/kubernetes_extension/_k8_releases.md
@@ -399,8 +399,8 @@ curl -X POST \
 // Change to a specific version of a chart
 {
 	"upgradeChart": {
-    "name": "aerospike",
-    "version": "4.9.0",
+		"name": "aerospike",
+		"version": "4.9.0",
 		"repository": {
 			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
 		}
@@ -410,12 +410,12 @@ curl -X POST \
 // Change the values for the latest version
 {
 	"upgradeChart": {
-    "name": "aerospike",
+		"name": "aerospike",
 		"repository": {
 			"url": "https://aerospike.github.io/aerospike-kubernetes-enterprise"
 		}
-  },
-  "upgradeValues": "\"replicaCount\": 3"
+	},
+	"upgradeValues": "\"replicaCount\": 3"
 }
 ```
 


### PR DESCRIPTION
### Fixes [MC-12789](https://cloud-ops.atlassian.net/browse/MC-12789)

#### Changes made
<!-- Changes should match the template provided below -->
- Update chart docs
- Update release docs

#### Related PRs
- https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/226
- https://github.com/cloudops/cloudmc-kubernetes-sdk/pull/227

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->