### PR TITLE
Feature/mc 13791 update documentation for delete quota

### DIFF
--- a/source/includes/administration/_quotas.md
+++ b/source/includes/administration/_quotas.md
@@ -113,10 +113,7 @@ QuotaDetail Attributes | &nbsp;
 
 ### Retrieve a quota
 
-`GET /quota/:id`
-
-```shell
-# Retrieve a specific quota
+`GET /quotas/:id`
 
 ```shell
 # Retrieve a specific quota
@@ -208,3 +205,32 @@ QuotaDetail Attributes | &nbsp;
 `metricIdentifier`<br/>*string* | Id matching the metric identifiers provided by the plugin writer.
 `ceiling`<br/>*number* | The ceiling value (metric).
 `limitsize`<br/>*number* | `DEPRECATED` The maximum for the type (metric).
+
+
+<!-------------------- DELETE A QUOTA -------------------->
+
+### Delete a quota
+`DELETE /quotas/:id1?quota_id=:id2`
+
+Deletes an existing quota. The parameter `quota_id` is only required when deleting a quota that is currently assigned to an organization. 
+
+```shell
+# Delete a specific Quota 
+curl -X DELETE "https://cloudmc_endpoint/api/v2/quotas/:id" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "085b008e-7ee4-444b-8092-350190786147",
+  "taskStatus": "SUCCESS"
+}
+```
+
+**Query Parameters**
+
+Optional | &nbsp;
+---------- | -----------
+`quota_id`<br/>*UUID* | The id of the quota that will be used as a substitution for the quota that is being deleted. 
+

--- a/source/includes/administration/_quotas.md
+++ b/source/includes/administration/_quotas.md
@@ -215,7 +215,7 @@ QuotaDetail Attributes | &nbsp;
 Deletes an existing quota. The parameter `quota_id` is only required when deleting a quota that is currently assigned to an organization. 
 
 ```shell
-# Delete a specific Quota 
+# Delete a specific quota 
 curl -X DELETE "https://cloudmc_endpoint/api/v2/quotas/:id" \
    -H "MC-Api-Key: your_api_key"
 ```


### PR DESCRIPTION
### Fixes [MC-13791](https://cloud-ops.atlassian.net/browse/MC-13791)

#### Changes made
<!-- Changes should match the template provided below -->
- Add the documentation for deleting a quota

![image](https://user-images.githubusercontent.com/36786091/109179431-e43d1300-7757-11eb-9169-afaf21fc56bc.png)


<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->