### PR TITLE
MC-12976: Adding list all and get workload api docs

### DIFF
--- a/source/includes/_stackpath.md
+++ b/source/includes/_stackpath.md
@@ -1,3 +1,3 @@
 # Stackpath plugin
 
-The Stackpath plugin provides endpoints for carrying out operations on CloudMC Edge computing entities. It also enforces CloudMC's environment-centric multi-tenancy model and RBAC over top of GCP.
+The Stackpath plugin provides endpoints for carrying out operations on CloudMC Edge computing entities. It also enforces CloudMC's environment-centric multi-tenancy model and RBAC over top of Stackpath.

--- a/source/includes/_stackpath.md
+++ b/source/includes/_stackpath.md
@@ -1,0 +1,3 @@
+# Stackpath plugin
+
+The Stackpath plugin provides endpoints for carrying out operations on CloudMC Edge computing entities. It also enforces CloudMC's environment-centric multi-tenancy model and RBAC over top of GCP.

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -63,7 +63,7 @@ Attributes | &nbsp;
 
 <!-------------------- RETRIEVE A WORKLOAD -------------------->
 
-#### Retrieve an instance
+### Retrieve an instance
 
 ```shell
 curl -X GET \

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -1,10 +1,10 @@
-### Workloads
+## Workloads
 
 Deploy and manage your workloads.
 
 <!-------------------- LIST WORKLOADS -------------------->
 
-#### List workloads
+### List workloads
 
 ```shell
 curl -X GET \

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -1,6 +1,9 @@
 ## Workloads
 
+StackPath Edge Computing uses the concept of workloads to organize different applications. A workload can consist of one container or virtual machine image that is deployed to one or many locations.
+
 Deploy and manage your workloads.
+
 
 <!-------------------- LIST WORKLOADS -------------------->
 
@@ -53,7 +56,7 @@ Attributes | &nbsp;
 `spec`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
 `version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
 `created`<br/>*string* | Creation timestamp of the workload.
-`type`<br/>*string* | Specify whether a workload is a VM based workload or container based.
+`type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
 `network`<br/>*string* | Network interfaces to bind to the workload's instances.
 `cpu`<br/>*string* | The number of vCPUs for the workload's instance.
 `memory`<br/>*string* | The memory size for the workload's instance.
@@ -107,7 +110,7 @@ Attributes | &nbsp;
 `spec`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
 `version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
 `created`<br/>*string* | Creation timestamp of the workload.
-`type`<br/>*string* | Specify whether a workload is a VM based workload or container based.
+`type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
 `network`<br/>*string* | Network interfaces to bind to the workload's instances.
 `cpu`<br/>*string* | The number of vCPUs for the workload's instance.
 `memory`<br/>*string* | The memory size for the workload's instance.

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -1,0 +1,115 @@
+### Workloads
+
+Deploy and manage your workloads.
+
+<!-------------------- LIST WORKLOADS -------------------->
+
+#### List workloads
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/stackpath/test-area/workloads"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "1b932678-1038-4ab4-9fa4-c4c06e696e20",
+      "name": "stackpath_wl_01",
+      "stackId": "3e651d2e-b1f4-44ad-b21a-ebcd0bf79ca1",
+      "slug": "stackpath-workload-01",
+      "status": "ACTIVE",
+      "spec": "SP-2",
+      "version": "3",
+      "created": "2020-11-06T18:48:36.850115786Z",
+      "type": "VM",
+      "network": "default",
+      "cpu": "2",
+      "memory": "4Gi",
+      "isRemoteManagementEnabled": false,
+      "image": "stackpath-edge/centos-7:v202007311835"
+    }
+  ],
+  "metadata": {
+    "recordCount": 1
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/workloads</code>
+
+Retrieve a list of all workloads in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | A workload's unique identifier.
+`name`<br/>*string* | The display name of the workload.
+`stackId`<br/>*string* | The ID of the stack that a workload belongs to.
+`slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
+`status`<br/>*string* | The status of the workload. It can be either ACTIVE or DISABLED.
+`spec`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
+`version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
+`created`<br/>*string* | Creation timestamp of the workload.
+`type`<br/>*string* | Specify whether a workload is a VM based workload or container based.
+`network`<br/>*string* | Network interfaces to bind to the workload's instances.
+`cpu`<br/>*string* | The number of vCPUs for the workload's instance.
+`memory`<br/>*string* | The memory size for the workload's instance.
+`isRemoteManagementEnabled`<br/>*boolean* | Specify if remote management is enabled on workload instance or not.
+`image`<br/>*string* | The workload's instance operating system image.
+
+
+<!-------------------- RETRIEVE A WORKLOAD -------------------->
+
+#### Retrieve an instance
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/stackpath/test-area/workloads/1b932678-1038-4ab4-9fa4-c4c06e696e20"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "bf9fd2ac-f761-46ef-88e0-b61ef68f8619",
+    "name": "stackpath-wl-01",
+    "stackId": "3e651d2e-b1f4-44ad-b21a-ebcd0bf79ca1",
+    "slug": "stackpath-workload-01",
+    "status": "ACTIVE",
+    "spec": "SP-1",
+    "version": "3",
+    "created": "2020-11-09T08:28:45.185278507Z",
+    "type": "Container",
+    "network": "default",
+    "cpu": "1",
+    "memory": "2Gi",
+    "isRemoteManagementEnabled": false,
+    "image": "nginx:latest"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/workloads/:id</code>
+
+Retrieve an instance in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | A workload's unique identifier.
+`name`<br/>*string* | The display name of the workload.
+`stackId`<br/>*string* | The ID of the stack that a workload belongs to.
+`slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
+`status`<br/>*string* | The status of the workload. It can be either ACTIVE or DISABLED.
+`spec`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
+`version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
+`created`<br/>*string* | Creation timestamp of the workload.
+`type`<br/>*string* | Specify whether a workload is a VM based workload or container based.
+`network`<br/>*string* | Network interfaces to bind to the workload's instances.
+`cpu`<br/>*string* | The number of vCPUs for the workload's instance.
+`memory`<br/>*string* | The memory size for the workload's instance.
+`isRemoteManagementEnabled`<br/>*boolean* | Specify if remote management is enabled on workload instance or not.
+`image`<br/>*string* | The workload's instance operating system image.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -183,6 +183,8 @@ includes:
   - swift
   - swift/containers
   - swift/objects
+  - stackpath
+  - stackpath/workloads
 
 search: true
 ---


### PR DESCRIPTION
### Fixes [MC-12976](https://cloud-ops.atlassian.net/browse/MC-12976)

#### Changes made
Added API docs for list all and get workload for stackpath plugin
- ...

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->