### PR TITLE
MC-12986: Fixed the casing of value used in creating/updating npr

### DIFF
--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -132,7 +132,7 @@ curl -X POST \
 {
   "workloadId": "bf9fd2ac-f761-46ef-88e0-b61ef68f8619",
   "description": "npr_cloudmc_isk",
-  "protocol": "tcp",
+  "protocol": "TCP",
   "type": "INBOUND",
   "action": "ALLOW",
   "source": "0.0.0.0/0",
@@ -149,7 +149,7 @@ Required | &nbsp;
 `workloadId`<br/>*UUID* | The workload UUID to create a network policy for.
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
 `protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` and `AH`. 
-`type`<br/>*string* | Either Inbound or Outbound
+`type`<br/>*string* | The type of network policy rule. Supported types are: `INBOUND` (Ingress) and `OUTBOUND` (Egress).
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (block traffic).
 `source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
@@ -200,7 +200,7 @@ Required | &nbsp;
 ------- | -----------
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
 `workloadId`<br/>*UUID* | The UUID of the workload to which the network policy rule is applied. Corresponds to the first workload ID in the network policy's list of instance selectors.
-`type`<br/>*string* | The type of network policy rule, either `INBOUND` or `OUTBOUND`.
+`type`<br/>*string* | The type of network policy rule. Supported types are: `INBOUND` (Ingress) and `OUTBOUND` (Egress).
 `source`<br/>*string* | A CIDR subnet that will define all the IPs allowed or denied by this rule.
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
 `protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` or `AH`.


### PR DESCRIPTION
### Fixes [MC-12986](https://cloud-ops.atlassian.net/browse/MC-12986)

#### Changes made
Fixed some casing and working in create/edit network policy rule docs

#### Related PRs

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->