### PR TITLE
Fix truncated string for chart name in k8 doc

### DIFF
--- a/source/includes/kubernetes/_k8_charts.md
+++ b/source/includes/kubernetes/_k8_charts.md
@@ -56,7 +56,7 @@ Retrieve a list of all charts in a given [environment](#administration-environme
 | Attributes                                         | &nbsp;                                                                                                     |
 |----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `id` <br/>_string_                                 | The id for the chart, of the form `repositoryName/chartName`.                                              |
-| `name` <br/>_st                                    | The chart name.                                                                                            |
+| `name` <br/>_string_                               | The chart name.                                                                                            |
 | `description` <br/>_string_                        | The chart description.                                                                                     |
 | `version` <br/>_string_                            | The latest chart version.                                                                                  |
 | `license` <br/>_string_                            | The chart's license.                                                                                       |
@@ -159,7 +159,7 @@ Retrieve a specific chart in a given [environment](#administration-environments)
 | Attributes                                         | &nbsp;                                                                                                     |
 |----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `id` <br/>_string_                                 | The id for the chart, of the form `repositoryName/chartName`.                                              |
-| `name` <br/>_st                                    | The chart name.                                                                                            |
+| `name` <br/>_string_                               | The chart name.                                                                                            |
 | `description` <br/>_string_                        | The chart description.                                                                                     |
 | `version` <br/>_string_                            | The latest chart version.                                                                                  |
 | `license` <br/>_string_                            | The chart's license.                                                                                       |

--- a/source/includes/kubernetes_extension/_k8_charts.md
+++ b/source/includes/kubernetes_extension/_k8_charts.md
@@ -63,7 +63,7 @@ Attributes | &nbsp;
 | Attributes                                         | &nbsp;                                                                                                     |
 |----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `id` <br/>_string_                                 | The id for the chart, of the form `repositoryName/chartName`.                                              |
-| `name` <br/>_st                                    | The chart name.                                                                                            |
+| `name` <br/>_string_                               | The chart name.                                                                                            |
 | `description` <br/>_string_                        | The chart description.                                                                                     |
 | `version` <br/>_string_                            | The latest chart version.                                                                                  |
 | `license` <br/>_string_                            | The chart's license.                                                                                       |
@@ -173,7 +173,7 @@ Required | &nbsp;
 | Attributes                                         | &nbsp;                                                                                                     |
 |----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `id` <br/>_string_                                 | The id for the chart, of the form `repositoryName/chartName`.                                              |
-| `name` <br/>_st                                    | The chart name.                                                                                            |
+| `name` <br/>_string_                               | The chart name.                                                                                            |
 | `description` <br/>_string_                        | The chart description.                                                                                     |
 | `version` <br/>_string_                            | The latest chart version.                                                                                  |
 | `license` <br/>_string_                            | The chart's license.                                                                                       |


### PR DESCRIPTION
### Context

Hi CloudOps folks 👋 I don't have a JIRA ticket for this. I was reading the API documentation and stumbled upon this after building the documentation.

<img width="425" alt="Before" src="https://user-images.githubusercontent.com/17802570/99150884-77e54a80-2665-11eb-9d39-fbde84848051.png">

I thought I would create this PR to fix the issue.

#### Changes made

- Changed `_st` to `_string_` to it can be rendered properly in `source/includes/kubernetes/_k8_charts.md` and in `source/includes/kubernetes_extension/_k8_charts.md`.

### How was it tested?

- I tested it locally by rebuilding the docker image. It now looks like this:

<img width="445" alt="after" src="https://user-images.githubusercontent.com/17802570/99150976-fe9a2780-2665-11eb-8f96-e8711256b0c6.png">


<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->