### PR TITLE
MC-14148 Update API docs for stackpath serverless scripts

### DIFF
--- a/source/includes/stackpath/_scripts.md
+++ b/source/includes/stackpath/_scripts.md
@@ -1,0 +1,116 @@
+## Scripts
+
+Deploy and manage Serverless Scripts used to interact with requests made to the site.
+
+<!-------------------- LIST SCIPTS -------------------->
+
+### List scripts
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/4d13a920-79b7-4129-957b-bd4f006b1ac8?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "4d13a920-79b7-4129-957b-bd4f006b1ac8",
+      "stackId": "87e22df5-cac9-4e42-9b75-02996af95566",
+      "siteId": "0a57855b-26d8-4e8f-8b77-429997c7c5fb",
+      "name": "scriptName",
+      "createdAt": "2021-03-15T19:05:45.157987Z",
+      "updatedAt": "2021-03-15T19:05:45.157987Z",
+      "version": "1",
+      "routes": [
+        "v1/api"
+      ]
+    },
+    {
+      "id": "28e6b0c7-ee5d-4bd3-abfb-13dfc6e15c0d",
+      "stackId": "87e22df5-cac9-4e42-9b75-02996af95566",
+      "siteId": "0a57855b-26d8-4e8f-8b77-429997c7c5fb",
+      "name": "scriptName2",
+      "createdAt": "2021-03-15T18:53:18.587749Z",
+      "updatedAt": "2021-03-15T18:53:18.587749Z",
+      "version": "1",
+      "routes": [
+        "v1/api",
+        "v2/api"
+      ]
+    }
+  ],
+  "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/scripts?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to list the scripts. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The unique identifier for the script.
+`stackId`<br/>*string* | The ID of the stack that the script belongs to.
+`siteId`<br/>*string* | The ID of the site that the script belongs to.
+`name`<br/>*string* | The display name of the script.
+`createdAt`<br/>*string* | Creation timestamp of the script.
+`updatedAt`<br/>*string* | The date on which the script was last updated.
+`version`<br/>*string* | The version number of the script.
+`routes`<br/>*Array[string]* | The routes that incoming requests should respond with a script.
+
+<!-------------------- RETRIEVE A SCRIPT --------------------->
+
+### Retrieve a script
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/439b145a-7c55-4a73-8cf2-d8faabfe6d22/test-domain.com"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "4d13a920-79b7-4129-957b-bd4f006b1ac8",
+    "stackId": "87e22df5-cac9-4e42-9b75-02996af95566",
+    "siteId": "0a57855b-26d8-4e8f-8b77-429997c7c5fb",
+    "name": "scriptName1",
+    "createdAt": "2021-03-15T19:05:45.157987Z",
+    "updatedAt": "2021-03-15T19:05:45.157987Z",
+    "code": "Ly8gc2FtcGxlIHNjcmlwdAphZGRFdmVudExpc3RlbmVyKCJmZXRjaCIsIGV2ZW50ID0+IHsKICBldmVudC5yZXNwb25kV2l0aChoYW5kbGVSZXF1ZXN0KGV2ZW50LnJlcXVlc3QpKTsKfSk7CgovKioKICogRmV0Y2ggYW5kIHJldHVybiB0aGUgcmVxdWVzdCBib2R5CiAqIEBwYXJhbSB7UmVxdWVzdH0gcmVxdWVzdAogKi8KYXN5bmMgZnVuY3Rpb24gaGFuZGxlUmVxdWVzdChyZXF1ZXN0KSB7CiAgLy8gV3JhcCB5b3VyIHNjcmlwdCBpbiBhIHRyeS9jYXRjaCBhbmQgcmV0dXJuIHRoZSBlcnJvciBzdGFjayB0byB2aWV3IGVycm9yIGluZm9ybWF0aW9uCiAgdHJ5IHsKICAgIC8qIFRoZSByZXF1ZXN0IGNhbiBiZSBtb2RpZmllZCBoZXJlIGJlZm9yZSBzZW5kaW5nIGl0IHdpdGggZmV0Y2ggKi8KCiAgICBjb25zdCByZXNwb25zZSA9IGF3YWl0IGZldGNoKHJlcXVlc3QpOwoKICAgIC8qIFRoZSByZXNwb25zZSBjYW4gYmUgbW9kaWZpZWQgaGVyZSBiZWZvcmUgcmV0dXJuaW5nIGl0ICovCgogICAgcmV0dXJuIHJlc3BvbnNlOwogIH0gY2F0Y2ggKGUpIHsKICAgIHJldHVybiBuZXcgUmVzcG9uc2UoZS5zdGFjayB8fCBlLCB7IHN0YXR1czogNTAwIH0pOwogIH0KfQ==",
+    "version": "1",
+    "routes": [
+      "v1/api"
+    ]
+  }
+}
+```
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/scripts/:id/?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to list the scripts. This parameter is required.
+
+Retrieve a script of a site in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The unique identifier for the script.
+`stackId`<br/>*string* | The ID of the stack that the script belongs to.
+`siteId`<br/>*string* | The ID of the site that the script belongs to.
+`name`<br/>*string* | The display name of the script.
+`createdAt`<br/>*string* | Creation timestamp of the script.
+`updatedAt`<br/>*string* | The date on which the script was last updated.
+`code`<br/>*string* | Base64 encoded contents of a script.
+`version`<br/>*string* | The version number of the script.
+`routes`<br/>*Array[string]* | The routes that incoming requests should respond with a script.
+
+

--- a/source/includes/stackpath/_scripts.md
+++ b/source/includes/stackpath/_scripts.md
@@ -56,9 +56,9 @@ Query Params | &nbsp;
 
 Attributes | &nbsp;
 ------- | -----------
-`id`<br/>*string* | The unique identifier for the script.
-`stackId`<br/>*string* | The ID of the stack that the script belongs to.
-`siteId`<br/>*string* | The ID of the site that the script belongs to.
+`id`<br/>*UUID* | The unique identifier for the script.
+`stackId`<br/>*UUID* | The ID of the stack that the script belongs to.
+`siteId`<br/>*UUID* | The ID of the site that the script belongs to.
 `name`<br/>*string* | The display name of the script.
 `createdAt`<br/>*string* | Creation timestamp of the script.
 `updatedAt`<br/>*string* | The date on which the script was last updated.
@@ -103,9 +103,9 @@ Retrieve a script of a site in a given [environment](#administration-environment
 
 Attributes | &nbsp;
 ------- | -----------
-`id`<br/>*string* | The unique identifier for the script.
-`stackId`<br/>*string* | The ID of the stack that the script belongs to.
-`siteId`<br/>*string* | The ID of the site that the script belongs to.
+`id`<br/>*UUID* | The unique identifier for the script.
+`stackId`<br/>*UUID* | The ID of the stack that the script belongs to.
+`siteId`<br/>*UUID* | The ID of the site that the script belongs to.
 `name`<br/>*string* | The display name of the script.
 `createdAt`<br/>*string* | Creation timestamp of the script.
 `updatedAt`<br/>*string* | The date on which the script was last updated.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -193,6 +193,7 @@ includes:
   - stackpath/images
   - stackpath/network_policy_rules
   - stackpath/delivery_domains
+  - stackpath/scripts
   - aws
   - aws/compute
   - aws/instances


### PR DESCRIPTION
### Fixes [MC-14148](https://cloud-ops.atlassian.net/browse/MC-14148)

#### Changes made
<!-- Changes should match the template provided below -->
- Created the new section for Serverless Scripts
- Added the section for fetching a single and multiple entities

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->