### PR TITLE
MC-12980: DoD bug fix, edit formatting of edit workload docs

### DIFF
--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -127,9 +127,9 @@ curl -X PUT \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/stackpath/test-area/workloads/1b932678-1038-4ab4-9fa4-c4c06e696e20"
 ```
-> Request body example:
-```js
-// Request body example for a VM
+> Request body example for a VM Workload type:
+
+```json
 {
   "name": "my-vm-workload",
   "id": "4b23edf3-9847-4400-b779-f94203227324",
@@ -146,9 +146,10 @@ curl -X PUT \
   "minInstancesPerPop": 2,
   "maxInstancesPerPop": 3
 }
+```
+> Request body example for a CONTAINER Workload type:
 
-// Request body example for a Container:
-
+```json
 {
   "name": "my-container-workload",
   "id": "e5f95455-1b50-4da1-86e1-6f9293f818a9",


### PR DESCRIPTION
### Fixes [MC-12980](https://cloud-ops.atlassian.net/browse/MC-12980)

#### Changes made
<!-- Changes should match the template provided below -->
- Modified sample json formatting for edit workload operation for StackPath

#### Related PRs
- [#275](https://github.com/cloudops/cloudmc-api-docs/pull/275)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->