### PR TITLE
MC-13931 Add documentation for creating a serverless script.

### DIFF
--- a/source/includes/stackpath/_scripts.md
+++ b/source/includes/stackpath/_scripts.md
@@ -9,7 +9,7 @@ Deploy and manage Serverless Scripts used to interact with requests made to the 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/4d13a920-79b7-4129-957b-bd4f006b1ac8?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
 ```
 > The above command returns a JSON structured like this:
 
@@ -72,7 +72,7 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/439b145a-7c55-4a73-8cf2-d8faabfe6d22/test-domain.com"
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/439b145a-7c55-4a73-8cf2-d8faabfe6d22?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
 ```
 > The above command returns a JSON structured like this:
 
@@ -85,7 +85,29 @@ curl -X GET \
     "name": "scriptName1",
     "createdAt": "2021-03-15T19:05:45.157987Z",
     "updatedAt": "2021-03-15T19:05:45.157987Z",
-    "code": "Ly8gc2FtcGxlIHNjcmlwdAphZGRFdmVudExpc3RlbmVyKCJmZXRjaCIsIGV2ZW50ID0+IHsKICBldmVudC5yZXNwb25kV2l0aChoYW5kbGVSZXF1ZXN0KGV2ZW50LnJlcXVlc3QpKTsKfSk7CgovKioKICogRmV0Y2ggYW5kIHJldHVybiB0aGUgcmVxdWVzdCBib2R5CiAqIEBwYXJhbSB7UmVxdWVzdH0gcmVxdWVzdAogKi8KYXN5bmMgZnVuY3Rpb24gaGFuZGxlUmVxdWVzdChyZXF1ZXN0KSB7CiAgLy8gV3JhcCB5b3VyIHNjcmlwdCBpbiBhIHRyeS9jYXRjaCBhbmQgcmV0dXJuIHRoZSBlcnJvciBzdGFjayB0byB2aWV3IGVycm9yIGluZm9ybWF0aW9uCiAgdHJ5IHsKICAgIC8qIFRoZSByZXF1ZXN0IGNhbiBiZSBtb2RpZmllZCBoZXJlIGJlZm9yZSBzZW5kaW5nIGl0IHdpdGggZmV0Y2ggKi8KCiAgICBjb25zdCByZXNwb25zZSA9IGF3YWl0IGZldGNoKHJlcXVlc3QpOwoKICAgIC8qIFRoZSByZXNwb25zZSBjYW4gYmUgbW9kaWZpZWQgaGVyZSBiZWZvcmUgcmV0dXJuaW5nIGl0ICovCgogICAgcmV0dXJuIHJlc3BvbnNlOwogIH0gY2F0Y2ggKGUpIHsKICAgIHJldHVybiBuZXcgUmVzcG9uc2UoZS5zdGFjayB8fCBlLCB7IHN0YXR1czogNTAwIH0pOwogIH0KfQ==",
+    "code": "// sample script
+    addEventListener('fetch', event => {
+      event.respondWith(handleRequest(event.request));
+    });
+
+    /**
+    * Fetch and return the request body
+    * @param {Request} request
+    */
+    async function handleRequest(request) {
+      // Wrap your script in a try/catch and return the error stack to view error information
+      try {
+        /* The request can be modified here before sending it with fetch */
+
+        const response = await fetch(request);
+
+        /* The response can be modified here before returning it */
+
+        return response;
+      } catch (e) {
+        return new Response(e.stack || e, { status: 500 });
+      }
+    }",
     "version": "1",
     "routes": [
       "v1/api"
@@ -109,9 +131,83 @@ Attributes | &nbsp;
 `name`<br/>*string* | The display name of the script.
 `createdAt`<br/>*string* | Creation timestamp of the script.
 `updatedAt`<br/>*string* | The date on which the script was last updated.
-`code`<br/>*string* | Base64 encoded contents of a script.
+`code`<br/>*string* | The contents of the script.
 `version`<br/>*string* | The version number of the script.
 `routes`<br/>*Array[string]* | The routes that incoming requests should respond with a script.
+
+<!-------------------- CREATE A SCRIPT -------------------->
+
+### Create a script
+
+Create a new serverless script that allows you to run JavaScript code at the Edge, on all of PoPs with real-time access to each of the requests that come in for your site.
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/scripts/:id/?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to create the script. This parameter is required.
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*string* | The name of the script.
+`routes`<br/>*Array[string]* | At least one route in the form of a URI.
+`code`<br/>*string* | The JavaScript code used for the script.
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts?siteId=:siteId"
+```
+> Request body example for creating a script:
+
+```json
+{
+  "siteId": "0a57855b-26d8-4e8f-8b77-429997c7c5fb",
+  "name": "script-name",
+  "routes": ["route"],
+  "code": "// sample script
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request));
+});
+
+/**
+ * Fetch and return the request body
+ * @param {Request} request
+ */
+async function handleRequest(request) {
+  // Wrap your script in a try/catch and return the error stack to view error information
+  try {
+    /* The request can be modified here before sending it with fetch */
+
+    const response = await fetch(request);
+
+    /* The response can be modified here before returning it */
+
+    return response;
+  } catch (e) {
+    return new Response(e.stack || e, { status: 500 });
+  }
+}"
+}
+```
+
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "dfc0b899-ac0f-447b-8f50-74bf78d1c034",
+  "taskStatus": "SUCCESS"
+}
+```
+
+There following attributes are returned as part of the response.
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to creation of the script.
+`taskStatus` <br/>*string* | The status of the operation.
+
 
 <!-------------------- DELETE A SCRIPT -------------------->
 
@@ -120,7 +216,7 @@ Attributes | &nbsp;
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/dd207010-4570-43ee-9ff2-5421d2306b41?siteId=06ca3df8-8e48-491e-b9f9-4ab4afc355ae"
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/scripts/dd207010-4570-43ee-9ff2-5421d2306b41?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
 ```
 > The above command returns a JSON structured like this:
 


### PR DESCRIPTION
### Fixes [MC-13931](https://cloud-ops.atlassian.net/browse/MC-13931)

#### Changes made

- Add the document for creating serverless scripts.
- Fixed URLs in the example that were not valid. See #321
- Fixed the documentation for the code being returned by the API. It's not in returned in base64. #321
- Changed the siteId in the examples across all operations so we are consistent within the same document.

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/200
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/197
- https://github.com/cloudops/cloudmc-api-docs/pull/321

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->