### PR TITLE
MC-12814: Add documentation for email settings

### DIFF
--- a/source/includes/administration/_applied_pricings.md
+++ b/source/includes/administration/_applied_pricings.md
@@ -1,4 +1,4 @@
-### Applied Pricings
+## Applied Pricings
 
 The applied pricing allows the assignment of pricing to organization with a determined scope.
 

--- a/source/includes/administration/_email_settings.md
+++ b/source/includes/administration/_email_settings.md
@@ -107,7 +107,7 @@ Attributes | &nbsp;
 
 ```shell
 # Updates an existing email settings for an organization
-curl -X PUT "https://cloudmc_endpoint/rest/email_settings/:id" \
+curl -X PUT "https://cloudmc_endpoint/rest/email_settings/dc30f8f7-1edc-11eb-92b6-0242ac120003 \
    -H "MC-Api-Key: your_api_key"
    -H "Content-Type: application/json" \
    -d "request-body"

--- a/source/includes/administration/_email_settings.md
+++ b/source/includes/administration/_email_settings.md
@@ -88,7 +88,7 @@ Retrieve the email settings associated to the email settings id.
 Attributes | &nbsp;
 ---------- | -----------
 `id`<br/>*UUID* | The configured email settings' id.
-`organization.id`<br/>*UUID* | The organization id that the email settings is linked to.
+`organization.id`<br/>*UUID* | The organization id that the email settings are linked to.
 `smtpHost`<br/>*string* | Hostname or IP address of your SMTP mail server (e.g. smtp.yourcompany.com).
 `smtpFromAddress`<br/>*string* | Email address used in the 'sender address' (or 'from') field.
 `smtpUsername`<br/>*string* | If your SMTP host requires authentication, specify the username of these authentication credentials here.
@@ -119,16 +119,16 @@ curl -X PUT "https://cloudmc_endpoint/rest/email_settings/dc30f8f7-1edc-11eb-92b
 {
   "organization": {
 		"id": "ce77d759-c015-4a92-b594-3f7119867e1f"
-	},
-	"mailgunPrivateKey": "VALIDPRIVATEKEY",
-	"smtpHost": "valid.host",
-	"smtpFromAddress": "valid.address@domain.com",
-	"smtpUsername": "valid.username@gmail.com",
-	"smtpPort": 2,
-	"mailgunDomain": "valid.mailgun.domain",
-	"smtpPassword": "coolPassword",
-	"smtpUseSsl": false,
-	"id": "dc30f8f7-1edc-11eb-92b6-0242ac120003"
+  },
+  "mailgunPrivateKey": "VALIDPRIVATEKEY",
+  "smtpHost": "valid.host",
+  "smtpFromAddress": "valid.address@domain.com",
+  "smtpUsername": "valid.username@gmail.com",
+  "smtpPort": 2,
+  "mailgunDomain": "valid.mailgun.domain",
+  "smtpPassword": "coolPassword",
+  "smtpUseSsl": false,
+  "id": "dc30f8f7-1edc-11eb-92b6-0242ac120003"
 }
 ```
 > The above command return JSON structured like this:
@@ -169,4 +169,3 @@ Optional | &nbsp;
 `smtpUseSsl`<br/>*boolean* | Set to true if your SMTP host uses the SSL protocol.
 `mailgunDomain`<br/>string* | Domain name for the MailGun service.
 `mailgunPrivateKey`<br/>*string* | Private key for the MailGun service.
-

--- a/source/includes/administration/_email_settings.md
+++ b/source/includes/administration/_email_settings.md
@@ -1,5 +1,57 @@
 ## Email Settings
 
