### PR TITLE
MC-13703: Added external documentation to knowledge base

### DIFF
--- a/source/includes/administration/_knowledge_base.md
+++ b/source/includes/administration/_knowledge_base.md
@@ -132,9 +132,9 @@ Attributes | &nbsp;
 `categories.createdAt`<br/>*string* | The creation date.
 `categories.updatedAt`<br/>*string* | The update date.
 `categories.featured`<br/>*boolean* | If the category needs to be displayed.
-`categories.externalDocumentation`<br/> | List of URL and language objects. Only either 1) articles, or, 2) external documentation, will be provided for a category (example above shows both only as an example for the object structure).
-`categories.externalDocumentation.language`<br/> | Language of the external documentation. This indicates which URL to use based on the help center selected language.
-`categories.externalDocumentation.url`<br/> | URL link to the external documentation.
+`categories.externalDocumentation`<br/>*Array[Object]* | List of URL and language objects. Only either 1) articles, or, 2) external documentation, will be provided for a category (example above shows both only as an example for the object structure).
+`categories.externalDocumentation.language`<br/>*string* | Language of the external documentation. This indicates which URL to use based on the help center selected language.
+`categories.externalDocumentation.url`<br/>*string* | URL link to the external documentation.
 `categories.translations`<br/>*Array[Object]* | The translation objects for the category.
 `categories.translations.id`<br/>*UUID* | The id of the translation.
 `categories.translations.language`<br/>*string* | The language of the translation.
@@ -280,9 +280,9 @@ Attributes | &nbsp;
 `categories.createdAt`<br/>*string* | The creation date.
 `categories.updatedAt`<br/>*string* | The update date.
 `categories.featured`<br/>*boolean* | If the category needs to be displayed.
-`categories.externalDocumentation`<br/> | List of URL and language objects. Only either 1) articles, or, 2) external documentation, will be provided for a category (example above shows both only as an example for the object structure).
-`categories.externalDocumentation.language`<br/> | Language of the external documentation. This indicates which URL to use based on the help center selected language.
-`categories.externalDocumentation.url`<br/> | URL link to the external documentation.
+`categories.externalDocumentation`<br/>*Array[Object]* | List of URL and language objects. Only either 1) articles, or, 2) external documentation, will be provided for a category (example above shows both only as an example for the object structure).
+`categories.externalDocumentation.language`<br/>*string* | Language of the external documentation. This indicates which URL to use based on the help center selected language.
+`categories.externalDocumentation.url`<br/>*string* | URL link to the external documentation.
 `categories.translations`<br/>*Array[Object]* | The translation objects for the category.
 `categories.translations.id`<br/>*UUID* | The id of the translation.
 `categories.translations.language`<br/>*string* | The language of the translation.

--- a/source/includes/administration/_knowledge_base.md
+++ b/source/includes/administration/_knowledge_base.md
@@ -132,7 +132,7 @@ Attributes | &nbsp;
 `categories.createdAt`<br/>*string* | The creation date.
 `categories.updatedAt`<br/>*string* | The update date.
 `categories.featured`<br/>*boolean* | If the category needs to be displayed.
-`categories.externalDocumentation`<br/> | List of URL and language object. Only one of articles or external documentation is provided for a category (example above shows both only as an example for the object structure).
+`categories.externalDocumentation`<br/> | List of URL and language objects. Only either 1) articles, or, 2) external documentation, will be provided for a category (example above shows both only as an example for the object structure).
 `categories.externalDocumentation.language`<br/> | Language of the external documentation. This indicates which URL to use based on the help center selected language.
 `categories.externalDocumentation.url`<br/> | URL link to the external documentation.
 `categories.translations`<br/>*Array[Object]* | The translation objects for the category.
@@ -280,7 +280,7 @@ Attributes | &nbsp;
 `categories.createdAt`<br/>*string* | The creation date.
 `categories.updatedAt`<br/>*string* | The update date.
 `categories.featured`<br/>*boolean* | If the category needs to be displayed.
