### PR TITLE
MC-13300 Add documentation for the feedback settings.

### DIFF
--- a/source/includes/administration/_feedback_settings.md
+++ b/source/includes/administration/_feedback_settings.md
@@ -1,0 +1,248 @@
+## Feedback Settings
+
+<!-------------------- FIND FEEDBACK SETTINGS -------------------->
+
+### Find feedback settings associated to an organization
+
+`GET /feedback/find?organizationId=:id`
+
+Retrieve the feedback settings associated to an organization. If the `organizationId` is omitted, the authenticated user's organization will be used.
+
+```shell
+# Retrieve the feedback settings
+curl "https://cloudmc_endpoint/api/v1/feedback/find?organizationId=fcda8d5a-0276-4de3-908f-b3bd0aff2491" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "supportEmail": "support@company.com",
+    "organization": {
+      "id": "fcda8d5a-0276-4de3-908f-b3bd0aff2491"
+    },
+    "feedbackSlackWebhookUrl": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    "id": "f4be2785-ec67-474c-af3a-38ffecfa4094",
+    "version": 1,
+    "feedbackEmail": "feedback@company.com"
+  }
+}
+```
+
+<!-------------------- GET FEEDBACK SETTINGS -------------------->
+### Retrieve feedback settings
+
+`GET /feedback/:id`
+
+Retrieve the feedback settings associated to a feedback setting id.
+
+```shell
+# Retrieve feedback settings
+curl "https://cloudmc_endpoint/api/v1/feedback/f4be2785-ec67-474c-af3a-38ffecfa4094" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "supportEmail": "support@company.com",
+    "organization": {
+      "id": "fcda8d5a-0276-4de3-908f-b3bd0aff2491"
+    },
+    "feedbackSlackWebhookUrl": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    "id": "f4be2785-ec67-474c-af3a-38ffecfa4094",
+    "version": 1,
+    "feedbackEmail": "feedback@company.com"
+  }
+}
+```
+Retrieve the feedback settings associated to the feedback settings id.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The configured feedback settings' id.
+`organization.id`<br/>*UUID* | The organization id that the feedback settings are linked to. It cannot be changed.
+`supportEmail`<br/>*string* | Email address used for support requests.
+`feedbackEmail`<br/>*string* |  Email address used for feedback.
+`feedbackSlackWebhookUrl`<br/>*string* | The slack webhook url used for feedback. Please refer to [https://api.slack.com/messaging/webhooks](https://api.slack.com/messaging/webhooks).
+`version`<br/>*integer* | The feedback settings version.
+
+
+<!-------------------- CREATE FEEDBACK SETTINGS -------------------->
+### Create feedback
+
+`POST /feedback`
+
+Create a new feedback settings.
+
+```shell
+# Creates a new feedback settings
+curl -X POST "https://cloudmc_endpoint/api/v1/feedback" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```json
+{
+    "id": "f4be2785-ec67-474c-af3a-38ffecfa4094",
+	"organization": {
+		"id": "fcda8d5a-0276-4de3-908f-b3bd0aff2491"
+	},
+	"feedbackEmail": "feedback@company.com",
+	"feedbackSlackWebhookUrl": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    "supportEmail": "support@company.com"
+}
+```
+> The above command return JSON structured like this:
+
+```json
+{
+  "data": {
+    "supportEmail": "support@company.com",
+    "organization": {
+      "id": "fcda8d5a-0276-4de3-908f-b3bd0aff2491"
+    },
+    "feedbackSlackWebhookUrl": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    "id": "f4be2785-ec67-474c-af3a-38ffecfa4094",
+    "version": 1,
+    "feedbackEmail": "feedback@company.com"
+  }
+}
+```
+
+Required | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The configured feedback settings' id.
+`organization.id`<br/>*UUID* | The organization id that the feedback settings are linked to. It cannot be changed.
+
+Optional | &nbsp;
+---------- | -----------
+`supportEmail`<br/>*string* | Email address used for support requests.
+`feedbackEmail`<br/>*string* |  Email address used for feedback.
+`feedbackSlackWebhookUrl`<br/>*string* | The slack webhook url used for feedback. Please refer to [https://api.slack.com/messaging/webhooks](https://api.slack.com/messaging/webhooks).
+`version`<br/>*integer* | The feedback settings version.
+
+
+<!-------------------- UPDATE FEEDBACK SETTINGS -------------------->
+### Update feedback settings
+
+`PUT /feedback/:id`
+
+Updates the feedback settings of an organization.
+
+```shell
+# Updates an existing feedback settings for an organization
+curl -X PUT "https://cloudmc_endpoint/api/v1/feedback/f4be2785-ec67-474c-af3a-38ffecfa4094 \
+   -H "MC-Api-Key: your_api_key"
+   -H "Content-Type: application/json" \
+   -d "request-body"
+```
+
+> Request body example:
+
+```json
+{
+    "id": "f4be2785-ec67-474c-af3a-38ffecfa4094",
+	"organization": {
+		"id": "fcda8d5a-0276-4de3-908f-b3bd0aff2491"
+	},
+	"feedbackEmail": "feedback@company.com",
+	"feedbackSlackWebhookUrl": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    "supportEmail": "support@company.com"
+}
+```
+> The above command return JSON structured like this:
+
+```json
+{
+  "data": {
+    "supportEmail": "support@company.com",
+    "organization": {
+      "id": "fcda8d5a-0276-4de3-908f-b3bd0aff2491"
+    },
+    "feedbackSlackWebhookUrl": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    "id": "f4be2785-ec67-474c-af3a-38ffecfa4094",
+    "version": 1,
+    "feedbackEmail": "feedback@company.com"
+  }
+}
+```
+
+Required | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The configured feedback settings' id.
+`organization.id`<br/>*UUID* | The organization id that the feedback settings are linked to. It cannot be changed.
+
+Optional | &nbsp;
+---------- | -----------
+`supportEmail`<br/>*string* | Email address used for support requests.
+`feedbackEmail`<br/>*string* |  Email address used for feedback.
+`feedbackSlackWebhookUrl`<br/>*string* | The slack webhook url used for feedback. Please refer to [https://api.slack.com/messaging/webhooks](https://api.slack.com/messaging/webhooks).
+`version`<br/>*integer* | The feedback settings version.
+
+
+<!-------------------- DELETE FEEDBACK SETTINGS -------------------->
+### Delete feedback settings
+
+`DELETE /feedback/:id`
+
+Delete an existing feedback settings.
+
+```shell
+curl -X DELETE "https://cloudmc_endpoint/api/v1/feedback/f4be2785-ec67-474c-af3a-38ffecfa4094" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "85df8dfb-b904-42dc-bb76-4824e6b50c83",
+  "taskStatus": "SUCCESS"
+}
+```
+
+<!-------------------- CHECKING IF FEEDBACK SETTINGS EXISTS -------------------->
+
+### Check if feedback settings is configured for an organization
+
+`GET /feedback/exists?organizationId=:id`
+
+Checks if feedback settings is configured for an organization. If the `organizationId` is omitted, the authenticated user's organization will be used.
+
+```shell
+# Check if feedback settings is configured
+curl "https://cloudmc_endpoint/api/v1/feedback/exists?organizationId=fcda8d5a-0276-4de3-908f-b3bd0aff2491" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{}
+```
+
+
+<!-------------------- CHECKING IF SUPPORT SETTINGS EXISTS -------------------->
+
+### Check if a support email is configured for an organization
+
+`GET /support/exists?organizationId=:id`
+
+Check if a support email is configured for an organization. If the `organizationId` is omitted, the authenticated user's organization will be used.
+
+```shell
+# Check if support email is configured
+curl "https://cloudmc_endpoint/api/v1/support/exists?organizationId=fcda8d5a-0276-4de3-908f-b3bd0aff2491" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{}
+```

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -29,6 +29,7 @@ includes:
   - administration/knowledge_base
   - administration/trials
   - administration/email_settings
+  - administration/feedback_settings
   - cloudstack
   - cloudstack/compute # Compute section
   - cloudstack/instances


### PR DESCRIPTION
### Fixes [MC-13330](https://cloud-ops.atlassian.net/browse/MC-13300)

#### Changes made
<!-- Changes should match the template provided below -->
- Add the documentaion for feedback settings.

#### Related PRs
- [https://github.com/cloudops/cloudmc-core/pull/1037](https://github.com/cloudops/cloudmc-core/pull/1037)
- [https://github.com/cloudops/cloudmc-ui/pull/1149](https://github.com/cloudops/cloudmc-ui/pull/1149)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->