### PR TITLE
MC-13457 Standardizing headers size in administration menu

### DIFF
--- a/source/includes/administration/_applied_pricings.md
+++ b/source/includes/administration/_applied_pricings.md
@@ -3,7 +3,7 @@
 The applied pricing allows the assignment of pricing to organization with a determined scope.
 
 <!-------------------- LIST APPLIED PRICINGS -------------------->
-#### List applied pricings
+### List applied pricings
 
 `GET /applied_pricings`
 
@@ -78,7 +78,7 @@ Attributes | &nbsp;
 
 
 <!-------------------- GET APPLIED PRICING -------------------->
-#### Retrieve an applied pricing
+### Retrieve an applied pricing
 
 `GET /applied_pricings/:id`
 
@@ -150,7 +150,7 @@ Attributes | &nbsp;
 `status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, FUTURE.
 
 <!-------------------- CREATE APPLIED PRICING -------------------->
-#### Create applied pricing
+### Create applied pricing
 
 `POST /applied_pricings`
 
@@ -217,7 +217,7 @@ Optional | &nbsp;
 
 
 <!-------------------- UPDATE APPLIED PRICING -------------------->
-#### Update applied pricing
+### Update applied pricing
 
 `PUT /applied_pricings/:id`
 
@@ -302,7 +302,7 @@ Optional | &nbsp;
 `endDate` <br/>*Date* | The end date for the applied pricing. 
 `scopeOrganization.id` <br/>*UUID* | The UUID of the organization that the scope is targeting. Only required for scopes : ORG_BASE, ORG_TREE, ORG_SUBS.
 
-#### Delete applied pricing
+### Delete applied pricing
 
 `DELETE /applied_pricings/:id`
 

--- a/source/includes/administration/_notification_categories.md
+++ b/source/includes/administration/_notification_categories.md
@@ -3,7 +3,7 @@ Manage notification categories.
 
 <!-------------------- LIST NOTIFICATION CATEGORIES -------------------->
 
-#### List notification categories
+### List notification categories
 
 `GET /content/categories`
 
@@ -69,7 +69,7 @@ Attributes | &nbsp;
 
 <!-------------------- GET NOTIFICATION CATEGORY -------------------->
 
-#### Retrieve notification category
+### Retrieve notification category
 
 `GET /content/categories/:id`
 
@@ -131,7 +131,7 @@ Attributes | &nbsp;
 
 <!-------------------- CREATE NOTIFICATION CATEGORY -------------------->
 
-#### Create notification category
+### Create notification category
 
 `POST /content/categories/`
 
@@ -175,7 +175,7 @@ Required | &nbsp;
 
 <!-------------------- UPDATE NOTIFICATION CATEGORY -------------------->
 
-#### Update notification category
+### Update notification category
 
 `PUT /content/categories/:id`
 

--- a/source/includes/administration/_notifications.md
+++ b/source/includes/administration/_notifications.md
@@ -3,7 +3,7 @@ Manage notifications.
 
 <!-------------------- LIST NOTIFICATIONS -------------------->
 
-#### List notifications
+### List notifications
 
 `GET /content/notifications`
 
@@ -120,7 +120,7 @@ Attributes | &nbsp;
 
 <!-------------------- GET NOTIFICATION -------------------->
 
-#### Retrieve notification
+### Retrieve notification
 
 `GET /content/notifications/:id`
 
@@ -234,7 +234,7 @@ Attributes | &nbsp;
 
 <!-------------------- CREATE NOTIFICATION -------------------->
 
-#### Create notification
+### Create notification
 
 `POST /content/notifications/`
 
@@ -295,7 +295,7 @@ Optional | &nbsp;
 
 <!-------------------- UPDATE NOTIFICATION -------------------->
 
-#### Update notification
+### Update notification
 
 `PUT /content/notifications/:id`
 

--- a/source/includes/administration/_pricings.md
+++ b/source/includes/administration/_pricings.md
@@ -3,7 +3,7 @@
 The pricing determines the price for each product defined for a selected catalog.
 
 <!-------------------- LIST PRICINGS -------------------->
-#### List pricings
+### List pricings
 
 `GET /pricings`
 
@@ -103,7 +103,7 @@ Attributes | &nbsp;
 
 
 <!-------------------- GET PRICING -------------------->
-#### Retrieve a pricing
+### Retrieve a pricing
 
 `GET /pricings/:id`
 
@@ -233,7 +233,7 @@ Attributes | &nbsp;
 `pricingProducts.currency`<br/>*string* | The currency of the pricing.
 
 <!-------------------- CREATE PRICING -------------------->
-#### Create pricing
+### Create pricing
 
 `POST /pricings`
 
@@ -365,7 +365,7 @@ Optional | &nbsp;
 `description` <br/>*Object* | A map of language language keys to the description in the specified language.
 
 <!-------------------- UPDATE PRICING -------------------->
-#### Update pricing
+### Update pricing
 
 `PUT /pricings/:id`
 
@@ -456,7 +456,7 @@ Optional | &nbsp;
 ------- | -----------
 `description` <br/>*Object* | A map of language language keys to the description in the specified language.
 
-#### Delete pricing
+### Delete pricing
 
 `DELETE /pricings/:id`
 

--- a/source/includes/administration/_products.md
+++ b/source/includes/administration/_products.md
@@ -3,7 +3,7 @@
 The product catalogs determine the product configured for a service type and optionally for specific connections.
 
 <!-------------------- LIST PRODUCT CATALOGS -------------------->
-#### List product catalogs
+### List product catalogs
 
 `GET /product_catalogs`
 
@@ -108,7 +108,7 @@ Attributes | &nbsp;
 
 
 <!-------------------- GET PRODUCT CATALOG -------------------->
-#### Retrieve a product catalog
+### Retrieve a product catalog
 
 `GET /product_catalogs/:id`
 
@@ -212,7 +212,7 @@ Attributes | &nbsp;
 
 
 <!-------------------- CREATE PRODUCT CATALOG -------------------->
-#### Create product catalog
+### Create product catalog
 
 `POST /product_catalogs`
 
@@ -373,7 +373,7 @@ Optional | &nbsp;
 
 
 <!-------------------- UPDATE PRODUCT CATALOG -------------------->
-#### Update product catalog
+### Update product catalog
 
 `PUT /product_catalogs/:id`
 
@@ -535,7 +535,7 @@ Optional | &nbsp;
 
 
 <!-------------------- DELETE PRODUCT CATALOG -------------------->
-#### Delete product catalog
+### Delete product catalog
 
 `DELETE /product_catalogs/:id`
 


### PR DESCRIPTION
### Fixes [MC-13457](https://cloud-ops.atlassian.net/browse/MC-13457)

#### Issue
Some of the headings in the CloudMC API are using 3 pounds(#) and some other place is using 4 pounds(#) sign for the same usage. The headings are not consistent throughout the entire documentation. 

#### Changes made
<!-- Changes should match the template provided below -->
- standardized headers with 3 pound signs `###` to be compliant the the different markdown linters out there. These headers are always nested in parent headers with 2 pound signs `##`. 