### PR TITLE
Feature/mc 13352 remove os policies

### DIFF
--- a/source/includes/stackpath/_images.md
+++ b/source/includes/stackpath/_images.md
@@ -23,21 +23,23 @@ curl -X GET \
     {
       "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
       "id": "a8050b2b-39eb-4929-bce5-1af42055903e/centos7/v20201110",
+      "slug": "stackpath-edge",
       "family": "centos7",
       "tag": "v20201110",
       "createdAt": "2020-11-10T20:33:32.609434Z",
       "description": "Image using centos7",
-      "reference": "a8050b2b-39eb-4929-bce5-1af42055903e/centos7:v20201110",
+      "reference": "stackpath-edge/centos7:v20201110",
       "status": "READY"
     },
     {
       "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
       "id": "a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu/v20201110",
+      "slug": "stackpath-edge",
       "family": "ubuntu",
       "tag": "v20201110",
       "createdAt": "2020-11-10T20:34:11.328575Z",
       "description": "Image using ubuntu",
-      "reference": "a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu:v20201110",
+      "reference": "stackpath-edge/ubuntu:v20201110",
       "status": "READY"
     }
   ],
@@ -50,6 +52,10 @@ curl -X GET \
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/images</code>
 
 Retrieve a list of all images in a given [environment](#administration-environments).
+
+Optional | &nbsp;
+------ | -----------
+`includeOnlySystemImages`<br/>*boolean* | Setting the query parameter to **true** will return only the default **stackpath images**.
 
 Attributes | &nbsp;
 ------- | -----------
@@ -79,6 +85,7 @@ curl -X GET \
   "data": {
     "stackId": "a8050b2b-39eb-4929-bce5-1af42055903e",
     "id": "a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu/v20201110",
+    "slug": "stackpath-edge",
     "family": "ubuntu",
     "tag": "v20201110",
     "createdAt": "2020-11-10T20:34:11.328575Z",

--- a/source/includes/stackpath/_images.md
+++ b/source/includes/stackpath/_images.md
@@ -90,7 +90,7 @@ curl -X GET \
     "tag": "v20201110",
     "createdAt": "2020-11-10T20:34:11.328575Z",
     "description": "test 2",
-    "reference": "a8050b2b-39eb-4929-bce5-1af42055903e/ubuntu:v20201110",
+    "reference": "stackpath-edge/ubuntu:v20201110",
     "status": "READY"
   }
 }


### PR DESCRIPTION
### Fixes [MC-13351](https://cloud-ops.atlassian.net/browse/MC-13351)

#### Changes made
<!-- Changes should match the template provided below -->
- Update image entity to reflect proper responses and added a query param

### Related PR
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/98

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->