+<!-------------------- LIST EMAIL SETTINGS -------------------->
+
+### List email settings
+
+`GET /email_settings`
+
+```shell
+# Retrieve email settings
+curl "https://cloudmc_endpoint/rest/email_settings" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "mailgunPrivateKey": "VALIDPRIVATEKEY",
+      "smtpHost": "valid.host",
+      "smtpFromAddress": "valid.address@domain.com",
+      "smtpUsername": "valid.username@gmail.com",
+      "organization": {
+          "id": "fb1b2caf-4ca4-4c45-b094-faa84bdabc47"
+      },
+      "smtpPort": 2,
+      "mailgunDomain": "valid.mailgun.domain",
+      "smtpPassword": "coolPassword",
+      "smtpUseSsl": false,
+      "id": "dc30f9a6-1edc-11eb-92b6-0242ac120003"
+    }
+  ]
+}
+```
+List the email settings configured for the organization.
+
+Query Params | &nbsp;
+---- | -----------
+`organization_id`<br/>*UUID* | Return only the settings for the provided organization id. If not provided, will default to the user's organization.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The configured email settings' id.
+`organization.id`<br/>*UUID* | The organization id that the email settings are linked to.
+`smtpHost`<br/>*string* | Hostname or IP address of your SMTP mail server (e.g. smtp.yourcompany.com).
+`smtpFromAddress`<br/>*string* | Email address used in the 'sender address' (or 'from') field.
+`smtpUsername`<br/>*string* | If your SMTP host requires authentication, specify the username of these authentication credentials here.
+`smtpPassword`<br/>*string* | If your SMTP host requires authentication, specify the password associated with the username you specified.
+`smtpPort`<br/>*integer* | SMTP port number, usually 25 for SMTP or 465 for SMTPS.
+`smtpUseSsl`<br/>*boolean* | Set to true if your SMTP host uses the SSL protocol.
+`mailgunDomain`<br/>string* | Domain name for the MailGun service.
+`mailgunPrivateKey`<br/>*string* | Private key for the MailGun service.
+
 <!-------------------- GET EMAIL SETTINGS -------------------->
 
 ### Retrieve email settings
@@ -8,7 +60,7 @@
 
 ```shell
 # Retrieve knowledge base
-curl "https://cloudmc_endpoint/rest/brandings/dc30f9a6-1edc-11eb-92b6-0242ac120003" \
+curl "https://cloudmc_endpoint/rest/email_settings/dc30f9a6-1edc-11eb-92b6-0242ac120003" \
    -H "MC-Api-Key: your_api_key"
 ```
 > The above command returns JSON structured like this:
