### PR TITLE
MC-13979: Delete a delivery domain a of site

### DIFF
--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -57,3 +57,63 @@ Attributes | &nbsp;
 `siteId`<br/>*UUID* | The ID of the site that the delivery domain belongs to.
 `stackId`<br/>*UUID* | The ID of the stack that the site belongs to.
 `updatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.
+
+<!-------------------- RETRIEVE A DELIVERY DOMAIN -------------------->
+
+### Retrieve a delivery domain
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliverydomains/439b145a-7c55-4a73-8cf2-d8faabfe6d22/test-domain.com"
+```
+> The above command returns a JSON structured like this:
+```json
+{
+  "data": {
+    "id": "439b145a-7c55-4a73-8cf2-d8faabfe6d22/test-domain.com",
+    "stackId": "3deddcbd-3757-44cf-a4a6-93028fc4649a",
+    "siteId": "439b145a-7c55-4a73-8cf2-d8faabfe6d22",
+    "domain": "test-domain.com"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliverydomains/:id</code>
+
+Retrieve a delivery domain of a site in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The delivery domain unique identifier.
+`domain`<br/>*string* | The site's domain name.
+`siteId`<br/>*UUID* | The ID of the site that the delivery domain belongs to.
+`stackId`<br/>*UUID* | The ID of the stack that the site belongs to.
+`updatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.
+
+<!-------------------- DELETE A DELIVERY DOMAIN -------------------->
+
+### Delete a delivery domain
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliverydomains/439b145a-7c55-4a73-8cf2-d8faabfe6d22/test-domain.com"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "57fc8d89-6f13-451b-8b66-fcd96e1fedbd",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliverydomains/:id</code>
+
+Delete a delivery domain of a site in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the site deletion.
+`taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -68,6 +68,7 @@ curl -X GET \
    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliverydomains/439b145a-7c55-4a73-8cf2-d8faabfe6d22/test-domain.com"
 ```
 > The above command returns a JSON structured like this:
+
 ```json
 {
   "data": {


### PR DESCRIPTION
### Fixes [MC-13979](https://cloud-ops.atlassian.net/browse/MC-13979)

#### Changes made
- Added GET delivery domain now after making changes to the fetcher
- Added DELETE delivery domain

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/157

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->