### PR TITLE
MC-13237: Fixed formatting issues

### DIFF
--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -14,6 +14,7 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/workloads"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -73,6 +74,7 @@ curl -X GET \
    -H "MC-Api-Key: your_api_key" \
    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/workloads/1b932678-1038-4ab4-9fa4-c4c06e696e20"
 ```
+
 > The above command returns a JSON structured like this:
 
 ```json
@@ -120,6 +122,7 @@ Attributes | &nbsp;
 <!-------------------- CREATE A WORKLOAD -------------------->
 
 ### Create a workload
+
 ```shell
 curl -X POST \
     -H "MC-Api-Key: your_api_key" \
@@ -127,6 +130,7 @@ curl -X POST \
     "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/workloads"
 ```
 > Request body example for a VM Workload type:
+
 ```json
 {
    "name":"w-user-zwg",
@@ -149,6 +153,7 @@ curl -X POST \
    "deploymentPops":"YYZ"
 }
 ```
+
 > Request body example for a CONTAINER Workload type:
 
 ```json
@@ -184,12 +189,14 @@ curl -X POST \
 }
 ```
 > The above commands return a JSON structured like this:
+
 ```json
 {
   "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
   "taskStatus": "PENDING"
 }
 ```
+
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/workloads</code>
 
 Create a new workload in a given [environment](#administration-environments).


### PR DESCRIPTION
### Fixes [MC-13237](https://cloud-ops.atlassian.net/browse/MC-13237)

#### Changes made
Added spaces after doc comments to fix formatting

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->