### PR TITLE
MC:13321 - Updated docs for validation on workload and deployment name

### DIFF
--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -292,13 +292,13 @@ Create a new workload in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
- `name`<br/>*string* | The name of the workload. The length of `<workload_name>-<deployment_name>` must not exceed 40 characters.
+ `name`<br/>*string* | The name of the workload. The workload name must not exceed 18 characters.
  `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
  `image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
  `vpc`<br/>*string* | The virtual private cloud option for now supports default vpc only.
  `firstBootSshKey`<br/>*string* | If creating a VM-based workload, SSH keys are required. Multiple SSH keys can be separated by newlines `\n`.
  `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload. Supported specifications are `SP-1 (1 vCPU, 2 GB RAM)`,`SP-2 (2 vCPU, 4 GB RAM)`,`SP-3 (2 vCPU, 8GB RAM)`,`SP-4 (4 vCPU, 16 GB RAM)`,`SP-5 (8 vCPU, 32 GB RAM)`.
- `deploymentName`<br/>*string* | The name of the deployment. The length of `<workload_name>-<deployment_name>` must not exceed 40 characters.
+ `deploymentName`<br/>*string* | The name of the deployment. The deployment name must not exceed 18 characters.
  `deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
  `enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required else `deploymentInstancePerPops` is 
  `cpuUtilization` <br/>*int* | Specify the percentage of CPU utilization.
@@ -307,7 +307,7 @@ Required | &nbsp;
  
  Optional | &nbsp;
  ------- | -----------
-  `slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names. If not provided, defaults to workload's name.
+  `slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names. If not provided, defaults to workload's name. It must not exceed 18 characters.
  `addAnyCastIpAddress`<br/>*boolean* | Option to AnyCast IP Address.
   `publicPort`<br/>*string* | A single port, such as 80 or a port range, such as 1024-65535 for which a network policy rule will be created for the workload.
  `publicPortSrc`<br/>*string* | A subnet that will define all the IPs allowed by the network policy rule.
@@ -397,11 +397,11 @@ Edit a workload in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The name of the workload. The length of `<workload_name>-<deployment_name>` must not exceed 40 characters.
+`name`<br/>*string* | The name of the workload. The workload name must not exceed 18 characters.
 `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either 'VM' or 'CONTAINER'.
 `image`<br/>*string* | The location of a Docker image to run as a container. Only editable when `type`is equal to 'CONTAINER'.
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
-`deploymentName`<br/>*string* | The name of the deployment. The length of `<workload_name>-<deployment_name>` must not exceed 40 characters.
+`deploymentName`<br/>*string* | The name of the deployment. The deployment name must not exceed 18 characters.
 `deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
 `enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required else `deploymentInstancePerPops` is required.
 

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -253,12 +253,12 @@ curl -X POST \
    "addImagePullCredentialsOption":true,
    "containerUsername":"test.username",
    "containerPassword":"test-password",
-   "containerServer":null,
-   "containerEmail":null,
-   "environmentVariableKey": null,
-   "environmentVariableValue": null,
-   "secretEnvironmentVariableKey":null,
-   "secretEnvironmentVariableValue":null,
+   "containerServer":"container.server.io",
+   "containerEmail":"mytestEmail@email.com",
+   "environmentVariableKey": "env-key",
+   "environmentVariableValue": "env-value",
+   "secretEnvironmentVariableKey":"secret-key",
+   "secretEnvironmentVariableValue":"secret-value",
    "vpc":"Default",
    "addAnyCastIpAddress":false,
    "publicPort": "80",
