### PR TITLE
MC-12980: edit workload documentation

### DIFF
--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -119,7 +119,7 @@ Attributes | &nbsp;
 
 <!-------------------- EDIT A WORKLOAD -------------------->
 
-### EDIT a workload
+### Edit a workload
 
 ```shell
 curl -X PUT \
@@ -127,8 +127,9 @@ curl -X PUT \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/stackpath/test-area/workloads/1b932678-1038-4ab4-9fa4-c4c06e696e20"
 ```
-> Request body example for a VM:
-```json
+> Request body example:
+```js
+// Request body example for a VM
 {
   "name": "my-vm-workload",
   "stackId": "2f661cf6-8d08-42d0-918c-c20362fc9940",
@@ -150,10 +151,9 @@ curl -X PUT \
   "id": "4b23edf3-9847-4400-b779-f94203227324",
   "status": "ACTIVE"
 }
-```
 
-> Request body example for a Container:
-```json
+// Request body example for a Container:
+
 {
   "name": "my-container-workload",
   "stackId": "2f661cf6-8d08-42d0-918c-c20362fc9940",
@@ -179,9 +179,9 @@ curl -X PUT \
 }
 ```
 
-<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/:id</code>
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/workloads/:id</code>
 
-Edit a new network policy rule.
+Edit a workload.
 
 Required | &nbsp;
 ------- | -----------

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -132,36 +132,36 @@ curl -X PUT \
 // Request body example for a VM
 {
   "name": "my-vm-workload",
+  "id": "4b23edf3-9847-4400-b779-f94203227324",
   "stackId": "2f661cf6-8d08-42d0-918c-c20362fc9940",
   "slug": "my-vm-workload",
   "version": "8",
   "type": "VM",
-  "isRemoteManagementEnabled": false,
-  "image": "stackpath-edge/centos-7-cpanel:v201905241955",
   "cpu": "1",
   "memory": "2Gi",
   "specs": "SP-1",
-  "firstBootSshKey": "ssh-rsa...",
   "deploymentName": "chicago-1",
   "deploymentPops": "ORD",
   "enableAutoScaling": true,
   "cpuUtilization": 50,
   "minInstancesPerPop": 2,
-  "maxInstancesPerPop": 3,
-  "id": "4b23edf3-9847-4400-b779-f94203227324",
-  "status": "ACTIVE"
+  "maxInstancesPerPop": 3
 }
 
 // Request body example for a Container:
 
 {
   "name": "my-container-workload",
+  "id": "e5f95455-1b50-4da1-86e1-6f9293f818a9",
   "stackId": "2f661cf6-8d08-42d0-918c-c20362fc9940",
   "slug": "my-container-workload",
   "version": "1",
   "type": "Container",
-  "isRemoteManagementEnabled": false,
   "image": "redis:alpine",
+  "environmentVariableKey": "env-key",
+  "environmentVariableValue": "env-value",
+  "secretEnvironmentVariableKey": "secret-key",
+  "secretEnvironmentVariableValue": "secret-value",
   "addImagePullCredentialsOption": true,
   "containerUsername": "username",
   "containerServer": "container.server.io",
@@ -173,42 +173,41 @@ curl -X PUT \
   "deploymentName": "toronto-1",
   "deploymentPops": "YYZ",
   "enableAutoScaling": false,
-  "deploymentInstancePerPops": 2,
-  "id": "e5f95455-1b50-4da1-86e1-6f9293f818a9",
-  "status": "ACTIVE"
+  "deploymentInstancePerPops": 2
 }
 ```
 
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/workloads/:id</code>
 
-Edit a workload.
+Edit a workload in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
 `name`<br/>*string* | The name of the workload.
+`id`<br/>*string* | A workload's unique identifier.
 `stackId`<br/>*UUID* | The ID of the stack that a workload belongs to.
 `slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
 `version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
