### PR TITLE
Mc 12986 create network policy

### DIFF
--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -1,0 +1,44 @@
+## Network policy rules
+
+Network policy rules allows you to control inbound and outbound traffic to your [workload](#stackpath-workloads).
+
+
+<!-------------------- CREATE A FIREWALL RULE -------------------->
+
+#### Create a network policy rule
+
+```shell
+curl -X POST \
+  -H "MC-Api-Key: your_api_key" \
+  -d "request_body" \
+  "https://cloudmc_endpoint/v1/services/stackpath/test-area/networkpolicyrules?workloadId=bf9fd2ac-f761-46ef-88e0-b61ef68f8619"
+```
+> Request body example:
+
+```json
+{
+  "description": "npr_cloudmc_isk",
+  "protocol": "tcp",
+  "type": "INBOUND",
+  "action": "ALLOW",
+  "source": "0.0.0.0/0",
+  "portRange": "8080"
+}
+```
+
+<code>CREATE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/?workloadId=:workloadId</code>
+
+Create a new network policy rule.
+
+Query Params | &nbsp;
+---- | -----------
+`workloadId`<br/>*string* | The workload ID to create a network policy for. It is mandatory.
+
+Required | &nbsp;
+------- | -----------
+`description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
+`protocol`<br/>*string* | Supported protocols are: `tcp`, `udp`, `tcp/udp`, `esp` and `ah`. 
+`type`<br/>*string* | Either Inbound or Outbound
+`action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `DENY` (deny traffic).
+`source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
+`portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -26,7 +26,7 @@ curl -X POST \
 }
 ```
 
-<code>CREATE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/?workloadId=:workloadId</code>
+<code>CREATE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules?workloadId=:workloadId</code>
 
 Create a new network policy rule.
 

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -5,7 +5,7 @@ Network policy rules allows you to control inbound and outbound traffic to your 
 
 <!-------------------- CREATE A NETWORK POLICY RULE -------------------->
 
-#### Create a network policy rule
+### Create a network policy rule
 
 ```shell
 curl -X POST \

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -3,7 +3,7 @@
 Network policy rules allows you to control inbound and outbound traffic to your [workload](#stackpath-workloads).
 
 
-<!-------------------- CREATE A FIREWALL RULE -------------------->
+<!-------------------- CREATE A NETWORK POLICY RULE -------------------->
 
 #### Create a network policy rule
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -187,6 +187,7 @@ includes:
   - stackpath/workloads
   - stackpath/instances
   - stackpath/images
+  - stackpath/network_policy_rules
 
 search: true
 ---


### PR DESCRIPTION
### Fixes [MC-12986](https://cloud-ops.atlassian.net/browse/MC-12986)

#### Changes made
Added API docs for creating network policy rules.

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->