### PR TITLE
MC-13026 addition of api docs for images

### DIFF
--- a/source/includes/stackpath/_images.md
+++ b/source/includes/stackpath/_images.md
@@ -3,7 +3,7 @@
 StackPath Edge Computing makes use of images to deploy virtual machines within a workload. The image can be from StackPath default images or
 a custom one. Only non-deprecated images are returned by default.
 
-Deploy and manage your Images.
+Deploy and manage your images.
 
 
 <!-------------------- LIST IMAGES -------------------->
@@ -22,7 +22,7 @@ curl -X GET \
   "data": [
     {
       "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
-      "id": "acad328a-153c-405b-a94d-d03479010e91",
+      "id": "a8050b2b-39eb-4929-bce5-1af42055903e/centos7/v20201110",
       "family": "centos7",
       "tag": "v20201110",
       "createdAt": "2020-11-10T20:33:32.609434Z",
@@ -32,7 +32,7 @@ curl -X GET \
     },
     {
       "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
-      "id": "c6f9f9c4-31a3-4114-946e-0bb82883301a",
+      "id": "a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu/v20201110",
       "family": "ubuntu",
       "tag": "v20201110",
       "createdAt": "2020-11-10T20:34:11.328575Z",
@@ -53,7 +53,7 @@ Retrieve a list of all images in a given [environment](#administration-environme
 
 Attributes | &nbsp;
 ------- | -----------
-`id`<br/>*string* | An image's unique identifier. It is the combination of /.
+`id`<br/>*string* | An image's unique identifier. It is the combination of stackId/family/tag.
 `stackId`<br/>*string* | The ID of the stack that an image belongs to.
 `family`<br/>*string* | The family of the image.
 `tag`<br/>*string* | The tag of the image.
@@ -70,7 +70,7 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/stackpath/test-area/images/image?family=ubuntu&tag=v20201110"
+   "https://cloudmc_endpoint/v1/services/stackpath/test-area/images/:id"
 ```
 > The above command returns a JSON structured like this:
 
@@ -78,7 +78,7 @@ curl -X GET \
 {
   "data": {
     "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
-    "id": "c6f9f9c4-31a3-4114-946e-0bb82883301a",
+    "id": "a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu/v20201110",
     "family": "ubuntu",
     "tag": "v20201110",
     "createdAt": "2020-11-10T20:34:11.328575Z",
@@ -95,7 +95,7 @@ Retrieve an image in a given [environment](#administration-environments).
 
 Attributes | &nbsp;
 ------- | -----------
-`id`<br/>*string* | An image's unique identifier. It is the combination of /.
+`id`<br/>*string* | An image's unique identifier. It is the combination of stackId/family/tag.
 `stackId`<br/>*string* | The ID of the stack that an image belongs to.
 `family`<br/>*string* | The family of the image.
 `tag`<br/>*string* | The tag of the image.

--- a/source/includes/stackpath/_images.md
+++ b/source/includes/stackpath/_images.md
@@ -1,0 +1,106 @@
+## Images
+
+StackPath Edge Computing makes use of images to deploy virtual machines within a workload. The image can be from StackPath default images or
+a custom one. Only non-deprecated images are returned by default.
+
+Deploy and manage your Images.
+
+
+<!-------------------- LIST IMAGES -------------------->
+
+### List images
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/stackpath/test-area/images"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
+      "id": "acad328a-153c-405b-a94d-d03479010e91",
+      "family": "centos7",
+      "tag": "v20201110",
+      "createdAt": "2020-11-10T20:33:32.609434Z",
+      "description": "Image using centos7",
+      "reference": "a8050b2b-39eb-4929-bce5-1af42055903e/centos7:v20201110",
+      "status": "READY"
+    },
+    {
+      "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
+      "id": "c6f9f9c4-31a3-4114-946e-0bb82883301a",
+      "family": "ubuntu",
+      "tag": "v20201110",
+      "createdAt": "2020-11-10T20:34:11.328575Z",
+      "description": "Image using ubuntu",
+      "reference": "a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu:v20201110",
+      "status": "READY"
+    }
+  ],
+  "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/images</code>
+
+Retrieve a list of all images in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | An image's unique identifier. It is the combination of /.
+`stackId`<br/>*string* | The ID of the stack that an image belongs to.
+`family`<br/>*string* | The family of the image.
+`tag`<br/>*string* | The tag of the image.
+`slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
+`status`<br/>*string* | The status of the workload. It can be either READY, PENDING, PROCESSING, FAILED or IMAGE_STATUS_UNKNOWN.
+`createdAt`<br/>*string* | Creation timestamp of the image.
+`description`<br/>*string* | The description of the image.
+`reference`<br/>*string* | The reference of the image.
+
+<!-------------------- RETRIEVE AN IMAGE -------------------->
+
+### Retrieve an image
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/stackpath/test-area/images/image?family=ubuntu&tag=v20201110"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
+    "id": "c6f9f9c4-31a3-4114-946e-0bb82883301a",
+    "family": "ubuntu",
+    "tag": "v20201110",
+    "createdAt": "2020-11-10T20:34:11.328575Z",
+    "description": "test 2",
+    "reference": "a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu:v20201110",
+    "status": "READY"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/images/:id</code>
+
+Retrieve an image in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | An image's unique identifier. It is the combination of /.
+`stackId`<br/>*string* | The ID of the stack that an image belongs to.
+`family`<br/>*string* | The family of the image.
+`tag`<br/>*string* | The tag of the image.
+`slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
+`status`<br/>*string* | The status of the workload. It can be either READY, PENDING, PROCESSING, FAILED or IMAGE_STATUS_UNKNOWN.
+`createdAt`<br/>*string* | Creation timestamp of the image.
+`description`<br/>*string* | The description of the image.
+`reference`<br/>*string* | The reference of the image.

--- a/source/includes/stackpath/_images.md
+++ b/source/includes/stackpath/_images.md
@@ -70,7 +70,7 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/v1/services/stackpath/test-area/images/:id"
+   "https://cloudmc_endpoint/v1/services/stackpath/test-area/images/a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu/v20201110"
 ```
 > The above command returns a JSON structured like this:
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -186,6 +186,7 @@ includes:
   - stackpath
   - stackpath/workloads
   - stackpath/instances
+  - stackpath/images
 
 search: true
 ---


### PR DESCRIPTION
### Fixes [MC-13026](https://cloudops.atlassian.net/browse/MC-13026)

#### Changes made
<!-- Changes should match the template provided below -->
- addition of images from stackpath.

#### Related PRs
- [list-images](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/19)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->