### PR TITLE
MC-13278: update SP workload with support for repeatable sections

### DIFF
--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -132,11 +132,11 @@ Attributes | &nbsp;
 `containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `containerEmail` <br/>*string* | The email address to use for the docker registry account. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `environmentVariables` <br/>*Array[Object]* | A list of environment variables. Only applicable to workloads of `type` 'CONTAINER'.
-`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable.
+`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable. When editing a workload, include keys you wish to preserve. Keys not included in the body will be removed.
 `environmentVariables.value` <br/>*string* | An environment variable's value.
 `secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
-`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
-`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value.
+`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable. When editing a workload, include keys you wish to preserve. Keys not included in the body will be removed.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value. When editing a workload, setting an existing environment variable's value to `[REDACTED]` will preserve the existing secret.
 `firstBootSshKey`<br/>*string* | The ssh key(s) for the VM image. Keys are delimited by a newline, `\n`. Only applicable to workloads of `type` 'VM'.
 `persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
 `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
@@ -247,11 +247,11 @@ Attributes | &nbsp;
 `containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `containerEmail` <br/>*string* | The email address to use for the docker registry account. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `environmentVariables` <br/>*Array[Object]* | A list of environment variables. Only applicable to workloads of `type` 'CONTAINER'.
-`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable.
+`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable. When editing a workload, include keys you wish to preserve. Keys not included in the body will be removed.
 `environmentVariables.value` <br/>*string* | An environment variable's value.
 `secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
-`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
-`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value.
+`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable. When editing a workload, include keys you wish to preserve. Keys not included in the body will be removed.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value. When editing a workload, setting an existing environment variable's value to `[REDACTED]` will preserve the existing secret.
 `firstBootSshKey`<br/>*string* | The ssh key(s) for the VM image. Keys are delimited by a newline, `\n`. Only applicable to workloads of `type` 'VM'.
 `persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
 `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
@@ -405,11 +405,11 @@ Required | &nbsp;
 `containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set.
 `containerEmail` <br/>*string* | The email address to use for the docker registry account
 `environmentVariables` <br/>*Array[Object]* | A list of environment variables. Only applicable to workloads of `type` 'CONTAINER'.
-`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable.
+`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable. When editing a workload, include keys you wish to preserve. Keys not included in the body will be removed.
 `environmentVariables.value` <br/>*string* | An environment variable's value.
 `secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
-`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
-`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value.
+`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable. When editing a workload, include keys you wish to preserve. Keys not included in the body will be removed.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value. When editing a workload, setting an existing environment variable's value to `[REDACTED]` will preserve the existing secret.
 `deployments.instancesPerPop`<br/>*int* | The number of instances per point of presence. Only applicable if autoscaling is not enabled.
 `deployments.cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
 `deployments.minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
@@ -513,11 +513,11 @@ Required | &nbsp;
 Optional | &nbsp;
 ------- | -----------
 `environmentVariables` <br/>*Array[Object]* | A list of environment variables. Only applicable to workloads of `type` 'CONTAINER'.
-`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable.
+`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable. When editing a workload, include keys you wish to preserve. Keys not included in the body will be removed.
 `environmentVariables.value` <br/>*string* | An environment variable's value.
 `secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
-`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
-`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value. Setting an existing environment variable's value to `[REDACTED]` will preserve the existing secret.
+`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable. When editing a workload, include keys you wish to preserve. Keys not included in the body will be removed.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value. When editing a workload, setting an existing environment variable's value to `[REDACTED]` will preserve the existing secret.
 `addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only available when `type` is equal to `CONTAINER`.
 `containerUsername`<br/>*string* | The username that should be used for authenticate the image pull. Only available when `type` is equal to `CONTAINER`.
 `containerEmail`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type` is equal to `CONTAINER`.

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -142,7 +142,7 @@ Attributes | &nbsp;
 `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
 `deployments`<br/>*Array[Object]* | The list of deployment targets.
 `deployments.name`<br/>*string* | The name of the deployment.
-`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z]{3, 3}`.
 `deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are shown.
 `deployments.instancesPerPop`<br/>*int* | The number of instances per point of presence. Only applicable if autoscaling is not enabled.
 `deployments.cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
