### PR TITLE
MC-13313: Removed vpc from request payload

### DIFF
--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -223,7 +223,6 @@ curl -X POST \
    "slug":"w-user-zwg",
    "type":"VM",
    "image":"stackpath-edge/centos-7-cpanel:v201905241955",
-   "vpc":"Default",
    "addAnyCastIpAddress":false,
    "publicPort": "80",
    "publicPortSrc": "0.0.0.0/0",
@@ -256,7 +255,6 @@ curl -X POST \
    "environmentVariableValue": null,
    "secretEnvironmentVariableKey":null,
    "secretEnvironmentVariableValue":null,
-   "vpc":"Default",
    "addAnyCastIpAddress":false,
    "publicPort": "80",
    "publicPortSrc": "0.0.0.0/0",
@@ -292,7 +290,6 @@ Required | &nbsp;
  `name`<br/>*string* | The name of the workload.
  `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
  `image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
- `vpc`<br/>*string* | The virtual private cloud option for now supports default vpc only.
  `firstBootSshKey(s)`<br/>*string* | If creating a VM-based workload, SSH keys are required. Multiple SSH keys can be separated by commas.
  `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload. Supported specifications are `SP-1 (1 vCPU, 2 GB RAM)`,`SP-2 (2 vCPU, 4 GB RAM)`,`SP-3 (2 vCPU, 8GB RAM)`,`SP-4 (4 vCPU, 16 GB RAM)`,`SP-5 (8 vCPU, 32 GB RAM)`.
  `deploymentName`<br/>*string* | The name of the deployment.


### PR DESCRIPTION
### Fixes [MC-13313](https://cloud-ops.atlassian.net/browse/MC-13313)

#### Changes made
Removed the vpc field as part of the request payload for creating workload.

#### Related PRs
- [cloudmc-stackpath-plugin](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/58)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->