### PR TITLE
MC-13392: Added endpoint in org to list identity providers

### DIFF
--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -553,3 +553,48 @@ curl -X POST "https://cloudmc_endpoint/api/v1/organizations/03bc22bd-adc4-46b8-9
 ```
 
 Mark the organization as a reseller. Returns an HTTP status code 200, with an empty response body.
+
+
+<!-------------------- GET IDENTITY PROVIDERS -------------------->
+### Get identity providers
+`GET /organizations/organization_id/identity_providers`
+
+Retrieve the identity providers for the organization.
+
+```shell
+# Retrieve the organization's identity providers
+curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e301bf5b86a/identity_providers" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "32a5640c-b366-44b1-882a-ee2e1951c592",
+      "organization": {
+        "name": "my organization",
+        "id": "87895f43-51c1-43cc-b987-7e301bf5b86a",
+        "entryPoint": "myOrg"
+      },
+      "type": "OIDC",
+      "css": "",
+      "provider": "GOOGLE",
+      "displayName": "Google",
+      "logo": "/static/img/google_signin.svg",
+      "rank": 1
+    }
+  ]
+}
+```
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The id of the identity provider.
+`organization`<br/>*[Organization](#administration-organizations)* | The organization to which the verified domain belongs. *includes*:`id`,`name`, `entryPoint`.
+`type`<br/>*string* | The type of authentication protocol. Possible values: OIDC, SAML.
+`css`<br/>*string* | Custom css for the login button of the identity provider.
+`provider`<br/>*string* | The name of the provider. Possible values include the default providers (e.g GOOGLE), or CUSTOM for a custom user-defined provider.
+`displayName`<br/>*string* | The display name of the identity provider that will appear on the login screen.
+`logo`<br/>*string* | A base64 encoded data URL or URL to an image for the logo to display on the login screen.
+`rank`<br/>*int* | If provided, this integer sorts identity providers on the Login page in ascending order.


### PR DESCRIPTION
### Fixes [MC-13392](https://cloud-ops.atlassian.net/browse/MC-13392)

#### Code walkthrough : @patrickspensieri 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
In the organization detail page, we don't mention when the organization has identity providers as authentication method.

#### Solution
- Added endpoint to get the organization identity providers (for org rights with only the basic information)
- Modify the detailed screen to display auth methods as tags
- Added OIDC for tag with tooltip to display the list

#### Test cases
- Manual UI test
- Manual API tests
- Unit test

#### UI changes
**No OIDC**
![image](https://user-images.githubusercontent.com/56133634/102571910-c5b3ff00-40b8-11eb-8c10-c211aef05531.png)

**Single OIDC**
![image](https://user-images.githubusercontent.com/56133634/102571846-98ffe780-40b8-11eb-86ea-ea4e45e21830.png)

**Multiple OIDC**
![image](https://user-images.githubusercontent.com/56133634/102571964-e5e3be00-40b8-11eb-9717-f12a45feb84e.png)

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-ui/pull/1160
- PR # https://github.com/cloudops/cloudmc-core/pull/1053
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/293

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->