@@ -293,7 +293,7 @@ Create a new workload in a given [environment](#administration-environments).
 Required | &nbsp;
 ------- | -----------
  `name`<br/>*string* | The name of the workload. The workload name must not exceed 18 characters.
- `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
+ `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either `VM` or `CONTAINER`.
  `image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
  `vpc`<br/>*string* | The virtual private cloud option for now supports default vpc only.
  `firstBootSshKey`<br/>*string* | If creating a VM-based workload, SSH keys are required. Multiple SSH keys can be separated by newlines `\n`.
@@ -313,7 +313,7 @@ Required | &nbsp;
  `publicPortSrc`<br/>*string* | A subnet that will define all the IPs allowed by the network policy rule.
  `publicPortDesc`<br/>*string* | A summary of what the network policy rule does or a name for it. It is highly recommended to give a unique description to easily identify a network policy rule.
  `protocol`<br/>*string* | Protocol for the network policy rule. Supported protocols are: `TCP`, `UDP` and `TCP_UDP`.
- `commands`<br/>*string* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
+ `commands`<br/>*string* | The commands that start a container. Only applicable to workloads of type `CONTAINER`.
  `persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
  `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
  `addImagePullCredentialsOption` <br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not.
@@ -398,8 +398,8 @@ Edit a workload in a given [environment](#administration-environments).
 Required | &nbsp;
 ------- | -----------
 `name`<br/>*string* | The name of the workload. The workload name must not exceed 18 characters.
-`type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either 'VM' or 'CONTAINER'.
-`image`<br/>*string* | The location of a Docker image to run as a container. Only editable when `type`is equal to 'CONTAINER'.
+`type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either `VM` or `CONTAINER`.
+`image`<br/>*string* | The location of a Docker image to run as a container. Only editable when `type` is equal to `CONTAINER`.
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
 `deploymentName`<br/>*string* | The name of the deployment. The deployment name must not exceed 18 characters.
 `deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
@@ -407,15 +407,15 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
-`environmentVariableKey`<br/>*string* | The key of the environmental variable you would like to edit. Only available when `type`is equal to 'CONTAINER'.
-`environmentVariableValue`<br/>*string* | The value of the environmental variable you would like to edit. Only available when `type`is equal to 'CONTAINER'.
-`secretEnvironmentVariableKey`<br/>*string* | The key of the secret environmental variable you would like to edit. Only available when `type`is equal to 'CONTAINER'.
-`secretEnvironmentVariableValue`<br/>*string* | The value of the secret environmental variable you would like to edit. Only available when `type`is equal to 'CONTAINER'.
-`addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only available when `type`is equal to 'CONTAINER'.
-`containerUsername`<br/>*string* | The username that should be used for authenticate the image pull. Only available when `type`is equal to 'CONTAINER'.
-`containerEmail`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type`is equal to 'CONTAINER'.
-`containerServer`<br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only available when `type`is equal to 'CONTAINER'.
-`containerPassword`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type`is equal to 'CONTAINER'.
+`environmentVariableKey`<br/>*string* | The key of the environmental variable you would like to edit. Only available when `type` is equal to `CONTAINER`.
+`environmentVariableValue`<br/>*string* | The value of the environmental variable you would like to edit. Only available when `type` is equal to `CONTAINER`.
+`secretEnvironmentVariableKey`<br/>*string* | The key of the secret environmental variable you would like to edit. Only available when `type` is equal to `CONTAINER`.
+`secretEnvironmentVariableValue`<br/>*string* | The value of the secret environmental variable you would like to edit. Only available when `type` is equal to `CONTAINER`.
+`addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only available when `type` is equal to `CONTAINER`.
+`containerUsername`<br/>*string* | The username that should be used for authenticate the image pull. Only available when `type` is equal to `CONTAINER`.
+`containerEmail`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type` is equal to `CONTAINER`.
+`containerServer`<br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only available when `type` is equal to `CONTAINER`.
+`containerPassword`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type` is equal to `CONTAINER`.
 `deploymentInstancePerPops`<br/>*integer* | The number of deployments per point of presence. Only required if autoscaling is not enabled.
 `cpuUtilization`<br/>*integer* | The average CPU utlilization threshold to be reached before deploying a new instance. Only required if autoscaling is enabled.
 `minInstancesPerPop`<br/>*integer* | The minimum number of instances per point of presence. Only required if autoscaling is enabled.

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -292,13 +292,13 @@ Create a new workload in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
- `name`<br/>*string* | The name of the workload. The string "workloadname-deploymentname" must not exceed 40 characters.
+ `name`<br/>*string* | The name of the workload. The length of `<workload_name>-<deployment_name>` must not exceed 40 characters.
  `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
  `image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
  `vpc`<br/>*string* | The virtual private cloud option for now supports default vpc only.
  `firstBootSshKey`<br/>*string* | If creating a VM-based workload, SSH keys are required. Multiple SSH keys can be separated by newlines `\n`.
  `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload. Supported specifications are `SP-1 (1 vCPU, 2 GB RAM)`,`SP-2 (2 vCPU, 4 GB RAM)`,`SP-3 (2 vCPU, 8GB RAM)`,`SP-4 (4 vCPU, 16 GB RAM)`,`SP-5 (8 vCPU, 32 GB RAM)`.
- `deploymentName`<br/>*string* | The name of the deployment. The string "workloadname-deploymentname" must not exceed 40 characters.
+ `deploymentName`<br/>*string* | The name of the deployment. The length of `<workload_name>-<deployment_name>` must not exceed 40 characters.
  `deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
  `enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required else `deploymentInstancePerPops` is 
  `cpuUtilization` <br/>*int* | Specify the percentage of CPU utilization.
@@ -397,11 +397,11 @@ Edit a workload in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The name of the workload. The string "workloadname-deploymentname" must not exceed 40 characters.
+`name`<br/>*string* | The name of the workload. The length of `<workload_name>-<deployment_name>` must not exceed 40 characters.
 `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either 'VM' or 'CONTAINER'.
 `image`<br/>*string* | The location of a Docker image to run as a container. Only editable when `type`is equal to 'CONTAINER'.
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
-`deploymentName`<br/>*string* | The name of the deployment. The string "workloadname-deploymentname" must not exceed 40 characters.
+`deploymentName`<br/>*string* | The name of the deployment. The length of `<workload_name>-<deployment_name>` must not exceed 40 characters.
 `deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
 `enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required else `deploymentInstancePerPops` is required.
 

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -292,13 +292,13 @@ Create a new workload in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
- `name`<br/>*string* | The name of the workload.
+ `name`<br/>*string* | The name of the workload. The string "workloadname-deploymentname" must not exceed 40 characters.
  `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based.
  `image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
  `vpc`<br/>*string* | The virtual private cloud option for now supports default vpc only.
  `firstBootSshKey`<br/>*string* | If creating a VM-based workload, SSH keys are required. Multiple SSH keys can be separated by newlines `\n`.
  `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload. Supported specifications are `SP-1 (1 vCPU, 2 GB RAM)`,`SP-2 (2 vCPU, 4 GB RAM)`,`SP-3 (2 vCPU, 8GB RAM)`,`SP-4 (4 vCPU, 16 GB RAM)`,`SP-5 (8 vCPU, 32 GB RAM)`.
- `deploymentName`<br/>*string* | The name of the deployment.
+ `deploymentName`<br/>*string* | The name of the deployment. The string "workloadname-deploymentname" must not exceed 40 characters.
  `deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
  `enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required else `deploymentInstancePerPops` is 
  `cpuUtilization` <br/>*int* | Specify the percentage of CPU utilization.
@@ -397,11 +397,11 @@ Edit a workload in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
-`name`<br/>*string* | The name of the workload.
+`name`<br/>*string* | The name of the workload. The string "workloadname-deploymentname" must not exceed 40 characters.
 `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either 'VM' or 'CONTAINER'.
 `image`<br/>*string* | The location of a Docker image to run as a container. Only editable when `type`is equal to 'CONTAINER'.
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
-`deploymentName`<br/>*string* | The name of the deployment.
+`deploymentName`<br/>*string* | The name of the deployment. The string "workloadname-deploymentname" must not exceed 40 characters.
 `deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
 `enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required else `deploymentInstancePerPops` is required.
 


### PR DESCRIPTION
### Fixes [MC-13321](https://cloud-ops.atlassian.net/browse/MC-13321)

#### Changes made
<!-- Changes should match the template provided below -->
- SP// requires the string "workloadname-deploymentname" to be under 40 characters.

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->