@@ -257,7 +257,7 @@ Attributes | &nbsp;
 `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
 `deployments`<br/>*Array[Object]* | The list of deployment targets.
 `deployments.name`<br/>*string* | The name of the deployment.
-`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z]{3, 3}`.
 `deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are shown.
 `deployments.instancesPerPop`<br/>*int* | The number of instances per point of presence. Only applicable if autoscaling is not enabled.
 `deployments.cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
@@ -310,53 +310,56 @@ curl -X POST \
 
 ```json
 {
-	"type": "CONTAINER",
-   "name":"container-workload",
-   "slug":"container-workload",
-	 "image": "nginx",
-   "addAnyCastIpAddress": false,
-	 "ports": [
-		 {
-			 "publicPort": "80",
-			 "protocol": "TCP",
-       "publicPortDesc": "rule-name"
-		 }
-	 ],
-   "specs":"SP-1",
-   "persistenceStoragePath": "/lib/data/newFolder",
-   "persistenceStorageSize": 1,
-	 "commands": [
-		 "/bin/sh -c \"sleep 50\""
-	 ],
-	 "environmentVariables": [
-		 {
-			 "key": "USER",
-			 "value": "my-user"
-		 }
-	 ],
-	 "secretEnvironmentVariables": [
-		 {
-			 "key": "PASSWORD",
-			 "value": "my-password"
-		 }
-	 ],
-	 "deployments": [
-		 {
-			 "name": "deployment-mia",
- 			 "enableAutoScaling": false,
- 			 "pops": ["MIA"],
-			 "instancesPerPop": "1"
-
-		 },
-		 {
-			 "name": "deployment-lax",
-			 "pops": ["LAX"],
-			 "enableAutoScaling": true,
-			 "minInstancesPerPop": 1,
-			 "maxInstancesPerPop": 2,
-			 "cpuUtilization": 50
-		 }
-	]
+  "type": "CONTAINER",
+  "name": "container-workload",
+  "slug": "container-workload",
+  "image": "nginx",
+  "addAnyCastIpAddress": false,
+  "ports": [
+    {
+      "publicPort": "80",
+      "protocol": "TCP",
+      "publicPortDesc": "rule-name"
+    }
+  ],
+  "specs": "SP-1",
+  "persistenceStoragePath": "/lib/data/newFolder",
+  "persistenceStorageSize": 1,
+  "commands": [
+    "/bin/sh -c \"sleep 50\""
+  ],
+  "environmentVariables": [
+    {
+      "key": "USER",
+      "value": "my-user"
+    }
+  ],
+  "secretEnvironmentVariables": [
+    {
+      "key": "PASSWORD",
+      "value": "my-password"
+    }
+  ],
+  "deployments": [
+    {
+      "name": "deployment-mia",
+      "enableAutoScaling": false,
+      "pops": [
+        "MIA"
+      ],
+      "instancesPerPop": "1"
+    },
+    {
+      "name": "deployment-lax",
+      "pops": [
+        "LAX"
+      ],
+      "enableAutoScaling": true,
+      "minInstancesPerPop": 1,
+      "maxInstancesPerPop": 2,
+      "cpuUtilization": 50
+    }
+  ]
 }
 ```
 > The above commands return a JSON structured like this:
@@ -381,7 +384,7 @@ Required | &nbsp;
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload. Supported specifications are `SP-1 (1 vCPU, 2 GB RAM)`,`SP-2 (2 vCPU, 4 GB RAM)`,`SP-3 (2 vCPU, 8GB RAM)`,`SP-4 (4 vCPU, 16 GB RAM)`,`SP-5 (8 vCPU, 32 GB RAM)`.
 `deployments`<br/>*Array[Object]* | The list of deployment targets.
 `deployments.name`<br/>*string* | The name of the deployment.
-`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z]{3, 3}`.
 `deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required.
  
  Optional | &nbsp;
@@ -413,7 +416,7 @@ Required | &nbsp;
 `deployments.maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
 
 <aside class="notice">
-A workload can be created without any `ports`. However, `ports.publicPort` and `ports.protocol` are required to open a port or port range at workload creation.
+A workload can be added without any `ports`. However, `ports.publicPort` and `ports.protocol` are required to open a port or port range at workload creation.
 </aside>
 
 <!-------------------- EDIT A WORKLOAD -------------------->
@@ -436,18 +439,20 @@ curl -X PUT \
   "deployments": [
     {
       "name": "toronto-1",
-      "pops": ["YYZ"],
+      "pops": [
+        "YYZ"
+      ],
       "enableAutoScaling": true,
-			"minInstancesPerPop": 1,
-			"maxInstancesPerPop": 2,
-			"cpuUtilization": 50
+      "minInstancesPerPop": 1,
+      "maxInstancesPerPop": 2,
+      "cpuUtilization": 50
     }
   ]
 }
 ```
 > Request body example for a CONTAINER Workload type:
 
-```json
+```js
 {
   "name": "my-container-workload",
   "type": "CONTAINER",
@@ -456,6 +461,11 @@ curl -X PUT \
     {
       "key": "PASSWORD",
       "value": "my-password"
+    },
+    {
+      // set value to [REDACTED] to preserve existing secret
+      "key": "PRIVATE-KEY",
+      "value": "[REDACTED]"
     }
   ],
   "addImagePullCredentialsOption": true,
@@ -468,7 +478,9 @@ curl -X PUT \
     {
       "name": "toronto-1",
       "enableAutoScaling": false,
-      "pops": ["YYZ"],
+      "pops": [
+        "YYZ"
+      ],
       "instancesPerPop": "1"
     }
   ]
@@ -495,7 +507,7 @@ Required | &nbsp;
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
 `deployments`<br/>*Array[Object]* | The list of deployment targets.
 `deployments.name`<br/>*string* | The name of the deployment.
