### PR TITLE
MC-12985: Document get and list network policy rules

### DIFF
--- a/source/includes/administration/_service_connections.md
+++ b/source/includes/administration/_service_connections.md
@@ -32,7 +32,7 @@ Attributes | &nbsp;
 
 Optional query parameters | &nbsp;
 ---------- | -----
-`organizationId`<br/>*string* | The organization whose connections are to be retreived. If this is not provided then the request defaults to the user's organization.
+`organizationId`<br/>*string* | The organization whose connections are to be retrieved. If this is not provided then the request defaults to the user's organization.
 
 <!-------------------- GET SERVICE CONNECTION -------------------->
 
@@ -69,7 +69,7 @@ Attributes | &nbsp;
 `GET /services/descriptors/:pluginType/parameters`
 
 ```shell
-# Retreive service connection parameters
+# Retrieve service connection parameters
 
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \

--- a/source/includes/gcp/_firewall_rules.md
+++ b/source/includes/gcp/_firewall_rules.md
@@ -168,7 +168,7 @@ curl -X POST \
 }
 ```
 
-<code>CREATE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/firewallrule</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/firewallrule</code>
 
 Create a new firewall rule.
 

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -52,6 +52,11 @@ curl -X GET \
 
 Retrieve a list of all network policy rules in a given [environment](#administration-environments).
 
+Query Params | &nbsp;
+---- | -----------
+`workloadId`<br/>*string* | The workload ID to get the network policy rules for. It is optional.
+`type`<br/>*string* | The type of network policy rule, either `INBOUND` or `OUTBOUND`. It is optional.
+
 Attributes | &nbsp;
 ------- | -----------
 `id`<br/>*string* | The ID of the network policy rule, in the form `workloadId/hashCode`.
@@ -62,7 +67,7 @@ Attributes | &nbsp;
 `type`<br/>*string* | The type of network policy rule, either `inbound` or `outbound`.
 `source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
-`protocol`<br/>*string* | Supported protocols are: `tcp`, `udp`, `tcpUdp`, `esp` and `ah`.
+`protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP`, `AH`, `ICMP` or `GRE`.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
 
 <!-------------------- GET A NETWORK POLICY RULE -------------------->
@@ -108,7 +113,7 @@ Attributes | &nbsp;
 `type`<br/>*string* | The type of network policy rule, either `inbound` or `outbound`.
 `source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
-`protocol`<br/>*string* | Supported protocols are: `tcp`, `udp`, `tcpUdp`, `esp` and `ah`.
+`protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP`, `AH`, `ICMP` or `GRE`.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
 
 <!-------------------- CREATE A NETWORK POLICY RULE -------------------->

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -48,7 +48,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules</code>
 
 Retrieve a list of all network policy rules in a given [environment](#administration-environments).
 

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -3,6 +3,114 @@
 Network policy rules allows you to control inbound and outbound traffic to your [workload](#stackpath-workloads).
 
 
+<!-------------------- LIST NETWORK POLICY RULES -------------------->
+### List network policy rules
+
+```shell
+curl -X GET \
+  -H "MC-Api-Key: your_api_key" \
+  "https://cloudmc_endpoint/v1/services/stackpath/test-area/networkpolicyrules"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "stackId": "bcc60174-50e6-44e4-bd45-463845124d87",
+      "workloadId": "",
+      "networkPolicyId": "f89e80ed-1208-4607-82b2-df2779d90f21",
+      "id": "f89e80ed-1208-4607-82b2-df2779d90f21/701825869",
+      "description": "Allow ICMP packets",
+      "type": "INGRESS",
+      "source": "0.0.0.0/0",
+      "action": "inbound",
+      "protocol": "icmp",
+      "portRange": "",
+    },
+    {
+      "stackId": "bcc60174-50e6-44e4-bd45-463845124d87",
+      "workloadId": "6ca53aff-8930-46d6-ba86-afbeb0b46bb7",
+      "networkPolicyId": "2ac958f2-0976-4de9-95f6-3546fc10f8d0",
+      "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/-812331665",
+      "description": "custom-inbound",
+      "type": "inbound",
+      "source": "192.168.0.1/32",
+      "action": "ALLOW",
+      "protocol": "tcp",
+      "portRange": "80",
+    }
+  ],
+  "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/</code>
+
+Retrieve a list of all network policy rules in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The ID of the network policy rule, in the form `workloadId/hashCode`.
+`stackId`<br/>*UUID* | The UUID of the stack to which the network policy belongs.
+`workloadId`<br/>*UUID* | The UUID of the workload to which the network policy rule is applied. Corresponds to the first workload ID in the network policy's list of instance selectors.
+`networkPolicyId`<br/>*UUID* | The UUID of the network policy to which the network policy rule belongs.
+`description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
+`type`<br/>*string* | The type of network policy rule, either `inbound` or `outbound`.
+`source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
+`action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
+`protocol`<br/>*string* | Supported protocols are: `tcp`, `udp`, `tcpUdp`, `esp` and `ah`.
+`portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
+
+<!-------------------- GET A NETWORK POLICY RULE -------------------->
+
+### Get a network policy rule
+
+```shell
+curl -X GET \
+  -H "MC-Api-Key: your_api_key" \
+  "https://cloudmc_endpoint/v1/services/stackpath/test-area/networkpolicyrules/2ac958f2-0976-4de9-95f6-3546fc10f8d0/-812331665"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "stackId": "bcc60174-50e6-44e4-bd45-463845124d87",
+    "workloadId": "6ca53aff-8930-46d6-ba86-afbeb0b46bb7",
+    "networkPolicyId": "2ac958f2-0976-4de9-95f6-3546fc10f8d0",
+    "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/-812331665",
+    "description": "custom-inbound",
+    "type": "ingress",
+    "source": "192.168.0.1/32",
+    "action": "ALLOW",
+    "protocol": "tcp",
+    "portRange": "80"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/:id</code>
+
+Retrieve a network policy rule in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The ID of the network policy rule, in the form `workloadId/hashCode`.
+`stackId`<br/>*UUID* | The UUID of the stack to which the network policy belongs.
+`workloadId`<br/>*UUID* | The UUID of the workload to which the network policy rule is applied. Corresponds to the first workload ID in the network policy's list of instance selectors.
+`networkPolicyId`<br/>*UUID* | The UUID of the network policy to which the network policy rule belongs.
+`description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
+`type`<br/>*string* | The type of network policy rule, either `inbound` or `outbound`.
+`source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
+`action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
+`protocol`<br/>*string* | Supported protocols are: `tcp`, `udp`, `tcpUdp`, `esp` and `ah`.
+`portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
+
 <!-------------------- CREATE A NETWORK POLICY RULE -------------------->
 
 ### Create a network policy rule
@@ -26,7 +134,7 @@ curl -X POST \
 }
 ```
 
-<code>CREATE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules?workloadId=:workloadId</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules?workloadId=:workloadId</code>
 
 Create a new network policy rule.
 

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -67,7 +67,7 @@ Attributes | &nbsp;
 
 <!-------------------- GET A NETWORK POLICY RULE -------------------->
 
-### Get a network policy rule
+### Retrieve a network policy rule
 
 ```shell
 curl -X GET \


### PR DESCRIPTION
### Fixes [MC-12985](https://cloud-ops.atlassian.net/browse/MC-12985)

#### Changes made
<!-- Changes should match the template provided below -->
- Document GET and LIST network policy rules

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/24

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->