### PR TITLE
MC-13237: Updated Create Workload payload formatting

### DIFF
--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -126,9 +126,8 @@ curl -X POST \
     -d "request_body" \
     "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/workloads"
 ```
-> Request body example(s):
+> Request body example for a VM Workload type:
 ```js
-// Request body example for a VM:
 {
    "name":"w-user-zwg",
    "slug":"w-user-zwg",
@@ -149,8 +148,10 @@ curl -X POST \
    "enableAutoScaling":false,
    "deploymentPops":"YYZ"
 }
+```
+> Request body example for a CONTAINER Workload type:
 
-// Request body example for a Container:
+```
 {
    "name":"w-user-pah",
    "type":"CONTAINER",

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -127,7 +127,7 @@ curl -X POST \
     "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/workloads"
 ```
 > Request body example for a VM Workload type:
-```js
+```json
 {
    "name":"w-user-zwg",
    "slug":"w-user-zwg",
@@ -151,7 +151,7 @@ curl -X POST \
 ```
 > Request body example for a CONTAINER Workload type:
 
-```
+```json
 {
    "name":"w-user-pah",
    "type":"CONTAINER",


### PR DESCRIPTION
### Fixes [MC-13237](https://cloud-ops.atlassian.net/browse/MC-MC-13237)

#### Changes made
Fix the formatting issue of the create the workload section.


<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->