-`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z]{3, 3}`.
 `deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required.
 
 Optional | &nbsp;
@@ -505,7 +517,7 @@ Optional | &nbsp;
 `environmentVariables.value` <br/>*string* | An environment variable's value.
 `secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
 `secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
-`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value.l to `CONTAINER`.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value. Setting an existing environment variable's value to `[REDACTED]` will preserve the existing secret.
 `addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only available when `type` is equal to `CONTAINER`.
 `containerUsername`<br/>*string* | The username that should be used for authenticate the image pull. Only available when `type` is equal to `CONTAINER`.
 `containerEmail`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type` is equal to `CONTAINER`.

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -21,39 +21,60 @@ curl -X GET \
 {
   "data": [
     {
-      "id": "8531b1ba-1c31-41ab-b0c4-8f65798e5ed7",
       "name": "container-workload",
-      "stackId": "4f246958-595d-4ead-ae56-a88cff334b97",
+      "stackId": "a397735b-66d2-49ba-b665-e77acb944481",
       "slug": "container-workload",
       "version": "1",
-      "created": "2020-11-26T16:07:42.788665965Z",
+      "created": "2021-02-22T17:32:27.202428099Z",
       "type": "CONTAINER",
-      "commands": "/bin/sh -c \"sleep 50\"",
       "network": "default",
-      "specs": "SP-1",
       "cpu": "1",
       "memory": "2Gi",
       "isRemoteManagementEnabled": false,
-      "image": "redis",
+      "image": "nginx",
       "addImagePullCredentialsOption": false,
-      "containerUsername": null,
-      "containerServer": null,
-      "containerEmail": null,
-      "environmentVariableKey": "key1",
-      "environmentVariableValue": "new-val",
-      "deploymentName": "my-deployment",
-      "deploymentPops": [
-        "MIA",
-        "ATL",
-        "DFW"
+      "environmentVariables": [
+        {
+          "key": "USER",
+          "value": "my-user"
+        }
       ],
-      "enableAutoScaling": true,
-      "cpuUtilization": 56,
-      "minInstancesPerPop": 1,
-      "maxInstancesPerPop": 2,
+      "secretEnvironmentVariables": [
+        {
+          "key": "PASSWORD",
+          "value": "[REDACTED]"
+        }
+      ],
+      "addAnyCastIpAddress": false,
+      "commands": [
+        "/bin/sh -c \"sleep 50\""
+      ],
+      "specs": "SP-1",
+      "persistenceStoragePath": "/lib/data/newFolder",
+      "persistenceStorageSize": 1,
+      "deployments": [
+        {
+          "name": "deployment-lax",
+          "pops": [
+            "LAX"
+          ],
+          "enableAutoScaling": true,
+          "cpuUtilization": 50,
+          "minInstancesPerPop": "1",
+          "maxInstancesPerPop": "2"
+        }, {
+          "name": "deployment-mia",
+          "pops": [
+            "MIA"
+          ],
+          "enableAutoScaling": false,
+          "instancesPerPop": "1",
+          "cpuUtilization": 0,
+        }
+      ],
+      "id": "af951a00-5d1f-4c0a-85a4-b0714e833cd1",
       "status": "ACTIVE"
-    },
-    {
+    }, {
       "id": "419be644-b2e7-4574-aad9-52e1cc0e6199",
       "name": "vm-workload",
       "stackId": "4f246958-595d-4ead-ae56-a88cff334b97",
@@ -105,25 +126,29 @@ Attributes | &nbsp;
 `memory`<br/>*string* | The memory size for the workload's instance.
 `isRemoteManagementEnabled`<br/>*boolean* | Specifies if remote management is enabled on workload instance or not.
 `image`<br/>*string* | The workload's instance operating system image.
-`commands`<br/>*string* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
+`commands`<br/>*Array[string]* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
 `addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only applicable to workloads of `type` 'CONTAINER'.
 `containerUsername` <br/>*string* | The username used to authenticate the image pull. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `containerEmail` <br/>*string* | The email address to use for the docker registry account. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
-`environmentVariableKey` <br/>*string* | The location to obtain a value for an environment variable. Only applicable to workloads of `type` 'CONTAINER'.
-`environmentVariableValue` <br/>*string* | An environment variable's value. Only applicable to workloads of `type` 'CONTAINER'.
-`secretEnvironmentVariableKey` <br/>*string* | The location to obtain a value for a secret environment variable. Only applicable to workloads of `type` 'CONTAINER'.
+`environmentVariables` <br/>*Array[Object]* | A list of environment variables. Only applicable to workloads of `type` 'CONTAINER'.
+`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable.
+`environmentVariables.value` <br/>*string* | An environment variable's value.
+`secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
+`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value.
 `firstBootSshKey`<br/>*string* | The ssh key(s) for the VM image. Keys are delimited by a newline, `\n`. Only applicable to workloads of `type` 'VM'.
 `persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
 `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
-`deploymentName`<br/>*string* | The name of the deployment.
-`deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
-`enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are shown.
-`deploymentInstancePerPops`<br/>*integer* | The number of deployments per point of presence. Only applicable if autoscaling is not enabled.
-`cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
-`minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP. Only applicable if autoscaling is enabled.
-`maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP. Only applicable if autoscaling is enabled.
-`status`<br/>*string* | The status of the workload. It can be either ACTIVE or DISABLED.
+`deployments`<br/>*Array[Object]* | The list of deployment targets.
+`deployments.name`<br/>*string* | The name of the deployment.
+`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are shown.
+`deployments.instancesPerPop`<br/>*int* | The number of instances per point of presence. Only applicable if autoscaling is not enabled.
+`deployments.cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
+`deployments.minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
+`deployments.maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
+`status`<br/>*string* | The status of the workload. It can be either `ACTIVE` or `DISABLED`.
 
 
 <!-------------------- RETRIEVE A WORKLOAD -------------------->
@@ -141,29 +166,58 @@ curl -X GET \
 ```json
 {
   "data": {
-    "id": "419be644-b2e7-4574-aad9-52e1cc0e6199",
-    "name": "vm-workload",
-    "stackId": "4f246958-595d-4ead-ae56-a88cff334b97",
-    "slug": "vm-workload",
-    "version": "10",
-    "created": "2020-11-27T20:11:09.563675315Z",
-    "type": "VM",
+    "name": "container-workload",
+    "stackId": "a397735b-66d2-49ba-b665-e77acb944481",
+    "slug": "container-workload",
+    "version": "1",
+    "created": "2021-02-22T17:32:27.202428099Z",
+    "type": "CONTAINER",
     "network": "default",
-    "specs": "SP-1",
     "cpu": "1",
     "memory": "2Gi",
     "isRemoteManagementEnabled": false,
-    "image": "stackpath-edge/centos-7:v202007311835",
-    "addAnyCastIpAddress": false,
-    "firstBootSshKey": "ssh-rsa...",
-    "persistenceStorageSize": 2,
-    "persistenceStoragePath": "/var/lib/data",
-    "deploymentName": "deployment-name",
-    "deploymentPops": [
-      "YYZ"
+    "image": "nginx",
+    "addImagePullCredentialsOption": false,
+    "environmentVariables": [
+      {
+        "key": "USER",
+        "value": "my-user"
+      }
     ],
-    "enableAutoScaling": false,
-    "deploymentInstancePerPops": 3,
+    "secretEnvironmentVariables": [
+      {
+        "key": "PASSWORD",
+        "value": "[REDACTED]"
+      }
+    ],
+    "addAnyCastIpAddress": false,
+    "commands": [
+      "/bin/sh -c \"sleep 50\""
+    ],
+    "specs": "SP-1",
+    "persistenceStoragePath": "/lib/data/newFolder",
+    "persistenceStorageSize": 1,
+    "deployments": [
+      {
+        "name": "deployment-lax",
+        "pops": [
+          "LAX"
+        ],
+        "enableAutoScaling": true,
+        "cpuUtilization": 50,
+        "minInstancesPerPop": "1",
+        "maxInstancesPerPop": "2"
+      }, {
+        "name": "deployment-mia",
+        "pops": [
+          "MIA"
+        ],
+        "enableAutoScaling": false,
+        "instancesPerPop": "1",
+        "cpuUtilization": 0,
+      }
+    ],
+    "id": "af951a00-5d1f-4c0a-85a4-b0714e833cd1",
     "status": "ACTIVE"
   }
 }
@@ -188,24 +242,27 @@ Attributes | &nbsp;
 `memory`<br/>*string* | The memory size for the workload's instance.
 `isRemoteManagementEnabled`<br/>*boolean* | Specifies if remote management is enabled on workload instance or not.
 `image`<br/>*string* | The workload's instance operating system image.
-`commands`<br/>*string* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
-`addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only applicable to workloads of `type` 'CONTAINER'.
+`commands`<br/>*Array[string]* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
 `containerUsername` <br/>*string* | The username used to authenticate the image pull. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `containerEmail` <br/>*string* | The email address to use for the docker registry account. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
-`environmentVariableKey` <br/>*string* | The location to obtain a value for an environment variable. Only applicable to workloads of `type` 'CONTAINER'.
-`environmentVariableValue` <br/>*string* | An environment variable's value. Only applicable to workloads of `type` 'CONTAINER'.
-`secretEnvironmentVariableKey` <br/>*string* | The location to obtain a value for a secret environment variable. Only applicable to workloads of `type` 'CONTAINER'.
+`environmentVariables` <br/>*Array[Object]* | A list of environment variables. Only applicable to workloads of `type` 'CONTAINER'.
+`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable.
+`environmentVariables.value` <br/>*string* | An environment variable's value.
+`secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
+`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value.
 `firstBootSshKey`<br/>*string* | The ssh key(s) for the VM image. Keys are delimited by a newline, `\n`. Only applicable to workloads of `type` 'VM'.
 `persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
 `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
-`deploymentName`<br/>*string* | The name of the deployment.
-`deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the format [A-Z][A-Z][A-Z].
-`enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are shown.
-`deploymentInstancePerPops`<br/>*integer* | The number of deployments per point of presence. Only applicable if autoscaling is not enabled.
-`cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
-`minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP. Only applicable if autoscaling is enabled.
-`maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP. Only applicable if autoscaling is enabled.
+`deployments`<br/>*Array[Object]* | The list of deployment targets.
+`deployments.deploymentName`<br/>*string* | The name of the deployment.
+`deployments.deploymentPopsNames`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are shown.
+`deployments.deploymentInstancePerPops`<br/>*int* | The number of instances per point of presence. Only applicable if autoscaling is not enabled.
+`deployments.cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
+`deployments.minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
+`deployments.maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
 `status`<br/>*string* | The status of the workload. It can be either ACTIVE or DISABLED.
 
 <!-------------------- CREATE A WORKLOAD -------------------->
@@ -222,23 +279,30 @@ curl -X POST \
 
 ```json
 {
-   "name":"w-user-zwg",
-   "slug":"w-user-zwg",
-   "type":"VM",
-   "image":"stackpath-edge/centos-7-cpanel:v201905241955",
-   "addAnyCastIpAddress":false,
-   "publicPort": "80",
-   "publicPortSrc": "0.0.0.0/0",
-   "publicPortDesc": "npr_root_btd",
-   "protocol": "TCP",
-   "firstBootSshKey":"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDcYr9OnzsDfYVW2I1kX/iYJ0mPG490bI5mbxbOAKPLMuWLguxRohX804j1XbwZJ+Sna+9rSfxaYA8vgd1MoYX10l9cnMLx/MMbYp4ZquauN4pGY3WoDeCqsTss3VUMW+7RFBILpU3SJTlDV02FI36D3IXb4A8XymCyU3KC99XXTfTQsuKC+WFRMsTWtklrasqCVd5yEG90i/aJc6A3TZGOYgPFNEeVYvNDaJmIkb3y4FfShoBIMgZRt0ay7SvWZUvyfvyNmK5W9ePdhZZ58R+7tQNmCzjQ4v0suWRuGJ/XL3+03w3HEsDdQx+noL+R+qAjoNFwc0spBBhJK+Q4ADqr nothing@gmail.com \nssh-rsa...",
-   "specs":"SP-1",
-   "persistenceStoragePath":"/lib/data/newFolder",
-   "persistenceStorageSize":1,
-   "deploymentName":"wi-root-ion",
-   "deploymentInstancePerPops":1,
-   "enableAutoScaling":false,
-   "deploymentPops": ["YYZ", "MIA", "LAX"]
+  "name":"vm-workload",
+  "slug":"vm-workload",
+  "type":"VM",
+  "image":"stackpath-edge/centos-7-cpanel:v201905241955",
+  "addAnyCastIpAddress":false,
+  "ports": [
+    {
+      "publicPort": "80",
+      "protocol": "TCP",
+      "publicPortDesc": "rule-name"
+    }
+  ],
+  "firstBootSshKey":"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDcYr9OnzsDfYVW2I1kX/iYJ0mPG490bI5mbxbOAKPLMuWLguxRohX804j1XbwZJ+Sna+9rSfxaYA8vgd1MoYX10l9cnMLx/MMbYp4ZquauN4pGY3WoDeCqsTss3VUMW+7RFBILpU3SJTlDV02FI36D3IXb4A8XymCyU3KC99XXTfTQsuKC+WFRMsTWtklrasqCVd5yEG90i/aJc6A3TZGOYgPFNEeVYvNDaJmIkb3y4FfShoBIMgZRt0ay7SvWZUvyfvyNmK5W9ePdhZZ58R+7tQNmCzjQ4v0suWRuGJ/XL3+03w3HEsDdQx+noL+R+qAjoNFwc0spBBhJK+Q4ADqr nothing@gmail.com \nssh-rsa...",
+  "specs":"SP-1",
+  "persistenceStoragePath":"/lib/data/newFolder",
+  "persistenceStorageSize":1,
+  "deployments": [
+    {
+      "name": "deployment-name",
+      "enableAutoScaling": false,
+      "pops": ["MIA"],
+      "instancesPerPop": "1"
+    }
+  ]
 }
 ```
 
@@ -246,33 +310,53 @@ curl -X POST \
 
 ```json
 {
-   "name":"w-user-pah",
-   "type":"CONTAINER",
-   "image":"nginx:latest",
-   "addImagePullCredentialsOption":true,
-   "containerUsername":"test.username",
-   "containerPassword":"test-password",
-   "containerServer":"container.server.io",
-   "containerEmail":"mytestEmail@email.com",
-   "environmentVariableKey": "env-key",
-   "environmentVariableValue": "env-value",
-   "secretEnvironmentVariableKey":"secret-key",
-   "secretEnvironmentVariableValue":"secret-value",
-   "addAnyCastIpAddress":false,
-   "publicPort": "80",
-   "publicPortSrc": "0.0.0.0/0",
-   "publicPortDesc": "npr_root_btd",
-   "protocol": "TCP",
-   "specs":"SP-3",
-   "persistenceStoragePath":null,
-   "persistenceStorageSize":1,
-   "deploymentName":"wi-root-pxa",
-   "deploymentInstancePerPops":1,
-   "deploymentPops": ["FRA", "YYZ"],
-   "enableAutoScaling":true,
-   "cpuUtilization":50,
-   "minInstancesPerPop":1,
-   "maxInstancesPerPop":2
+	"type": "CONTAINER",
+   "name":"container-workload",
+   "slug":"container-workload",
+	 "image": "nginx",
+   "addAnyCastIpAddress": false,
+	 "ports": [
+		 {
+			 "publicPort": "80",
+			 "protocol": "TCP",
+       "publicPortDesc": "rule-name"
+		 }
+	 ],
+   "specs":"SP-1",
+   "persistenceStoragePath": "/lib/data/newFolder",
+   "persistenceStorageSize": 1,
+	 "commands": [
+		 "/bin/sh -c \"sleep 50\""
+	 ],
+	 "environmentVariables": [
+		 {
+			 "key": "USER",
+			 "value": "my-user"
+		 }
+	 ],
+	 "secretEnvironmentVariables": [
+		 {
+			 "key": "PASSWORD",
+			 "value": "my-password"
+		 }
+	 ],
+	 "deployments": [
+		 {
+			 "name": "deployment-mia",
+ 			 "enableAutoScaling": false,
+ 			 "pops": ["MIA"],
+			 "instancesPerPop": "1"
+
+		 },
+		 {
+			 "name": "deployment-lax",
+			 "pops": ["LAX"],
+			 "enableAutoScaling": true,
+			 "minInstancesPerPop": 1,
+			 "maxInstancesPerPop": 2,
+			 "cpuUtilization": 50
+		 }
+	]
 }
 ```
 > The above commands return a JSON structured like this:
@@ -290,42 +374,43 @@ Create a new workload in a given [environment](#administration-environments).
 
 Required | &nbsp;
 ------- | -----------
- `name`<br/>*string* | The name of the workload. The workload name must not exceed 18 characters.
- `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either `VM` or `CONTAINER`.
- `image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
- `firstBootSshKey`<br/>*string* | If creating a VM-based workload, SSH keys are required. Multiple SSH keys can be separated by newlines `\n`.
- `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload. Supported specifications are `SP-1 (1 vCPU, 2 GB RAM)`,`SP-2 (2 vCPU, 4 GB RAM)`,`SP-3 (2 vCPU, 8GB RAM)`,`SP-4 (4 vCPU, 16 GB RAM)`,`SP-5 (8 vCPU, 32 GB RAM)`.
- `deploymentName`<br/>*string* | The name of the deployment. The deployment name must not exceed 18 characters.
- `deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
- `enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required else `deploymentInstancePerPops` is 
- `cpuUtilization` <br/>*int* | Specify the percentage of CPU utilization.
- `minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP.
- `maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP.
+`name`<br/>*string* | The name of the workload. The workload name must not exceed 18 characters.
+`type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either `VM` or `CONTAINER`.
+`image`<br/>*string* | Either the location of a Docker image to run as a container or the image to use for the virtual machine. If for a virtual machine, this is in the format of /[:]. If the image tag portion is omitted, 'default' is assumed which is the most recently created, ready, and non-deprecated image of that slug. A set of common images is present on the 'stackpath-edge' stack.
+`firstBootSshKey`<br/>*string* | If creating a VM-based workload, SSH keys are required. Multiple SSH keys can be separated by newlines `\n`.
+`specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload. Supported specifications are `SP-1 (1 vCPU, 2 GB RAM)`,`SP-2 (2 vCPU, 4 GB RAM)`,`SP-3 (2 vCPU, 8GB RAM)`,`SP-4 (4 vCPU, 16 GB RAM)`,`SP-5 (8 vCPU, 32 GB RAM)`.
+`deployments`<br/>*Array[Object]* | The list of deployment targets.
+`deployments.name`<br/>*string* | The name of the deployment.
+`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required.
  
  Optional | &nbsp;
  ------- | -----------
-  `slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names. If not provided, defaults to workload's name. It must not exceed 18 characters.
- `addAnyCastIpAddress`<br/>*boolean* | Option to AnyCast IP Address.
-  `publicPort`<br/>*string* | A single port, such as 80 or a port range, such as 1024-65535 for which a network policy rule will be created for the workload.
- `publicPortSrc`<br/>*string* | A subnet that will define all the IPs allowed by the network policy rule.
- `publicPortDesc`<br/>*string* | A summary of what the network policy rule does or a name for it. It is highly recommended to give a unique description to easily identify a network policy rule.
- `protocol`<br/>*string* | Protocol for the network policy rule. Supported protocols are: `TCP`, `UDP` and `TCP_UDP`.
- `commands`<br/>*string* | The commands that start a container. Only applicable to workloads of type `CONTAINER`.
- `persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
- `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
- `addImagePullCredentialsOption` <br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not.
- `containerUsername` <br/>*string* | The username used to authenticate the image pull.
- `containerPassword` <br/>*string* | The password used to authenticate the image pull.
- `containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set.
- `containerEmail` <br/>*string* | The email address to use for the docker registry account
- `environmentVariableKey` <br/>*string* | The location to obtain a value for an environment variable.
- `environmentVariableValue` <br/>*string* | An environment variable's value.
- `secretEnvironmentVariableKey` <br/>*string* | The secret environment variable's key.
- `secretEnvironmentVariableValue` <br/>*string* | A sensitive environment variable that should not be exposed.
- `deploymentInstancePerPops`<br/>*integer* | The number of deployments per point of presence. Only required if autoscaling is not enabled.
- `cpuUtilization` <br/>*int* | Specify the percentage of CPU utilization.
- `minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP.
- `maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP.
+`slug`<br/>*string* | A workload's programmatic name. Workload slugs are used to build its instances names. If not provided, defaults to workload's name. It must not exceed 18 characters.
+`addAnyCastIpAddress`<br/>*boolean* | Option to AnyCast IP Address.
+`ports` <br/>*Array[Object]* | A list of network interfaces that will be created for each workload instance.
+`ports.publicPort`<br/>*string* | A single port, such as 80 or a port range, such as 1024-65535 for which a network policy rule will be created for the workload.
+`ports.protocol`<br/>*string* | Protocol for the network policy rule. Supported protocols are: `TCP`, `UDP` and `TCP_UDP`.
+`ports.publicPortSrc`<br/>*string* | A subnet that will define all the IPs allowed by the network policy rule. Defaults to `0.0.0.0/0` if not specified.
+`ports.publicPortDesc`<br/>*string* | A summary of what the network policy rule does or a name for it. It is highly recommended to give a unique description to easily identify a network policy rule. Defaults to an empty string if not provided.
+`commands`<br/>*Array[string]* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
+`persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
+`persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
+`addImagePullCredentialsOption` <br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not.
+`containerUsername` <br/>*string* | The username used to authenticate the image pull.
+`containerPassword` <br/>*string* | The password used to authenticate the image pull.
+`containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set.
+`containerEmail` <br/>*string* | The email address to use for the docker registry account
+`environmentVariables` <br/>*Array[Object]* | A list of environment variables. Only applicable to workloads of `type` 'CONTAINER'.
+`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable.
+`environmentVariables.value` <br/>*string* | An environment variable's value.
+`secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
+`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value.
+`deployments.instancesPerPop`<br/>*int* | The number of instances per point of presence. Only applicable if autoscaling is not enabled.
+`deployments.cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
+`deployments.minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
+`deployments.maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
 
 <aside class="notice">
 A workload can be created without `publicPort`, `publicPortSrc`, `publicPortDesc` and `protocol` as part of the payload. But all these fields are required to open a port/port-range on the created workload.
@@ -348,12 +433,16 @@ curl -X PUT \
   "name": "my-vm-workload",
   "type": "VM",
   "specs": "SP-1",
-  "deploymentName": "chicago-1",
-  "deploymentPops": ["ORD"],
-  "enableAutoScaling": true,
-  "cpuUtilization": 50,
-  "minInstancesPerPop": 2,
-  "maxInstancesPerPop": 3
+  "deployments": [
+    {
+      "name": "toronto-1",
+      "pops": ["YYZ"],
+      "enableAutoScaling": true,
+			"minInstancesPerPop": 1,
+			"maxInstancesPerPop": 2,
+			"cpuUtilization": 50
+    }
+  ]
 }
 ```
 > Request body example for a CONTAINER Workload type:
@@ -363,20 +452,26 @@ curl -X PUT \
   "name": "my-container-workload",
   "type": "CONTAINER",
   "image": "redis:alpine",
-  "environmentVariableKey": "env-key",
-  "environmentVariableValue": "env-value",
-  "secretEnvironmentVariableKey": "secret-key",
-  "secretEnvironmentVariableValue": "secret-value",
+  "secretEnvironmentVariables": [
+    {
+      "key": "PASSWORD",
+      "value": "my-password"
+    }
+  ],
   "addImagePullCredentialsOption": true,
   "containerUsername": "username",
   "containerServer": "container.server.io",
   "containerEmail": "myemail@email.com",
   "containerPassword": "my-password",
   "specs": "SP-2",
-  "deploymentName": "toronto-1",
-  "deploymentPops": ["YYZ"],
-  "enableAutoScaling": false,
-  "deploymentInstancePerPops": 2
+  "deployments": [
+    {
+      "name": "toronto-1",
+      "enableAutoScaling": false,
+      "pops": ["YYZ"],
+      "instancesPerPop": "1"
+    }
+  ]
 }
 ```
 
@@ -398,25 +493,28 @@ Required | &nbsp;
 `type`<br/>*string* | Specify whether a workload is a VM-based workload or container-based. Can be either `VM` or `CONTAINER`.
 `image`<br/>*string* | The location of a Docker image to run as a container. Only editable when `type` is equal to `CONTAINER`.
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
-`deploymentName`<br/>*string* | The name of the deployment. The deployment name must not exceed 18 characters.
-`deploymentPops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
-`enableAutoScaling` <br/>*boolean* | Specify if you would like to enable autoscaling. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required else `deploymentInstancePerPops` is required.
+`deployments`<br/>*Array[Object]* | The list of deployment targets.
+`deployments.deploymentName`<br/>*string* | The name of the deployment.
+`deployments.deploymentPopsNames`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required.
 
 Optional | &nbsp;
 ------- | -----------
-`environmentVariableKey`<br/>*string* | The key of the environmental variable you would like to edit. Only available when `type` is equal to `CONTAINER`.
-`environmentVariableValue`<br/>*string* | The value of the environmental variable you would like to edit. Only available when `type` is equal to `CONTAINER`.
-`secretEnvironmentVariableKey`<br/>*string* | The key of the secret environmental variable you would like to edit. Only available when `type` is equal to `CONTAINER`.
-`secretEnvironmentVariableValue`<br/>*string* | The value of the secret environmental variable you would like to edit. Only available when `type` is equal to `CONTAINER`.
+`environmentVariables` <br/>*Array[Object]* | A list of environment variables. Only applicable to workloads of `type` 'CONTAINER'.
+`environmentVariables.key` <br/>*string* | The location to obtain a value for an environment variable.
+`environmentVariables.value` <br/>*string* | An environment variable's value.
+`secretEnvironmentVariables` <br/>*Array[Object]* | A list of sensitive environment variables. Only applicable to workloads of `type` 'CONTAINER'.
+`secretEnvironmentVariables.key` <br/>*string* | The location to obtain a value for a secret environment variable.
+`secretEnvironmentVariables.value` <br/>*string* | A secret environment variable's value.l to `CONTAINER`.
 `addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only available when `type` is equal to `CONTAINER`.
 `containerUsername`<br/>*string* | The username that should be used for authenticate the image pull. Only available when `type` is equal to `CONTAINER`.
 `containerEmail`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type` is equal to `CONTAINER`.
 `containerServer`<br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only available when `type` is equal to `CONTAINER`.
 `containerPassword`<br/>*string* | The password that should be used to authenticate the image pull. Only available when `type` is equal to `CONTAINER`.
-`deploymentInstancePerPops`<br/>*integer* | The number of deployments per point of presence. Only required if autoscaling is not enabled.
-`cpuUtilization`<br/>*integer* | The average CPU utlilization threshold to be reached before deploying a new instance. Only required if autoscaling is enabled.
-`minInstancesPerPop`<br/>*integer* | The minimum number of instances per point of presence. Only required if autoscaling is enabled.
-`maxInstancesPerPop`<br/>*integer* | The maximum number of instances per point of presence. Only required if autoscaling is enabled.
+`deployments.instancesPerPop`<br/>*integer* | The number of deployments per point of presence. Only required if autoscaling is not enabled.
+`deployments.cpuUtilization`<br/>*integer* | The average CPU utlilization threshold to be reached before deploying a new instance. Only required if autoscaling is enabled.
+`deployments.minInstancesPerPop`<br/>*integer* | The minimum number of instances per point of presence. Only required if autoscaling is enabled.
+`deployments.maxInstancesPerPop`<br/>*integer* | The maximum number of instances per point of presence. Only required if autoscaling is enabled.
 
 <!-------------------- DELETE A WORKLOAD -------------------->
 

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -396,7 +396,7 @@ Required | &nbsp;
 `ports.protocol`<br/>*string* | Protocol for the network policy rule. Supported protocols are: `TCP`, `UDP` and `TCP_UDP`.
 `ports.publicPortSrc`<br/>*string* | A subnet that will define all the IPs allowed by the network policy rule. Defaults to `0.0.0.0/0` if not specified.
 `ports.publicPortDesc`<br/>*string* | A summary of what the network policy rule does or a name for it. It is highly recommended to give a unique description to easily identify a network policy rule. Defaults to an empty string if not provided.
-`commands`<br/>*Array[string]* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
+`commands`<br/>*Array[string]* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'. Commands cannot be updated or removed after workload creation.
 `persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
 `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
 `addImagePullCredentialsOption` <br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not.

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -256,10 +256,10 @@ Attributes | &nbsp;
 `persistenceStoragePath`<br/>*string* | The path in an instance to mount a volume.
 `persistenceStorageSize`<br/>*int* | The size of the mounted volume (in GB).
 `deployments`<br/>*Array[Object]* | The list of deployment targets.
-`deployments.deploymentName`<br/>*string* | The name of the deployment.
-`deployments.deploymentPopsNames`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.name`<br/>*string* | The name of the deployment.
+`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
 `deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are shown.
-`deployments.deploymentInstancePerPops`<br/>*int* | The number of instances per point of presence. Only applicable if autoscaling is not enabled.
+`deployments.instancesPerPop`<br/>*int* | The number of instances per point of presence. Only applicable if autoscaling is not enabled.
 `deployments.cpuUtilization` <br/>*int* | The percentage of CPU utilization. Only applicable if autoscaling is enabled.
 `deployments.minInstancesPerPop` <br/>*int* | The minimum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
 `deployments.maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
@@ -413,7 +413,7 @@ Required | &nbsp;
 `deployments.maxInstancesPerPop` <br/>*int* | The maximum number of instances per PoP. Only applicable if autoscaling is enabled. Should be greater than zero and less than 50.
 
 <aside class="notice">
-A workload can be created without `publicPort`, `publicPortSrc`, `publicPortDesc` and `protocol` as part of the payload. But all these fields are required to open a port/port-range on the created workload.
+A workload can be created without any `ports`. However, `ports.publicPort` and `ports.protocol` are required to open a port or port range at workload creation.
 </aside>
 
 <!-------------------- EDIT A WORKLOAD -------------------->
@@ -494,8 +494,8 @@ Required | &nbsp;
 `image`<br/>*string* | The location of a Docker image to run as a container. Only editable when `type` is equal to `CONTAINER`.
 `specs`<br/>*string* | Specification type for resources which are allocated to each instance in a workload.
 `deployments`<br/>*Array[Object]* | The list of deployment targets.
-`deployments.deploymentName`<br/>*string* | The name of the deployment.
-`deployments.deploymentPopsNames`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
+`deployments.name`<br/>*string* | The name of the deployment.
+`deployments.pops`<br/>*Array[string]* | The points of presence of a deployment. In the regex format `[A-Z][A-Z][A-Z]`.
 `deployments.enableAutoScaling` <br/>*boolean* | Specifies if autoscaling is enabled. If enabled, then `cpuUtilization` , `minInstancesPerPop` and `maxInstancesPerPop` are required.
 
 Optional | &nbsp;


### PR DESCRIPTION
### Fixes [MC-13278](https://cloud-ops.atlassian.net/browse/MC-13278)

#### Code walkthrough : @INSERT_NAME
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
Create and edit workload should use repeatable sections for
- environment variables
- ports
- commands
- deployments

#### Solution
Add support for repeatable sections
- Currently, repeatable does not support removing the last element
- Workaround for the moment is to "ignore" some invalid port objects rather than return an operation error
- See [this comment](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/127#discussion_r579315155) for an example of this
- See [MC-13765](https://cloudops.atlassian.net/browse/MC-13765) for improvement (with reference to create workload)

#### Test cases
- Unit tests
- Manually API tested

#### UI changes
Other small changes including removing some description labels are not detailed below (like in persistent storage section).
| | Before | After |
| --- | --- | --- |
| Env vars | ![4-env-vars-before](https://user-images.githubusercontent.com/8960233/108738219-6384d980-7501-11eb-9355-dc7d39efe6bf.jpg) | ![4-env-vars-after](https://user-images.githubusercontent.com/8960233/108738241-697aba80-7501-11eb-911c-4025e274341d.jpg) |
| Commands | ![4-commands-before](https://user-images.githubusercontent.com/8960233/108738295-77c8d680-7501-11eb-9e9c-78b81eeb2da0.jpg) | ![4-commands-after](https://user-images.githubusercontent.com/8960233/108738322-7e574e00-7501-11eb-8243-0b044451859d.jpg) |
| Ports | ![4-ports-before](https://user-images.githubusercontent.com/8960233/108738351-84e5c580-7501-11eb-86bc-be4a33cb3ffb.jpg) | ![4-ports-after](https://user-images.githubusercontent.com/8960233/108738374-89aa7980-7501-11eb-82a8-09d9b4c54d66.jpg) |
| Deployments | ![4-deployments-before](https://user-images.githubusercontent.com/8960233/108738403-9202b480-7501-11eb-9da6-e793491378f2.jpg) | ![4-deployments-after](https://user-images.githubusercontent.com/8960233/108738427-962ed200-7501-11eb-94c9-b5290d6c25fd.jpg) |

#### Related PRs
- PR #
