### PR TITLE
MC-12825: Added api doc for delete custom field

### DIFF
--- a/source/includes/administration/_custom_fields.md
+++ b/source/includes/administration/_custom_fields.md
@@ -150,8 +150,3 @@ curl --request DELETE \
 ```
 
 Delete a custom field.
-
-Required | &nbsp;
----------- | -----------
-`id`<br/>*UUID* | The custom field's id.
-

--- a/source/includes/administration/_custom_fields.md
+++ b/source/includes/administration/_custom_fields.md
@@ -26,7 +26,7 @@ curl "https://cloudmc_endpoint/rest/custom_fields?organization_id=fb0eeef9-eddd-
       "type": "ORGANIZATION",
       "nameTranslations": {
         "en": "username",
-        "fr": "username fr",
+        "fr": "username fr"
       },
       "descriptionTranslations": {
         "en": "username desc",
@@ -136,3 +136,22 @@ Optional | &nbsp;
 `descriptionTranslations`<br/>*map* | Map of language short codes to description translations for the field. If passed translations for all languages are required.
 `organization.id`<br/>*UUID* | The organization id that the email settings are linked to. It cannot be changed. If not passed will default to the calling user's organization.
 `required`<br/>*boolean* | Whether or not the field is required on the field. Defaults to false.
+
+### Delete a custom field
+
+`DELETE /custom_fields/:id`
+
+
+```shell
+curl --request DELETE \
+  --url https://cloudmc_endpoint/rest/custom_fields/f9a2b02b-7d67-4910-8353-c4bfcbdeaa7e \
+  --header "Content-Type: application/json" \
+  --header "Mc-Api-Key: your_api_key" 
+```
+
+Delete a custom field.
+
+Required | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The custom field's id.
+


### PR DESCRIPTION
### Feature [MC-12825](https://cloud-ops.atlassian.net/browse/MC-12825)

#### Code walkthrough : @evanluc 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
Missing the delete function on the custom fields

#### Solution
Added the delete option of the custom fields for users and organizations.

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-ui/pull/1188
- PR # https://github.com/cloudops/cloudmc-core/pull/1077
- PR # https://github.com/cloudops/cloudmc-api-docs/pull/297

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->