### PR TITLE
MC-13977: create delivery domains

### DIFF
--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -127,7 +127,7 @@ Attributes | &nbsp;
 curl -X POST \
     -H "MC-Api-Key: your_api_key" \
     -d "request_body" \
-    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliverydomains?siteId=a2fefb15-7e31-4c72-87e0-5a892e91c8d9&operation=Create"
+    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliverydomains?siteId=a2fefb15-7e31-4c72-87e0-5a892e91c8d9"
 ```
 
 > Request body example:
@@ -147,7 +147,7 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliverydomains?siteId=:id&operation=Create</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliverydomains?siteId=:id</code>
 
 Create a delivery domain of a site in a given [environment](#administration-environments).
 
@@ -157,5 +157,5 @@ Required | &nbsp;
 
 Attributes | &nbsp;
 ------- | -----------
-`taskId` <br/>*string* | The task id related to the site creation.
+`taskId` <br/>*string* | The task id related to the domain creation.
 `taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -118,3 +118,44 @@ Attributes | &nbsp;
 ------- | -----------
 `taskId` <br/>*string* | The task id related to the site deletion.
 `taskStatus` <br/>*string* | The status of the operation.
+
+<!-------------------- CREATE A DELIVERY DOMAIN -------------------->
+
+### Create a delivery domain
+
+```shell
+curl -X POST \
+    -H "MC-Api-Key: your_api_key" \
+    -d "request_body" \
+    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliverydomains?siteId=a2fefb15-7e31-4c72-87e0-5a892e91c8d9&operation=Create"
+```
+
+> Request body example for a VM Workload type:
+
+```json
+{
+  "domain": "new-domain.com",
+  "validatedAt": "2021-02-26T19:00:15.177411Z"
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "57fc8d89-6f13-451b-8b66-fcd96e1fedbd",
+  "taskStatus": "SUCCESS"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliverydomains?siteId=:id&operation=Create</code>
+
+Create a delivery domain of a site in a given [environment](#administration-environments).
+
+Required | &nbsp;
+---------- | -----------
+`domain`<br/>*String* | The site's domain name.
+
+Optional | &nbsp;
+---------- | -----------
+`validatedAt`<br/>*String* | The date the domain was validated to be pointing to Stackpath.

--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -135,7 +135,6 @@ curl -X POST \
 ```json
 {
   "domain": "new-domain.com",
-  "validatedAt": "2021-02-26T19:00:15.177411Z"
 }
 ```
 
@@ -155,10 +154,6 @@ Create a delivery domain of a site in a given [environment](#administration-envi
 Required | &nbsp;
 ---------- | -----------
 `domain`<br/>*String* | The site's domain name.
-
-Optional | &nbsp;
----------- | -----------
-`validatedAt`<br/>*String* | The date the domain was validated to be pointing to Stackpath.
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/stackpath/_delivery_domains.md
+++ b/source/includes/stackpath/_delivery_domains.md
@@ -130,7 +130,7 @@ curl -X POST \
     "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliverydomains?siteId=a2fefb15-7e31-4c72-87e0-5a892e91c8d9&operation=Create"
 ```
 
-> Request body example for a VM Workload type:
+> Request body example:
 
 ```json
 {
@@ -159,3 +159,8 @@ Required | &nbsp;
 Optional | &nbsp;
 ---------- | -----------
 `validatedAt`<br/>*String* | The date the domain was validated to be pointing to Stackpath.
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the site creation.
+`taskStatus` <br/>*string* | The status of the operation.


### PR DESCRIPTION
### Fixes [MC-13977](https://cloud-ops.atlassian.net/browse/MC-13977)

#### Changes made
<!-- Changes should match the template provided below -->
- create delivery domains

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/161

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->