@@ -31,11 +83,11 @@ curl "https://cloudmc_endpoint/rest/brandings/dc30f9a6-1edc-11eb-92b6-0242ac1200
   }
 }
 ```
-Retrieve the email settings associated to the id.
+Retrieve the email settings associated to the email settings id.
 
 Attributes | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of email settings.
+`id`<br/>*UUID* | The configured email settings' id.
 `organization.id`<br/>*UUID* | The organization id that the email settings is linked to.
 `smtpHost`<br/>*string* | Hostname or IP address of your SMTP mail server (e.g. smtp.yourcompany.com).
 `smtpFromAddress`<br/>*string* | Email address used in the 'sender address' (or 'from') field.
@@ -43,66 +95,13 @@ Attributes | &nbsp;
 `smtpPassword`<br/>*string* | If your SMTP host requires authentication, specify the password associated with the username you specified.
 `smtpPort`<br/>*integer* | SMTP port number, usually 25 for SMTP or 465 for SMTPS.
 `smtpUseSsl`<br/>*boolean* | Set to true if your SMTP host uses the SSL protocol.
-`mailgunDomain`<br/>sString* | Domain name for the MailGun service.
-`mailgunPrivateKey`<br/>*string* | Private key for the MailGun service.
-
-
-<!-------------------- LIST EMAIL SETTINGS -------------------->
-
-#### List email settings
-
-`GET /email_settings`
-
-```shell
-# Retrieve email settings
-curl "https://cloudmc_endpoint/rest/email_settings" \
-   -H "MC-Api-Key: your_api_key"
-```
-> The above command returns JSON structured like this:
-
-```json
-{
-    "data": [
-        {
-            "mailgunPrivateKey": "VALIDPRIVATEKEY",
-            "smtpHost": "valid.host",
-            "smtpFromAddress": "valid.address@domain.com",
-            "smtpUsername": "valid.username@gmail.com",
-            "organization": {
-                "id": "fb1b2caf-4ca4-4c45-b094-faa84bdabc47"
-            },
-            "smtpPort": 2,
-            "mailgunDomain": "valid.mailgun.domain",
-            "smtpPassword": "coolPassword",
-            "smtpUseSsl": false,
-            "id": "dc30f9a6-1edc-11eb-92b6-0242ac120003"
-    }
-  ]
-}
-```
-List the email settings configured on the system.
-
-Query Params | &nbsp;
----- | -----------
-`organization_id`<br/>*UUID* | Return only settings for the provided organization id. If not provided, will default to the user organization.
-
-Attributes | &nbsp;
----------- | -----------
-`id`<br/>*UUID* | The id of email settings.
-`organization.id`<br/>*UUID* | The organization id that the email settings is linked to.
-`smtpHost`<br/>*string* | Hostname or IP address of your SMTP mail server (e.g. smtp.yourcompany.com).
-`smtpFromAddress`<br/>*string* | Email address used in the 'sender address' (or 'from') field.
-`smtpUsername`<br/>*string* | If your SMTP host requires authentication, specify the username of these authentication credentials here.
-`smtpPassword`<br/>*string* | If your SMTP host requires authentication, specify the password associated with the username you specified.
-`smtpPort`<br/>*integer* | SMTP port number, usually 25 for SMTP or 465 for SMTPS.
-`smtpUseSsl`<br/>*boolean* | Set to true if your SMTP host uses the SSL protocol.
-`mailgunDomain`<br/>sString* | Domain name for the MailGun service.
+`mailgunDomain`<br/>string* | Domain name for the MailGun service.
 `mailgunPrivateKey`<br/>*string* | Private key for the MailGun service.
 
 
 <!-------------------- UPDATE EMAIL SETTINGS -------------------->
 
-#### Update email settings
+### Update email settings
 
 `PUT /email_settings/:id`
 
@@ -110,13 +109,15 @@ Attributes | &nbsp;
 # Updates an existing email settings for an organization
 curl -X PUT "https://cloudmc_endpoint/rest/email_settings/:id" \
    -H "MC-Api-Key: your_api_key"
+   -H "Content-Type: application/json" \
+   -d "request-body"
 ```
 
 > Request body example:
 
 ```json
 {
-    "organization": {
+  "organization": {
 		"id": "ce77d759-c015-4a92-b594-3f7119867e1f"
 	},
 	"mailgunPrivateKey": "VALIDPRIVATEKEY",
@@ -156,7 +157,7 @@ Updates the email settings of an organization.
 Required | &nbsp;
 ---------- | -----------
 `id`<br/>*UUID* | The id of the email settings.
-`organization.id`<br/>*UUID* | The organization id that the email settings is linked to. It cannot be changed.
+`organization.id`<br/>*UUID* | The organization id that the email settings are linked to. It cannot be changed.
 
 Optional | &nbsp;
 ---------- | -----------
@@ -166,6 +167,6 @@ Optional | &nbsp;
 `smtpPassword`<br/>*string* | If your SMTP host requires authentication, specify the password associated with the username you specified.
 `smtpPort`<br/>*integer* | SMTP port number, usually 25 for SMTP or 465 for SMTPS.
 `smtpUseSsl`<br/>*boolean* | Set to true if your SMTP host uses the SSL protocol.
-`mailgunDomain`<br/>sString* | Domain name for the MailGun service.
+`mailgunDomain`<br/>string* | Domain name for the MailGun service.
 `mailgunPrivateKey`<br/>*string* | Private key for the MailGun service.
 

--- a/source/includes/administration/_email_settings.md
+++ b/source/includes/administration/_email_settings.md
@@ -1,0 +1,171 @@
+## Email Settings
+
+<!-------------------- GET EMAIL SETTINGS -------------------->
+
+### Retrieve email settings
+
+`GET /email_settings/:id`
+
+```shell
+# Retrieve knowledge base
+curl "https://cloudmc_endpoint/rest/brandings/dc30f9a6-1edc-11eb-92b6-0242ac120003" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "mailgunPrivateKey": "VALIDPRIVATEKEY",
+    "smtpHost": "valid.host",
+    "smtpFromAddress": "valid.address@domain.com",
+    "smtpUsername": "valid.username@gmail.com",
+    "organization": {
+      "id": "fb1b2caf-4ca4-4c45-b094-faa84bdabc47"
+    },
+    "smtpPort": 2,
+    "mailgunDomain": "valid.mailgun.domain",
+    "smtpPassword": "coolPassword",
+    "smtpUseSsl": false,
+    "id": "dc30f9a6-1edc-11eb-92b6-0242ac120003"
+  }
+}
+```
+Retrieve the email settings associated to the id.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of email settings.
+`organization.id`<br/>*UUID* | The organization id that the email settings is linked to.
+`smtpHost`<br/>*string* | Hostname or IP address of your SMTP mail server (e.g. smtp.yourcompany.com).
+`smtpFromAddress`<br/>*string* | Email address used in the 'sender address' (or 'from') field.
+`smtpUsername`<br/>*string* | If your SMTP host requires authentication, specify the username of these authentication credentials here.
+`smtpPassword`<br/>*string* | If your SMTP host requires authentication, specify the password associated with the username you specified.
+`smtpPort`<br/>*integer* | SMTP port number, usually 25 for SMTP or 465 for SMTPS.
+`smtpUseSsl`<br/>*boolean* | Set to true if your SMTP host uses the SSL protocol.
+`mailgunDomain`<br/>sString* | Domain name for the MailGun service.
+`mailgunPrivateKey`<br/>*string* | Private key for the MailGun service.
+
+
+<!-------------------- LIST EMAIL SETTINGS -------------------->
+
+#### List email settings
+
+`GET /email_settings`
+
+```shell
+# Retrieve email settings
+curl "https://cloudmc_endpoint/rest/email_settings" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+    "data": [
+        {
+            "mailgunPrivateKey": "VALIDPRIVATEKEY",
+            "smtpHost": "valid.host",
+            "smtpFromAddress": "valid.address@domain.com",
+            "smtpUsername": "valid.username@gmail.com",
+            "organization": {
+                "id": "fb1b2caf-4ca4-4c45-b094-faa84bdabc47"
+            },
+            "smtpPort": 2,
+            "mailgunDomain": "valid.mailgun.domain",
+            "smtpPassword": "coolPassword",
+            "smtpUseSsl": false,
+            "id": "dc30f9a6-1edc-11eb-92b6-0242ac120003"
+    }
+  ]
+}
+```
+List the email settings configured on the system.
+
+Query Params | &nbsp;
+---- | -----------
+`organization_id`<br/>*UUID* | Return only settings for the provided organization id. If not provided, will default to the user organization.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of email settings.
+`organization.id`<br/>*UUID* | The organization id that the email settings is linked to.
+`smtpHost`<br/>*string* | Hostname or IP address of your SMTP mail server (e.g. smtp.yourcompany.com).
+`smtpFromAddress`<br/>*string* | Email address used in the 'sender address' (or 'from') field.
+`smtpUsername`<br/>*string* | If your SMTP host requires authentication, specify the username of these authentication credentials here.
+`smtpPassword`<br/>*string* | If your SMTP host requires authentication, specify the password associated with the username you specified.
+`smtpPort`<br/>*integer* | SMTP port number, usually 25 for SMTP or 465 for SMTPS.
+`smtpUseSsl`<br/>*boolean* | Set to true if your SMTP host uses the SSL protocol.
+`mailgunDomain`<br/>sString* | Domain name for the MailGun service.
+`mailgunPrivateKey`<br/>*string* | Private key for the MailGun service.
+
+
+<!-------------------- UPDATE EMAIL SETTINGS -------------------->
+
+#### Update email settings
+
+`PUT /email_settings/:id`
+
+```shell
+# Updates an existing email settings for an organization
+curl -X PUT "https://cloudmc_endpoint/rest/email_settings/:id" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```json
+{
+    "organization": {
+		"id": "ce77d759-c015-4a92-b594-3f7119867e1f"
+	},
+	"mailgunPrivateKey": "VALIDPRIVATEKEY",
+	"smtpHost": "valid.host",
+	"smtpFromAddress": "valid.address@domain.com",
+	"smtpUsername": "valid.username@gmail.com",
+	"smtpPort": 2,
+	"mailgunDomain": "valid.mailgun.domain",
+	"smtpPassword": "coolPassword",
+	"smtpUseSsl": false,
+	"id": "dc30f8f7-1edc-11eb-92b6-0242ac120003"
+}
+```
+> The above command return JSON structured like this:
+
+```json
+{
+  "data": {
+    "mailgunPrivateKey": "VALIDPRIVATEKEY",
+    "smtpHost": "valid.host",
+    "smtpFromAddress": "valid.address@domain.com",
+    "smtpUsername": "valid.username@gmail.com",
+    "organization": {
+      "id": "ce77d759-c015-4a92-b594-3f7119867e1f"
+    },
+    "smtpPort": 2,
+    "mailgunDomain": "valid.mailgun.domain",
+    "smtpPassword": "coolPassword",
+    "smtpUseSsl": false,
+    "id": "dc30f8f7-1edc-11eb-92b6-0242ac120003"
+  }
+}
+```
+
+Updates the email settings of an organization.
+
+Required | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The id of the email settings.
+`organization.id`<br/>*UUID* | The organization id that the email settings is linked to. It cannot be changed.
+
+Optional | &nbsp;
+---------- | -----------
+`smtpHost`<br/>*string* | Hostname or IP address of your SMTP mail server (e.g. smtp.yourcompany.com).
+`smtpFromAddress`<br/>*string* | Email address used in the 'sender address' (or 'from') field.
+`smtpUsername`<br/>*string* | If your SMTP host requires authentication, specify the username of these authentication credentials here.
+`smtpPassword`<br/>*string* | If your SMTP host requires authentication, specify the password associated with the username you specified.
+`smtpPort`<br/>*integer* | SMTP port number, usually 25 for SMTP or 465 for SMTPS.
+`smtpUseSsl`<br/>*boolean* | Set to true if your SMTP host uses the SSL protocol.
+`mailgunDomain`<br/>sString* | Domain name for the MailGun service.
+`mailgunPrivateKey`<br/>*string* | Private key for the MailGun service.
+

