### PR TITLE
MC-13918: Added delivery domains

### DIFF
--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -53,7 +53,7 @@ Query Params | &nbsp;
 Attributes | &nbsp;
 ------- | -----------
 `id`<br/>*string* | The delivery domain unique identifier.
-`domain`<br/>*string* | Site's domain name.
+`domain`<br/>*string* | The site's domain name.
 `siteId`<br/>*UUID* | The ID of the site that a the delivery domain belongs to.
 `stackId`<br/>*UUID* | The ID of the stack that the site belongs to.
 `updatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.

--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -54,6 +54,6 @@ Attributes | &nbsp;
 ------- | -----------
 `id`<br/>*string* | The delivery domain unique identifier.
 `domain`<br/>*string* | The site's domain name.
-`siteId`<br/>*UUID* | The ID of the site that a the delivery domain belongs to.
+`siteId`<br/>*UUID* | The ID of the site that the delivery domain belongs to.
 `stackId`<br/>*UUID* | The ID of the stack that the site belongs to.
 `updatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.

--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -1,0 +1,59 @@
+## Delivery domains
+
+Delivery domains allow the CDN to recognize an HTTP request and associate it with a site.
+
+<!-------------------- LIST DELIVERY DOMAINS -------------------->
+
+### List delivery domains
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliverydomains?siteId=439b145a-7c55-4a73-8cf2-d8faabfe6d22"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "439b145a-7c55-4a73-8cf2-d8faabfe6d22/test-domain.com",
+      "stackId": "3deddcbd-3757-44cf-a4a6-93028fc4649a",
+      "siteId": "439b145a-7c55-4a73-8cf2-d8faabfe6d22",
+      "domain": "test-domain.com"
+    },
+    {
+      "id": "439b145a-7c55-4a73-8cf2-d8faabfe6d22/u7f7rXXX.stackpathcdn.com",
+      "stackId": "3deddcbd-3757-44cf-a4a6-93028fc4649a",
+      "siteId": "439b145a-7c55-4a73-8cf2-d8faabfe6d22",
+      "domain": "u7f7rXXX.stackpathcdn.com",
+      "validatedAt": "2021-02-26T19:00:15.177411Z"
+    },
+    {
+      "id": "439b145a-7c55-4a73-8cf2-d8faabfe6d22/www.test-domain.com",
+      "stackId": "3deddcbd-3757-44cf-a4a6-93028fc4649a",
+      "siteId": "439b145a-7c55-4a73-8cf2-d8faabfe6d22",
+      "domain": "www.test-domain.com"
+    }
+  ],
+  "metadata": {
+    "recordCount": 3
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliverydomains?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Retrieve a list of all delivery domains in a given [environment](#administration-environments) for a [site] (#stackpath-sites).
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to list delivery domains. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The delivery domain unique identifier.
+`domain`<br/>*string* | Site's domain name.
+`siteId`<br/>*UUID* | The ID of the site that a the delivery domain belongs to.
+`stackId`<br/>*UUID* | The ID of the stack that the site belongs to.
+`updatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -191,6 +191,7 @@ includes:
   - stackpath/instances
   - stackpath/images
   - stackpath/network_policy_rules
+  - stackpath/delivery_domains
   - aws
   - aws/compute
   - aws/instances


### PR DESCRIPTION
### Fixes [MC-13918](https://cloud-ops.atlassian.net/browse/MC-13918)

#### Changes made
- Added delivery domains list

#### Related PRs
- Stackpath: https://github.com/cloudops/cloudmc-stackpath-plugin/pull/147

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->