-`type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
-`isRemoteManagementEnabled` <br/>*boolean* | Specify if you would like to manage your instances remotely via serial console or VNC.
-`image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
+`type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either 'VM' or 'CONTAINER'.
+`image`<br/>*string* | The location of a Docker image to run as a container. Only available when `type`is equal to 'CONTAINER'.
 `cpu`<br/>*string* | The number of vCPUs for the workload's instance.
 `memory`<br/>*string* | The memory size for the workload's instance.
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
 `deploymentName`<br/>*string* | The name of the deployment.
 `deploymentPops`<br/>*string* | The point of presence of a deployment. In the format [A-Z][A-Z][A-Z]. I
-`enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling.
-`id`<br/>*string* | A workload's unique identifier.
-`status`<br/>*string* | The status of the workload. It can be either ACTIVE or DISABLED.
+`enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required.
 
 Optional | &nbsp;
 ------- | -----------
-`addImagePullCredentialsOption`<br/>*boolean* | Specify if there are credentials neededed to pull a container image. Defaults to false. Only appicable for containers.
-`containerUsername`<br/>*string* | The username that should be used for authenticate the image pull.
-`containerEmail`<br/>*string* | The password that should be used to authenticate the image pull.
-`containerServer`<br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set.
-`containerPassword`<br/>*string* | The password that should be used to authenticate the image pull.
-`firstBootSshKey`<br/>*string* | The first boot SSH key.
+`environmentVariableKey`<br/>*string* | The key of the environmental variable you would like to edit. Only available when `type`is equal to 'CONTAINER'.
+`environmentVariableValue`<br/>*string* | The value of the environmental variable you would like to edit. Only available when `type`is equal to 'CONTAINER'.
+`secretEnvironmentVariableKey`<br/>*string* | The key of the secret environmental variable you would like to edit. Only available when `type`is equal to 'CONTAINER'.
+`secretEnvironmentVariableValue`<br/>*string* | The value of the secret environmental variable you would like to edit. Only available when `type`is equal to 'CONTAINER'.
+`addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only available when `type`is equal to 'CONTAINER'.
+`containerUsername`<br/>*string* | The username that should be used for authenticate the image pull. Only available when `type`is equal to 'CONTAINER'.
+`containerEmail`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type`is equal to 'CONTAINER'.
+`containerServer`<br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only available when `type`is equal to 'CONTAINER'.
+`containerPassword`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type`is equal to 'CONTAINER'.
 `deploymentInstancePerPops`<br/>*integer* | The number of deployments per point of presence. Only required if autoscaling is not enabled.
 `cpuUtilization`<br/>*integer* | The average CPU utlilization threshold to be reached before deploying a new instance. Only required if autoscaling is enabled.
 `minInstancesPerPop`<br/>*integer* | The minimum number of instances per point of presence. Only required if autoscaling is enabled.

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -25,7 +25,7 @@ curl -X GET \
       "stackId": "3e651d2e-b1f4-44ad-b21a-ebcd0bf79ca1",
       "slug": "stackpath-workload-01",
       "status": "ACTIVE",
-      "spec": "SP-2",
+      "specs": "SP-2",
       "version": "3",
       "created": "2020-11-06T18:48:36.850115786Z",
       "type": "VM",
@@ -53,7 +53,7 @@ Attributes | &nbsp;
 `stackId`<br/>*string* | The ID of the stack that a workload belongs to.
 `slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
 `status`<br/>*string* | The status of the workload. It can be either ACTIVE or DISABLED.
-`spec`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
+`specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
 `version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
 `created`<br/>*string* | Creation timestamp of the workload.
 `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
@@ -83,7 +83,7 @@ curl -X GET \
     "stackId": "3e651d2e-b1f4-44ad-b21a-ebcd0bf79ca1",
     "slug": "stackpath-workload-01",
     "status": "ACTIVE",
-    "spec": "SP-1",
+    "specs": "SP-1",
     "version": "3",
     "created": "2020-11-09T08:28:45.185278507Z",
     "type": "Container",
@@ -107,7 +107,7 @@ Attributes | &nbsp;
 `stackId`<br/>*string* | The ID of the stack that a workload belongs to.
 `slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
 `status`<br/>*string* | The status of the workload. It can be either ACTIVE or DISABLED.
-`spec`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
+`specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
 `version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
 `created`<br/>*string* | Creation timestamp of the workload.
 `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
@@ -116,6 +116,103 @@ Attributes | &nbsp;
 `memory`<br/>*string* | The memory size for the workload's instance.
 `isRemoteManagementEnabled`<br/>*boolean* | Specify if remote management is enabled on workload instance or not.
 `image`<br/>*string* | The workload's instance operating system image.
