### PR TITLE
Small fixes for StackPath docs

### DIFF
--- a/source/includes/_stackpath.md
+++ b/source/includes/_stackpath.md
@@ -1,3 +1,3 @@
-# Stackpath plugin
+# StackPath plugin
 
-The Stackpath plugin provides endpoints for carrying out operations on CloudMC Edge computing entities. It also enforces CloudMC's environment-centric multi-tenancy model and RBAC over top of Stackpath.
+The StackPath plugin provides endpoints for carrying out operations on CloudMC Edge computing entities. It also enforces CloudMC's environment-centric multi-tenancy model and RBAC on top of StackPath.

--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -170,7 +170,7 @@ Delete a network policy rule.
 
 <!-------------------- EDIT A NETWORK POLICY RULE -------------------->
 
-### EDIT a network policy rule
+### Edit a network policy rule
 
 ```shell
 curl -X PUT \
@@ -194,7 +194,7 @@ curl -X PUT \
 
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/networkpolicyrules/:id</code>
 
-Edit a new network policy rule.
+Edit a network policy rule.
 
 Required | &nbsp;
 ------- | -----------


### PR DESCRIPTION
### Small fixes for StackPath

#### Changes made
- Use `StackPath` rather than `Stackpath`
- Other small fixes

#### Related PRs
- none

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->