### PR TITLE
MC-12998: Added documentation for the Edit and align the list and cre…

### DIFF
--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -23,22 +23,22 @@ curl -X GET \
       "networkPolicyId": "f89e80ed-1208-4607-82b2-df2779d90f21",
       "id": "f89e80ed-1208-4607-82b2-df2779d90f21/701825869",
       "description": "Allow ICMP packets",
-      "type": "INGRESS",
+      "type": "INBOUND",
       "source": "0.0.0.0/0",
-      "action": "inbound",
-      "protocol": "icmp",
+      "action": "INBOUND",
+      "protocol": "ICMP",
       "portRange": "",
     },
     {
       "stackId": "bcc60174-50e6-44e4-bd45-463845124d87",
       "workloadId": "6ca53aff-8930-46d6-ba86-afbeb0b46bb7",
       "networkPolicyId": "2ac958f2-0976-4de9-95f6-3546fc10f8d0",
-      "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/-812331665",
+      "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/INBOUND/-812331665/0",
       "description": "custom-inbound",
-      "type": "inbound",
+      "type": "INBOUND",
       "source": "192.168.0.1/32",
       "action": "ALLOW",
-      "protocol": "tcp",
+      "protocol": "TCP",
       "portRange": "80",
     }
   ],
@@ -52,17 +52,22 @@ curl -X GET \
 
 Retrieve a list of all network policy rules in a given [environment](#administration-environments).
 
+
+Query Params | &nbsp;
+---- | -----------
+`workloadId`<br/>*string* | The workload ID to get the network policy rules for. It is optional.
+
 Attributes | &nbsp;
 ------- | -----------
-`id`<br/>*string* | The ID of the network policy rule, in the form `workloadId/hashCode`.
+`id`<br/>*string* | The ID of the network policy rule, in the form `networkProfileId/type/hashCode/occurrence`.
 `stackId`<br/>*UUID* | The UUID of the stack to which the network policy belongs.
 `workloadId`<br/>*UUID* | The UUID of the workload to which the network policy rule is applied. Corresponds to the first workload ID in the network policy's list of instance selectors.
 `networkPolicyId`<br/>*UUID* | The UUID of the network policy to which the network policy rule belongs.
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
-`type`<br/>*string* | The type of network policy rule, either `inbound` or `outbound`.
+`type`<br/>*string* | The type of network policy rule, either `INBOUND` or `OUTBOUND`.
 `source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
-`protocol`<br/>*string* | Supported protocols are: `tcp`, `udp`, `tcpUdp`, `esp` and `ah`.
+`protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP`, `AH`, `ICMP` or `GRE`.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
 
 <!-------------------- GET A NETWORK POLICY RULE -------------------->
@@ -72,7 +77,7 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
   -H "MC-Api-Key: your_api_key" \
-  "https://cloudmc_endpoint/v1/services/stackpath/test-area/networkpolicyrules/2ac958f2-0976-4de9-95f6-3546fc10f8d0/-812331665"
+  "https://cloudmc_endpoint/v1/services/stackpath/test-area/networkpolicyrules/2ac958f2-0976-4de9-95f6-3546fc10f8d0/INBOUND/-812331665/0"
 ```
 
 > The above command returns a JSON structured like this:
@@ -83,12 +88,12 @@ curl -X GET \
     "stackId": "bcc60174-50e6-44e4-bd45-463845124d87",
     "workloadId": "6ca53aff-8930-46d6-ba86-afbeb0b46bb7",
     "networkPolicyId": "2ac958f2-0976-4de9-95f6-3546fc10f8d0",
-    "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/-812331665",
+    "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/INBOUND/-812331665/0",
     "description": "custom-inbound",
-    "type": "ingress",
+    "type": "INBOUND",
     "source": "192.168.0.1/32",
     "action": "ALLOW",
-    "protocol": "tcp",
+    "protocol": "TCP",
     "portRange": "80"
   }
 }
@@ -100,15 +105,15 @@ Retrieve a network policy rule in a given [environment](#administration-environm
 
 Attributes | &nbsp;
 ------- | -----------
-`id`<br/>*string* | The ID of the network policy rule, in the form `workloadId/hashCode`.
+`id`<br/>*string* | The ID of the network policy rule, in the form `networkProfileId/type/hashCode/occurrence`.
 `stackId`<br/>*UUID* | The UUID of the stack to which the network policy belongs.
 `workloadId`<br/>*UUID* | The UUID of the workload to which the network policy rule is applied. Corresponds to the first workload ID in the network policy's list of instance selectors.
 `networkPolicyId`<br/>*UUID* | The UUID of the network policy to which the network policy rule belongs.
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
-`type`<br/>*string* | The type of network policy rule, either `inbound` or `outbound`.
+`type`<br/>*string* | The type of network policy rule, either `INBOUND` or `OUTBOUND`.
 `source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
-`protocol`<br/>*string* | Supported protocols are: `tcp`, `udp`, `tcpUdp`, `esp` and `ah`.
+`protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP`, `AH`, `ICMP` or `GRE`.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
 
 <!-------------------- CREATE A NETWORK POLICY RULE -------------------->
@@ -145,8 +150,47 @@ Query Params | &nbsp;
 Required | &nbsp;
 ------- | -----------
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
-`protocol`<br/>*string* | Supported protocols are: `tcp`, `udp`, `tcp/udp`, `esp` and `ah`. 
+`protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` and `AH`. 
 `type`<br/>*string* | Either Inbound or Outbound
-`action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `DENY` (deny traffic).
+`action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (block traffic).
 `source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
-`portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
+`portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen. Not required for protocol for `ESP` or `AH`.
+
+
+<!-------------------- EDIT A NETWORK POLICY RULE -------------------->
+
+### EDIT a network policy rule
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+  -d "request_body" \
+  "https://cloudmc_endpoint/v1/services/stackpath/test-area/networkpolicyrules/2ac958f2-0976-4de9-95f6-3546fc10f8d0/INBOUND/-812331665/0"
+```
+> Request body example:
+
+```json
+{
+  "description": "npr_cloudmc_isk",
+  "workloadId": "6ca53aff-8930-46d6-ba86-afbeb0b46bb7",
+  "type": "INBOUND",
+  "source": "192.168.0.1/32",
+  "action": "ALLOW",
+  "protocol": "TCP",
+  "portRange": "80"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/:id</code>
+
+Edit a new network policy rule.
+
+Required | &nbsp;
+------- | -----------
+`description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
+`workloadId`<br/>*UUID* | The UUID of the workload to which the network policy rule is applied. Corresponds to the first workload ID in the network policy's list of instance selectors.
+`type`<br/>*string* | The type of network policy rule, either `INBOUND` or `OUTBOUND`.
+`source`<br/>*string* | A CIDR subnet that will define all the IPs allowed or denied by this rule.
+`action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
+`protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` or `AH`.
+`portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen. Not required for protocol for `ESP` or `AH`. 


### PR DESCRIPTION
…ate with the changes made

### Fixes [MC-12998](https://cloud-ops.atlassian.net/browse/MC-12998)

#### Changes made
<!-- Changes should match the template provided below -->
- Made correction on list/get and create
- Added the edit documentation

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/273
- PR # https://github.com/cloudops/cloudmc-stackpath-plugin/pull/23

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->