--- a/source/includes/administration/_email_settings.md
+++ b/source/includes/administration/_email_settings.md
@@ -156,7 +156,7 @@ Updates the email settings of an organization.
 
 Required | &nbsp;
 ---------- | -----------
-`id`<br/>*UUID* | The id of the email settings.
+`id`<br/>*UUID* | The configured email settings' id.
 `organization.id`<br/>*UUID* | The organization id that the email settings are linked to. It cannot be changed.
 
 Optional | &nbsp;

--- a/source/includes/administration/_email_settings.md
+++ b/source/includes/administration/_email_settings.md
@@ -118,7 +118,7 @@ curl -X PUT "https://cloudmc_endpoint/rest/email_settings/dc30f8f7-1edc-11eb-92b
 ```json
 {
   "organization": {
-		"id": "ce77d759-c015-4a92-b594-3f7119867e1f"
+    "id": "ce77d759-c015-4a92-b594-3f7119867e1f"
   },
   "mailgunPrivateKey": "VALIDPRIVATEKEY",
   "smtpHost": "valid.host",

--- a/source/includes/administration/_pricings.md
+++ b/source/includes/administration/_pricings.md
@@ -1,4 +1,4 @@
-### Pricings
+## Pricings
 
 The pricing determines the price for each product defined for a selected catalog.
 

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -1,4 +1,4 @@
-### Product Catalogs
+## Product Catalogs
 
 The product catalogs determine the product configured for a service type and optionally for specific connections.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -24,6 +24,7 @@ includes:
   - administration/service_providers
   - administration/saml_settings
   - administration/trials
+  - administration/email_settings
   - cloudstack
   - cloudstack/compute # Compute section
   - cloudstack/instances


### PR DESCRIPTION
### Fixes [MC-12814](https://cloud-ops.atlassian.net/browse/MC-12814)

#### Changes made
- Add documentation for email settings resource endpoint

#### Related PRs
- [Core #993](https://github.com/cloudops/cloudmc-core/pull/993)
- [UI #1089](https://github.com/cloudops/cloudmc-ui/pull/1089)