### PR TITLE
MC-12986: Moved workloadId from query param to request body

### DIFF
--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -130,7 +130,7 @@ curl -X POST \
 
 ```json
 {
-  "workloadId": "bf9fd2ac-f761-46ef-88e0-b61ef68f8619"
+  "workloadId": "bf9fd2ac-f761-46ef-88e0-b61ef68f8619",
   "description": "npr_cloudmc_isk",
   "protocol": "tcp",
   "type": "INBOUND",

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -124,12 +124,13 @@ Attributes | &nbsp;
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
-  "https://cloudmc_endpoint/v1/services/stackpath/test-area/networkpolicyrules?workloadId=bf9fd2ac-f761-46ef-88e0-b61ef68f8619"
+  "https://cloudmc_endpoint/v1/services/stackpath/test-area/networkpolicyrules"
 ```
 > Request body example:
 
 ```json
 {
+  "workloadId": "bf9fd2ac-f761-46ef-88e0-b61ef68f8619"
   "description": "npr_cloudmc_isk",
   "protocol": "tcp",
   "type": "INBOUND",
@@ -139,16 +140,13 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules?workloadId=:workloadId</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules</code>
 
 Create a new network policy rule.
 
-Query Params | &nbsp;
----- | -----------
-`workloadId`<br/>*string* | The workload ID to create a network policy for. It is mandatory.
-
 Required | &nbsp;
 ------- | -----------
+`workloadId`<br/>*UUID* | The workload UUID to create a network policy for.
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
 `protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` and `AH`. 
 `type`<br/>*string* | Either Inbound or Outbound


### PR DESCRIPTION
### Fixes [MC-12986](https://cloud-ops.atlassian.net/browse/MC-12986)

#### Changes made
Moved the workloadId from the create network policy rule URL to the request body.

#### Related PRs

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->