### PR TITLE
Feature/mc 14135 password policy

### DIFF
--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -458,7 +458,10 @@ Attributes | &nbsp;
 `autoCreationEnabled`<br/>*boolean* | A boolean specifying whether to enable automatic end-user account creation upon successful OIDC login.
 `verifiedDomains`<br/>*Array[[verified domains](#administration-get-verified-domains)]*| A list of verified domains (with VERIFIED status) for which successful matching OIDC logins will create new users.
 `passwordPolicy`<br/>*object*  | The password policy assigned to the organization. 
-`passwordPolicy.constraints`<br/>*Array[]* | List of password policy constraints objects with the following fields.
+`passwordPolicy.constraints`<br/>*Array[]* | List of password policy constraints. Each constraint contains -
+- `name`: A string that represents the constraint name.
+- `value`: An integer that represents the minimum value for the constraint.
+- `isMandatory`: A boolean flag to indicate if the constraint is mandatory or not.
 `name`<br/>*string* | The name of the constraint.
 `value`<br/>*int* | The minimum value for the constraint.
 `isMandatory`<br/>*boolean* | Flag to indicate if the constraint is mandatory or not.

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -470,6 +470,149 @@ Optional | &nbsp;
 
 Returns an HTTP status code 200, with an empty response body.
 
+<!-------------------- GET ORGANIZATION PASSWORD POLICY -------------------->
+
+### Get password policy
+`GET /organizations/organization_id/password_policy`
+
+Retrieve the password policy for the organization.
+
+```shell
+# Retrieve the organization's security settings
+curl "https://cloudmc_endpoint/api/v1/organizations/e8d95716-26a9-4054-833e-81cd3a5155cd/password_policy" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "data": [
+        {
+            "name": "min_password_length",
+            "value": 8,
+            "isMandatory": true
+        },
+        {
+            "name": "min_lowercase_letters",
+            "value": 1,
+            "isMandatory": true
+        },
+        {
+            "name": "min_uppercase_letters",
+            "value": 1,
+            "isMandatory": true
+        },
+        {
+            "name": "min_numbers",
+            "value": 1,
+            "isMandatory": true
+        },
+        {
+            "name": "min_special_characters",
+            "value": 1,
+            "isMandatory": true
+        }
+    ]
+}
+```
+Attributes | &nbsp;
+---- | -----------
+*Array[]*| A list of password policy constraint objects with the following fields.
+`name`<br/>*string* | The name of the constraint.
+`value`<br/>*int* | The minimum value for the constraint.
+`isMandatory`<br/>*boolean* | Flag to indicate if the constraint is mandatory or not.
+
+<!-------------------- CREATE/UPDATE ORGANIZATION PASSWORD POLICY -------------------->
+### Create/Update password policy
+`PUT /organizations/:organization_id/security_settings`
+
+```shell
+# Update an organization's security settings
+curl -X PUT "https://cloudmc_endpoint/api/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c0cb5/security_settings" \
+   -H "MC-Api-Key: your_api_key" \
+   -H "Content-Type: application/json" \
+   -d "request_body"
+```
+> Request body example:
+
+```json
+{
+   "passwordPolicy": {
+      "constraints": [
+         {
+               "name": "min_password_length",
+               "value": 8,
+               "isMandatory": false
+         },
+         {
+               "name": "min_lowercase_letters",
+               "value": 1,
+               "isMandatory": true
+         },
+         {
+               "name": "min_uppercase_letters",
+               "value": 1,
+               "isMandatory": true
+         },
+         {
+               "name": "min_numbers",
+               "value": 1,
+               "isMandatory": true
+         },
+         {
+               "name": "min_special_characters",
+               "value": 1,
+               "isMandatory": true
+         }
+      ]
+   },
+   "autoCreationEnabled": true,
+   "verifiedDomains": [ 
+	 	{ 
+			 "id": "29d66b1d-669a-439b-883a-d7c1e36e1ca6"
+		}
+	],
+	"defaultRole": {
+      "name": "guest",
+      "id": "6e022506-ab89-4676-859d-06d370b67417" 
+	}
+}
+```
+
+Create a new or update an existing password policy for an organization.
+
+This is the same endpoint which is used for creating/updating organization security settings. If the password policy related fields are passed along with the security related fields in the request, it will create or update the password policy along with modifying the security settings. Refer to [update security settings](#administration-update-security-settings) for security settings fields.
+
+Required | &nbsp;
+---- | ----
+`passwordPolicy`<br/>*object*  | The password policy that will be assigned to the organization. 
+`passwordPolicy.constraints`<br/>*Array[]* | List of password policy constraints objects with the following fields.
+`name`<br/>*string* | The name of the constraint.
+`value`<br/>*int* | The minimum value for the constraint.
+`isMandatory`<br/>*boolean* | Flag to indicate if the constraint is mandatory or not.
+
+Optional | &nbsp;
+---- | ----
+`defaultRole`<br/>*object*  | The role that will be assigned to new users logging into the organization with an email domain matching that of the organization's security settings. 
+`autoCreationEnabled`<br/>*boolean* | A boolean specifying whether to enable automatic end-user account creation upon successful OIDC login.
+`verifiedDomains`<br/>*Array[[verified domains](#administration-get-verified-domains)]*| A list of objects containing the ids of verified domains (with VERIFIED status) for which successful matching OIDC logins will create new users.
+
+Returns an HTTP status code 200, with an empty response body.
+
+<!-------------------- DELETE PASSWORD POLICY FOR ORGANIZATION -------------------->
+### Delete password policy
+`DELETE /organizations/:id/password_policy`
+
+Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A sub-organization can delete its password policy
+
+```shell
+# Delete an organization
+curl -X DELETE "https://cloudmc_endpoint/api/v1/organizations/e8d95716-26a9-4054-833e-81cd3a5155cd/password_policy" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+Returns an HTTP status code 204, with an empty response body.
+
 <!-------------------- GET MANAGEABLE CONNECTIONS OF ORGANIZATION -------------------->
 ### Get manageable connections of an organization
 `GET /organizations/:id/manageable_connections`

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -458,7 +458,7 @@ Attributes | &nbsp;
 `autoCreationEnabled`<br/>*boolean* | A boolean specifying whether to enable automatic end-user account creation upon successful OIDC login.
 `verifiedDomains`<br/>*Array[[verified domains](#administration-get-verified-domains)]*| A list of verified domains (with VERIFIED status) for which successful matching OIDC logins will create new users.
 `passwordPolicy`<br/>*object*  | The password policy assigned to the organization. 
-`passwordPolicy.constraints`<br/>*Array[Object]* | List of password policy constraints. Each constraint contains -
+`passwordPolicy.constraints`<br/>*Array[Object]* | List of password policy constraints.
 `passwordPolicy.constraints.name`<br/>*string* | A string that represents the constraint name.
 `passwordPolicy.constraints.value`<br/>*int* | An integer that represents the minimum value for the constraint.
 `passwordPolicy.constraints.isMandatory`<br/>*boolean* | A boolean flag to indicate if the constraint is mandatory or not.

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -638,7 +638,7 @@ Returns an HTTP status code 200, with an empty response body.
 ### Delete password policy
 `DELETE /organizations/:id/password_policy`
 
-Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A sub-organization can delete its password policy
+Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A reseller sub-organization can delete its password policy
 
 ```shell
 # Delete an organization

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -488,9 +488,40 @@ curl -X PUT "https://cloudmc_endpoint/api/v1/organizations/03bc22bd-adc4-46b8-98
 	"defaultRole": {
       "name": "guest",
       "id": "6e022506-ab89-4676-859d-06d370b67417" 
-	}
+	},
+   "passwordPolicy": {
+      "constraints": [
+         {
+               "name": "min_password_length",
+               "value": 8,
+               "isMandatory": false
+         },
+         {
+               "name": "min_lowercase_letters",
+               "value": 1,
+               "isMandatory": true
+         },
+         {
+               "name": "min_uppercase_letters",
+               "value": 1,
+               "isMandatory": true
+         },
+         {
+               "name": "min_numbers",
+               "value": 1,
+               "isMandatory": true
+         },
+         {
+               "name": "min_special_characters",
+               "value": 1,
+               "isMandatory": true
+         }
+      ]
+   }
 }
 ```
+
+Create a new or update an existing security settings for an organization.
 
 Required | &nbsp;
 ---- | ----
@@ -502,8 +533,21 @@ Optional | &nbsp;
 ---- | ----
 `autoCreationEnabled`<br/>*boolean* | A boolean specifying whether to enable automatic end-user account creation upon successful OIDC login.
 `verifiedDomains`<br/>*Array[[verified domains](#administration-get-verified-domains)]*| A list of objects containing the ids of verified domains (with VERIFIED status) for which successful matching OIDC logins will create new users.
+`passwordPolicy`<br/>*object*  | The password policy that will be assigned to the organization. 
+`passwordPolicy.constraints`<br/>*Array[Object]* | List of password policy constraints objects with the following fields.
+`passwordPolicy.constraints.name`<br/>*string* | A string that represents the constraint name.
+`passwordPolicy.constraints.value`<br/>*int* | An integer that represents the minimum value for the constraint.
+`passwordPolicy.constraints.isMandatory`<br/>*boolean* | A boolean flag to indicate if the constraint is mandatory or not.
 
 Returns an HTTP status code 200, with an empty response body.
+
+- If `defaultRole` is not passed in the request:
+   - The system will assign `Guest`as a default role to the organization.
+- If `passwordPolicy` is passed in the request:
+   - The system will create a new or update the existing password policy for the organization.
+- If `autoCreationEnabled` and/or `verifiedDomains` is passed in the request:
+   - The system will create a new or update the existing security settings for the organization.
+
 
 <!-------------------- GET ORGANIZATION PASSWORD POLICY -------------------->
 
@@ -556,83 +600,6 @@ Attributes | &nbsp;
 `name`<br/>*string* | The name of the constraint.
 `value`<br/>*int* | The minimum value for the constraint.
 `isMandatory`<br/>*boolean* | Flag to indicate if the constraint is mandatory or not.
-
-<!-------------------- CREATE/UPDATE ORGANIZATION PASSWORD POLICY -------------------->
-### Create/Update password policy
-`PUT /organizations/:organization_id/security_settings`
-
-```shell
-# Update an organization's security settings
-curl -X PUT "https://cloudmc_endpoint/api/v1/organizations/03bc22bd-adc4-46b8-988d-afddc24c0cb5/security_settings" \
-   -H "MC-Api-Key: your_api_key" \
-   -H "Content-Type: application/json" \
-   -d "request_body"
-```
-> Request body example:
-
-```json
-{
-   "passwordPolicy": {
-      "constraints": [
-         {
-               "name": "min_password_length",
-               "value": 8,
-               "isMandatory": false
-         },
-         {
-               "name": "min_lowercase_letters",
-               "value": 1,
-               "isMandatory": true
-         },
-         {
-               "name": "min_uppercase_letters",
-               "value": 1,
-               "isMandatory": true
-         },
-         {
-               "name": "min_numbers",
-               "value": 1,
-               "isMandatory": true
-         },
-         {
-               "name": "min_special_characters",
-               "value": 1,
-               "isMandatory": true
-         }
-      ]
-   },
-   "autoCreationEnabled": true,
-   "verifiedDomains": [ 
-	 	{ 
-			 "id": "29d66b1d-669a-439b-883a-d7c1e36e1ca6"
-		}
-	],
-	"defaultRole": {
-      "name": "guest",
-      "id": "6e022506-ab89-4676-859d-06d370b67417" 
-	}
-}
-```
-
-Create a new or update an existing password policy for an organization.
-
-This is the same endpoint which is used for creating/updating organization security settings. If the password policy related fields are passed along with the security related fields in the request, it will create or update the password policy along with modifying the security settings. Refer to [update security settings](#administration-update-security-settings) for security settings fields.
-
-Required | &nbsp;
----- | ----
-`passwordPolicy`<br/>*object*  | The password policy that will be assigned to the organization. 
-`passwordPolicy.constraints`<br/>*Array[Object]* | List of password policy constraints objects with the following fields.
-`passwordPolicy.constraints.name`<br/>*string* | A string that represents the constraint name.
-`passwordPolicy.constraints.value`<br/>*int* | An integer that represents the minimum value for the constraint.
-`passwordPolicy.constraints.isMandatory`<br/>*boolean* | A boolean flag to indicate if the constraint is mandatory or not.
-
-Optional | &nbsp;
----- | ----
-`defaultRole`<br/>*object*  | The role that will be assigned to new users logging into the organization with an email domain matching that of the organization's security settings. 
-`autoCreationEnabled`<br/>*boolean* | A boolean specifying whether to enable automatic end-user account creation upon successful OIDC login.
-`verifiedDomains`<br/>*Array[[verified domains](#administration-get-verified-domains)]*| A list of objects containing the ids of verified domains (with VERIFIED status) for which successful matching OIDC logins will create new users.
-
-Returns an HTTP status code 200, with an empty response body.
 
 <!-------------------- DELETE PASSWORD POLICY FOR ORGANIZATION -------------------->
 ### Delete password policy

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -416,7 +416,36 @@ curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e30
         "verificationCode": "cmc-verification=8c8f5473-9306-4e16-a820-a747482e85e5",
         "status": "VERIFIED"
       }
-    ]
+    ],
+    "passwordPolicy": {
+      "constraints": [
+        {
+          "name": "min_password_length",
+          "value": 8,
+          "isMandatory": false
+        },
+        {
+          "name": "min_lowercase_letters",
+          "value": 1,
+          "isMandatory": true
+        },
+        {
+          "name": "min_uppercase_letters",
+          "value": 1,
+          "isMandatory": true
+        },
+        {
+          "name": "min_numbers",
+          "value": 1,
+          "isMandatory": true
+        },
+        {
+          "name": "min_special_characters",
+          "value": 1,
+          "isMandatory": true
+        }
+      ]
+    }
   }
 }
 ```
@@ -428,6 +457,12 @@ Attributes | &nbsp;
 `organization`<br/>*[Organization](#administration-organizations)* | The organization to which the verified domain belongs. *includes*:`id`,`name`, `entryPoint`.
 `autoCreationEnabled`<br/>*boolean* | A boolean specifying whether to enable automatic end-user account creation upon successful OIDC login.
 `verifiedDomains`<br/>*Array[[verified domains](#administration-get-verified-domains)]*| A list of verified domains (with VERIFIED status) for which successful matching OIDC logins will create new users.
+`passwordPolicy`<br/>*object*  | The password policy assigned to the organization. 
+`passwordPolicy.constraints`<br/>*Array[]* | List of password policy constraints objects with the following fields.
+`name`<br/>*string* | The name of the constraint.
+`value`<br/>*int* | The minimum value for the constraint.
+`isMandatory`<br/>*boolean* | Flag to indicate if the constraint is mandatory or not.
+
 
 <!-------------------- UPDATE SECURITY SETTINGS -------------------->
 ### Update security settings

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -516,7 +516,7 @@ Returns an HTTP status code 200, with an empty response body.
 Retrieve the password policy for the organization.
 
 ```shell
-# Retrieve the organization's security settings
+# Retrieve the organization's own or inherited password policy.
 curl "https://cloudmc_endpoint/api/v1/organizations/e8d95716-26a9-4054-833e-81cd3a5155cd/password_policy" \
    -H "MC-Api-Key: your_api_key"
 ```

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -641,7 +641,7 @@ Returns an HTTP status code 200, with an empty response body.
 ### Delete password policy
 `DELETE /organizations/:id/password_policy`
 
-Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A sub-organization can delete its password policy
+Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A reseller sub-organization can delete its password policy
 
 ```shell
 # Delete an organization

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -458,13 +458,10 @@ Attributes | &nbsp;
 `autoCreationEnabled`<br/>*boolean* | A boolean specifying whether to enable automatic end-user account creation upon successful OIDC login.
 `verifiedDomains`<br/>*Array[[verified domains](#administration-get-verified-domains)]*| A list of verified domains (with VERIFIED status) for which successful matching OIDC logins will create new users.
 `passwordPolicy`<br/>*object*  | The password policy assigned to the organization. 
-`passwordPolicy.constraints`<br/>*Array[]* | List of password policy constraints. Each constraint contains -
-- `name`: A string that represents the constraint name.
-- `value`: An integer that represents the minimum value for the constraint.
-- `isMandatory`: A boolean flag to indicate if the constraint is mandatory or not.
-`name`<br/>*string* | The name of the constraint.
-`value`<br/>*int* | The minimum value for the constraint.
-`isMandatory`<br/>*boolean* | Flag to indicate if the constraint is mandatory or not.
+`passwordPolicy.constraints`<br/>*Array[Object]* | List of password policy constraints. Each constraint contains -
+`passwordPolicy.constraints.name`<br/>*string* | A string that represents the constraint name.
+`passwordPolicy.constraints.value`<br/>*int* | An integer that represents the minimum value for the constraint.
+`passwordPolicy.constraints.isMandatory`<br/>*boolean* | A boolean flag to indicate if the constraint is mandatory or not.
 
 
 <!-------------------- UPDATE SECURITY SETTINGS -------------------->
@@ -555,7 +552,7 @@ curl "https://cloudmc_endpoint/api/v1/organizations/e8d95716-26a9-4054-833e-81cd
 ```
 Attributes | &nbsp;
 ---- | -----------
-*Array[]*| A list of password policy constraint objects with the following fields.
+*Array[Object]*| A list of password policy constraint objects with the following fields.
 `name`<br/>*string* | The name of the constraint.
 `value`<br/>*int* | The minimum value for the constraint.
 `isMandatory`<br/>*boolean* | Flag to indicate if the constraint is mandatory or not.
@@ -624,10 +621,10 @@ This is the same endpoint which is used for creating/updating organization secur
 Required | &nbsp;
 ---- | ----
 `passwordPolicy`<br/>*object*  | The password policy that will be assigned to the organization. 
-`passwordPolicy.constraints`<br/>*Array[]* | List of password policy constraints objects with the following fields.
-`name`<br/>*string* | The name of the constraint.
-`value`<br/>*int* | The minimum value for the constraint.
-`isMandatory`<br/>*boolean* | Flag to indicate if the constraint is mandatory or not.
+`passwordPolicy.constraints`<br/>*Array[Object]* | List of password policy constraints objects with the following fields.
+`passwordPolicy.constraints.name`<br/>*string* | A string that represents the constraint name.
+`passwordPolicy.constraints.value`<br/>*int* | An integer that represents the minimum value for the constraint.
+`passwordPolicy.constraints.isMandatory`<br/>*boolean* | A boolean flag to indicate if the constraint is mandatory or not.
 
 Optional | &nbsp;
 ---- | ----
@@ -641,7 +638,7 @@ Returns an HTTP status code 200, with an empty response body.
 ### Delete password policy
 `DELETE /organizations/:id/password_policy`
 
-Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A reseller sub-organization can delete its password policy
+Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A sub-organization can delete its password policy
 
 ```shell
 # Delete an organization

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -605,7 +605,7 @@ Attributes | &nbsp;
 ### Delete password policy
 `DELETE /organizations/:id/password_policy`
 
-Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A reseller sub-organization can delete its password policy
+Delete a password policy for an organization. Root reseller organization will not be able to delete its password policy. A reseller sub-organization can delete its password policy.
 
 ```shell
 # Delete an organization


### PR DESCRIPTION
### Fixes [MC-14135](https://cloud-ops.atlassian.net/browse/MC-14135)

#### Changes made
<!-- Changes should match the template provided below -->
- Added password policy and modified security setting API endpoints.

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->