+
+<!-------------------- EDIT A WORKLOAD -------------------->
+
+### EDIT a workload
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+  -d "request_body" \
+  "https://cloudmc_endpoint/v1/services/stackpath/test-area/workloads/1b932678-1038-4ab4-9fa4-c4c06e696e20"
+```
+> Request body example for a VM:
+```json
+{
+  "name": "my-vm-workload",
+  "stackId": "2f661cf6-8d08-42d0-918c-c20362fc9940",
+  "slug": "my-vm-workload",
+  "version": "8",
+  "type": "VM",
+  "isRemoteManagementEnabled": false,
+  "image": "stackpath-edge/centos-7-cpanel:v201905241955",
+  "cpu": "1",
+  "memory": "2Gi",
+  "specs": "SP-1",
+  "firstBootSshKey": "ssh-rsa...",
+  "deploymentName": "chicago-1",
+  "deploymentPops": "ORD",
+  "enableAutoScaling": true,
+  "cpuUtilization": 50,
+  "minInstancesPerPop": 2,
+  "maxInstancesPerPop": 3,
+  "id": "4b23edf3-9847-4400-b779-f94203227324",
+  "status": "ACTIVE"
+}
+```
+
+> Request body example for a Container:
+```json
+{
+  "name": "my-container-workload",
+  "stackId": "2f661cf6-8d08-42d0-918c-c20362fc9940",
+  "slug": "my-container-workload",
+  "version": "1",
+  "type": "Container",
+  "isRemoteManagementEnabled": false,
+  "image": "redis:alpine",
+  "addImagePullCredentialsOption": true,
+  "containerUsername": "username",
+  "containerServer": "container.server.io",
+  "containerEmail": "myemail@email.com",
+  "containerPassword": "my-password",
+  "cpu": "2",
+  "memory": "4Gi",
+  "specs": "SP-2",
+  "deploymentName": "toronto-1",
+  "deploymentPops": "YYZ",
+  "enableAutoScaling": false,
+  "deploymentInstancePerPops": 2,
+  "id": "e5f95455-1b50-4da1-86e1-6f9293f818a9",
+  "status": "ACTIVE"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/:id</code>
+
+Edit a new network policy rule.
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*string* | The name of the workload.
+`stackId`<br/>*UUID* | The ID of the stack that a workload belongs to.
+`slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
+`version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
+`type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
+`isRemoteManagementEnabled` <br/>*boolean* | Specify if you would like to manage your instances remotely via serial console or VNC.
+`image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
+`cpu`<br/>*string* | The number of vCPUs for the workload's instance.
+`memory`<br/>*string* | The memory size for the workload's instance.
+`specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
+`deploymentName`<br/>*string* | The name of the deployment.
+`deploymentPops`<br/>*string* | The point of presence of a deployment. In the format [A-Z][A-Z][A-Z]. I
+`enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling.
+`id`<br/>*string* | A workload's unique identifier.
+`status`<br/>*string* | The status of the workload. It can be either ACTIVE or DISABLED.
+
+Optional | &nbsp;
+------- | -----------
+`addImagePullCredentialsOption`<br/>*boolean* | Specify if there are credentials neededed to pull a container image. Defaults to false. Only appicable for containers.
+`containerUsername`<br/>*string* | The username that should be used for authenticate the image pull.
+`containerEmail`<br/>*string* | The password that should be used to authenticate the image pull.
+`containerServer`<br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set.
+`containerPassword`<br/>*string* | The password that should be used to authenticate the image pull.
+`firstBootSshKey`<br/>*string* | The first boot SSH key.
+`deploymentInstancePerPops`<br/>*integer* | The number of deployments per point of presence. Only required if autoscaling is not enabled.
+`cpuUtilization`<br/>*integer* | The average CPU utlilization threshold to be reached before deploying a new instance. Only required if autoscaling is enabled.
+`minInstancesPerPop`<br/>*integer* | The minimum number of instances per point of presence. Only required if autoscaling is enabled.
+`maxInstancesPerPop`<br/>*integer* | The maximum number of instances per point of presence. Only required if autoscaling is enabled.
 
 <!-------------------- DELETE A WORKLOAD -------------------->
 

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -135,7 +135,6 @@ curl -X PUT \
   "id": "4b23edf3-9847-4400-b779-f94203227324",
   "stackId": "2f661cf6-8d08-42d0-918c-c20362fc9940",
   "slug": "my-vm-workload",
-  "version": "8",
   "type": "VM",
   "cpu": "1",
   "memory": "2Gi",
@@ -155,7 +154,6 @@ curl -X PUT \
   "id": "e5f95455-1b50-4da1-86e1-6f9293f818a9",
   "stackId": "2f661cf6-8d08-42d0-918c-c20362fc9940",
   "slug": "my-container-workload",
-  "version": "1",
   "type": "Container",
   "image": "redis:alpine",
   "environmentVariableKey": "env-key",
@@ -187,7 +185,6 @@ Required | &nbsp;
 `id`<br/>*string* | A workload's unique identifier.
 `stackId`<br/>*UUID* | The ID of the stack that a workload belongs to.
 `slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names.
-`version`<br/>*string* | A version number for the workload. Versions start at 1 when they are created and increment by 1 every time they are updated.
 `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either 'VM' or 'CONTAINER'.
 `image`<br/>*string* | The location of a Docker image to run as a container. Only available when `type`is equal to 'CONTAINER'.
 `cpu`<br/>*string* | The number of vCPUs for the workload's instance.


### PR DESCRIPTION
### Fixes [MC-12980](https://cloud-ops.atlassian.net/browse/MC-12980)

#### Changes made
Added edit workload documentation for the stackpath plugin.

#### Related PRs
- [#26](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/26)
- [#20](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/20)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->