### PR TITLE
Feature/MC 14148 create api docs for serverless scripts

### DIFF
--- a/source/includes/stackpath/_scripts.md
+++ b/source/includes/stackpath/_scripts.md
@@ -72,7 +72,7 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/439b145a-7c55-4a73-8cf2-d8faabfe6d22/test-domain.com"
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/439b145a-7c55-4a73-8cf2-d8faabfe6d22?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
 ```
 > The above command returns a JSON structured like this:
 
@@ -93,7 +93,7 @@ curl -X GET \
   }
 }
 ```
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/scripts/:id/?siteId=<a href="#stackpath-sites">:siteId</a></code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/scripts/:id?siteId=<a href="#stackpath-sites">:siteId</a></code>
 
 Query Params | &nbsp;
 ---- | -----------

--- a/source/includes/stackpath/_scripts.md
+++ b/source/includes/stackpath/_scripts.md
@@ -9,7 +9,7 @@ Deploy and manage Serverless Scripts used to interact with requests made to the 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/4d13a920-79b7-4129-957b-bd4f006b1ac8?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
 ```
 > The above command returns a JSON structured like this:
 
@@ -79,7 +79,7 @@ curl -X GET \
 ```json
 {
   "data": {
-    "id": "4d13a920-79b7-4129-957b-bd4f006b1ac8",
+    "id": "439b145a-7c55-4a73-8cf2-d8faabfe6d22",
     "stackId": "87e22df5-cac9-4e42-9b75-02996af95566",
     "siteId": "0a57855b-26d8-4e8f-8b77-429997c7c5fb",
     "name": "scriptName1",


### PR DESCRIPTION
### Fixes [MC-14148](https://cloud-ops.atlassian.net/browse/MC-14148)

#### Changes made
<!-- Changes should match the template provided below -->
- My changes for my previous PR weren't pushed successfully, merged my PR without those fixes 
- The list and get serverless scripts endpoint format in curl was not correct 
- The response data `id` did not match that of the request
- Extra `/` in the endpoint 

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->