### PR TITLE
MC-13608: Added documentation for the create site

### DIFF
--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -123,17 +123,17 @@ curl -X POST \
 
 ```json
 {
-	"domain": "www.rpgfan.com",
-	"services": [
-		"CDN",
-		"SERVERLESS_EDGE_ENGINE",
-		"WAF"
-	],
-	"protocol": "HTTPS",
-	"hostname": "199.250.204.212",
-    "authMethod": "BASIC",
-	"username": "alavoie",
-	"password": "123456"
+  "domain": "www.rpgfan.com",
+  "services": [
+    "CDN",
+    "SERVERLESS_EDGE_ENGINE",
+    "WAF"
+  ],
+  "protocol": "HTTPS",
+  "hostname": "199.250.204.212",
+  "authMethod": "BASIC",
+  "username": "alavoie",
+  "password": "123456"
 }
 ```
 
@@ -141,14 +141,14 @@ curl -X POST \
 
 ```json
 {
-	"domain": "www.rpgfan.com",
-	"services": [
-		"CDN",
-		"SERVERLESS_EDGE_ENGINE",
-		"WAF"
-	],
-	"protocol": "HTTPS",
-	"hostname": "199.250.204.212"
+  "domain": "www.rpgfan.com",
+  "services": [
+    "CDN",
+    "SERVERLESS_EDGE_ENGINE",
+    "WAF"
+  ],
+  "protocol": "HTTPS",
+  "hostname": "199.250.204.212"
 }
 ```
 > The above commands return a JSON structured like this:

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -109,6 +109,75 @@ Attributes | &nbsp;
 `updatedAt`<br/>*string* | The date on which the site was last updated.
 `services`<br/>*array* | List of services running on the site.
 
+<!-------------------- CREATE A SITE -------------------->
+
+### Create a site
+
+```shell
+curl -X POST \
+    -H "MC-Api-Key: your_api_key" \
+    -d "request_body" \
+    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/sites"
+```
+> Request body example for a site with basic authentication:
+
+```json
+{
+	"domain": "www.rpgfan.com",
+	"services": [
+		"CDN",
+		"SERVERLESS_EDGE_ENGINE",
+		"WAF"
+	],
+	"protocol": "HTTPS",
+	"hostname": "199.250.204.212",
+    "authMethod": "BASIC",
+	"username": "alavoie",
+	"password": "123456"
+}
+```
+
+> Request body example for a site with no authentication:
+
+```json
+{
+	"domain": "www.rpgfan.com",
+	"services": [
+		"CDN",
+		"SERVERLESS_EDGE_ENGINE",
+		"WAF"
+	],
+	"protocol": "HTTPS",
+	"hostname": "199.250.204.212"
+}
+```
+> The above commands return a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/sites</code>
+
+Create a site in a given [environment](#administration-environments).
+
+Required | &nbsp;
+------- | -----------
+`domain`<br/>*string* | The domain name that will be used for the site.
+`services`<br/>*Array[string]* | Services list that will be used on the site. Possibles values are `CDN`,`SERVERLESS_EDGE_ENGINE` or  `WAF`.
+`protocol`<br/>*string* | Protocol that will be used to communicate with the hostname. Possibles values are `HTTP` or `HTTPS`.
+`hostname`<br/>*string* | The hostname to that will be used to get the information from. The hostname can be an IP or a name. It may include a specific port and a precise path as well. (e.g. 199.250.204.212:80/test) 
+ 
+ Optional | &nbsp;
+ ------- | -----------
+`authMethod`<br/>*string* | The authentication method to communicate with the hostname. Possibles values are `NONE` or `BASIC`. If not provided, it will default to `NONE` unless the username or password is provided. It would then default to `BASIC`.
+`username`<br/>*Array[Object]* | The username for the basic authentication. Required if authMethod is `BASIC` or if the password id provided 
+`password`<br/>*string* | The password for the basic authentication. Required if authMethod is `BASIC` or if the password id provided
+
+
 <!-------------------- DELETE A SITE -------------------->
 
 ### Delete a site

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -169,13 +169,13 @@ Required | &nbsp;
 `domain`<br/>*string* | The domain name that will be used for the site.
 `services`<br/>*Array[string]* | Services list that will be used on the site. Possibles values are `CDN`,`SERVERLESS_EDGE_ENGINE` or  `WAF`.
 `protocol`<br/>*string* | Protocol that will be used to communicate with the hostname. Possibles values are `HTTP` or `HTTPS`.
-`hostname`<br/>*string* | The hostname to that will be used to get the information from. The hostname can be an IP or a name. It may include a specific port and a precise path as well. (e.g. 199.250.204.212:80/test) 
+`hostname`<br/>*string* | The hostname to that will be used to get the information from. The hostname can be an IP or a name. It may include a specific port and a precise path as well (e.g. 199.250.204.212:80/test). 
  
  Optional | &nbsp;
  ------- | -----------
 `authMethod`<br/>*string* | The authentication method to communicate with the hostname. Possibles values are `NONE` or `BASIC`. If not provided, it will default to `NONE` unless the username or password is provided. It would then default to `BASIC`.
-`username`<br/>*Array[Object]* | The username for the basic authentication. Required if authMethod is `BASIC` or if the password id provided 
-`password`<br/>*string* | The password for the basic authentication. Required if authMethod is `BASIC` or if the password id provided
+`username`<br/>*Array[Object]* | The username for the basic authentication. Required if authMethod is `BASIC` or if the password id provided. 
+`password`<br/>*string* | The password for the basic authentication. Required if authMethod is `BASIC` or if the password id provided.
 
 
 <!-------------------- DELETE A SITE -------------------->


### PR DESCRIPTION
### Feature [MC-13608](https://cloud-ops.atlassian.net/browse/MC-13608)

#### Changes made
<!-- Changes should match the template provided below -->
- Added the create site api doc

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-stackpath-plugin/pull/140

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->