-`categories.externalDocumentation`<br/> | List of URL and language object. Only one of articles or external documentation is provided for a category (example above shows both only as an example for the object structure).
+`categories.externalDocumentation`<br/> | List of URL and language objects. Only either 1) articles, or, 2) external documentation, will be provided for a category (example above shows both only as an example for the object structure).
 `categories.externalDocumentation.language`<br/> | Language of the external documentation. This indicates which URL to use based on the help center selected language.
 `categories.externalDocumentation.url`<br/> | URL link to the external documentation.
 `categories.translations`<br/>*Array[Object]* | The translation objects for the category.

--- a/source/includes/administration/_knowledge_base.md
+++ b/source/includes/administration/_knowledge_base.md
@@ -33,6 +33,20 @@ curl "https://cloudmc_endpoint/rest/content/kb" \
         {
           "createdAt": "2020-07-27T15:46:59.000Z",
           "featured": false,
+          "externalDocumentation": [
+            {
+              "language": "en",
+              "url": "http://docs.cloudstack.apache.org/en/latest/"
+            },
+            {
+              "language": "es",
+              "url": "http://docs.cloudstack.apache.org/en/latest/"
+            },
+            {
+              "language": "fr",
+              "url": "http://docs.cloudstack.apache.org/en/latest/"
+            }
+          ],
           "translations": [
             {
               "language": "en",
@@ -118,6 +132,9 @@ Attributes | &nbsp;
 `categories.createdAt`<br/>*string* | The creation date.
 `categories.updatedAt`<br/>*string* | The update date.
 `categories.featured`<br/>*boolean* | If the category needs to be displayed.
+`categories.externalDocumentation`<br/> | List of URL and language object. Only one of articles or external documentation is provided for a category (example above shows both only as an example for the object structure).
+`categories.externalDocumentation.language`<br/> | Language of the external documentation. This indicates which URL to use based on the help center selected language.
+`categories.externalDocumentation.url`<br/> | URL link to the external documentation.
 `categories.translations`<br/>*Array[Object]* | The translation objects for the category.
 `categories.translations.id`<br/>*UUID* | The id of the translation.
 `categories.translations.language`<br/>*string* | The language of the translation.
@@ -170,6 +187,20 @@ curl "https://cloudmc_endpoint/rest/content/kb/671f113c-dbbb-4478-be9c-90765b325
       {
         "createdAt": "2020-07-27T15:46:59.000Z",
         "featured": false,
+        "externalDocumentation": [
+            {
+              "language": "en",
+              "url": "http://docs.cloudstack.apache.org/en/latest/"
+            },
+            {
+              "language": "es",
+              "url": "http://docs.cloudstack.apache.org/en/latest/"
+            },
+            {
+              "language": "fr",
+              "url": "http://docs.cloudstack.apache.org/en/latest/"
+            }
+          ],
         "translations": [
           {
            "language": "en",
@@ -249,6 +280,9 @@ Attributes | &nbsp;
 `categories.createdAt`<br/>*string* | The creation date.
 `categories.updatedAt`<br/>*string* | The update date.
 `categories.featured`<br/>*boolean* | If the category needs to be displayed.
+`categories.externalDocumentation`<br/> | List of URL and language object. Only one of articles or external documentation is provided for a category (example above shows both only as an example for the object structure).
+`categories.externalDocumentation.language`<br/> | Language of the external documentation. This indicates which URL to use based on the help center selected language.
+`categories.externalDocumentation.url`<br/> | URL link to the external documentation.
 `categories.translations`<br/>*Array[Object]* | The translation objects for the category.
 `categories.translations.id`<br/>*UUID* | The id of the translation.
 `categories.translations.language`<br/>*string* | The language of the translation.


### PR DESCRIPTION
### Fixes [MC-13703](https://cloud-ops.atlassian.net/browse/MC-13703)

#### Changes made
- Added the external documentation URL to the return API call.

#### Related PRs
- Core: https://github.com/cloudops/cloudmc-core/pull/1134
- UI: https://github.com/cloudops/cloudmc-ui/pull/1261
