### PR TITLE
MC-13958: Update API docs for patching waf settings

### DIFF
--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -466,7 +466,7 @@ Attributes | &nbsp;
 `ddosSettings.burstThreshold`<br/>*Integer* | The number of requests per two seconds that can trigger DDoS protection
 `ddosSettings.subSecondBurstThreshold`<br/>*Integer* | The number of requests per 0.1 seconds that can trigger DDoS protection
 `apiUrls`<br/>*array* | List of configured API urls.
-`isMonitoring`<br/>*boolean* | If the monitoring mode is enabled.
+`monitoringEnabled`<br/>*boolean* | If the monitoring mode is enabled.
 `listPolicyGroups`<br/>*object* | An object containing the list of policy groups.
 `policyGroups`<br/>*array[object]* | A list of policy group object.
 `policyGroups.id`<br/>*string* | The ID of the policy group.
@@ -478,3 +478,82 @@ Attributes | &nbsp;
 `policyGroups.policies.action`<br/>*string* | The potential actions that the WAF will take when a policy is triggered. It can either be `ALLOW`, `BLOCK`, `HANDSHAKE`, `MONITOR` or `CAPTCHA`.
 `policyGroups.policies.enabled`<br/>*boolean* | If the WAF policy is enabled.
 
+<!-------------------- Edit WAF Settings for a Site -------------------->
+
+### Edit WAF Settings for a Site
+
+```shell
+curl -X PATCH \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/wafsettings/c0ddc1b3-b390-4f39-b200-5c0323ca306e"
+```
+
+> Request body example:
+
+```json
+{
+  "siteId": "c0ddc1b3-b390-4f39-b200-5c0323ca306e",
+  "stackId": "3df12b20-758e-4143-a706-46e724d335fc",
+  "listPolicyGroups": {
+    "policyGroups": [
+      {
+        "id": "8365e00f-a6c4-43a4-9f07-b830759737b8",
+        "name": "User Agents",
+        "policies": [
+          {
+            "name": "Invalid User Agent Prevention",
+            "description": "Block requests in which the HTTP header describing the user-agent (browser and platform) seems invalid as it does not fit the client's properties.",
+            "action": "BLOCK",
+            "id": "S28259696",
+            "enabled": false
+          },
+          {
+            "name": "Unknown User Agent Prevention",
+            "description": "Challenge requests in which the HTTP header describing the user-agent (browser and platform) is missing or unknown.",
+            "action": "HANDSHAKE",
+            "id": "S28259697",
+            "enabled": false
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "573ca8fa-c5ad-4b19-a315-8ddbbc78d7c0",
+  "taskStatus": "SUCCESS"
+}
+```
+
+<code>PATCH /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/wafsettings/<a href="#administration-sites">:site_id</a></code>
+
+Edit the WAF settings for a site in a given [environment](#administration-environments).
+
+Required | &nbsp;
+------- | -----------
+`siteId`<br/>*UUID*  | A site's unique identifier. 
+`stackId`<br/>*UUID*  | The ID of the stack that a site belongs to.
+
+Attributes | &nbsp;
+------- | -----------
+`ddosSettings`<br/>*object* | The DDoS Setting containing the different threshold values.
+`ddosSettings.globalThreshold`<br/>*Integer* | The number of overall requests per ten seconds that can trigger DDoS protection
+`ddosSettings.burstThreshold`<br/>*Integer* | The number of requests per two seconds that can trigger DDoS protection
+`ddosSettings.subSecondBurstThreshold`<br/>*Integer* | The number of requests per 0.1 seconds that can trigger DDoS protection
+`apiUrls`<br/>*array* | List of configured API urls.
+`monitoringEnabled`<br/>*boolean* | If the monitoring mode is enabled.
+`listPolicyGroups`<br/>*object* | An object containing the list of policy groups.
+`policyGroups`<br/>*array[object]* | A list of policy group object.
+`policyGroups.id`<br/>*string* | The ID of the policy group.
+`policyGroups.name`<br/>*string* | The name of the policy group.
+`policyGroups.policies`<br/>*array[object]* | A list of policies in a policy group.
+`policyGroups.policies.name`<br/>*string* | A WAF policy's name.
+`policyGroups.policies.id`<br/>*string* | A WAF policy's ID.
+`policyGroups.policies.description`<br/>*string* | A WAF policy's description.
+`policyGroups.policies.action`<br/>*string* | The potential actions that the WAF will take when a policy is triggered. It can either be `ALLOW`, `BLOCK`, `HANDSHAKE`, `MONITOR` or `CAPTCHA`.
+`policyGroups.policies.enabled`<br/>*boolean* | If the WAF policy is enabled.

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -462,9 +462,9 @@ Attributes | &nbsp;
 `siteId`<br/>*string* | The ID of the site that the WAF settings belongs to.
 `stackId`<br/>*string* | The ID of the stack that a site belongs to.
 `ddosSettings`<br/>*object* | The DDoS Setting containing the different threshold values.
-`ddosSettings.globalThreshold`<br/>*Integer* | The number of overall requests per ten seconds that can trigger DDoS protection
-`ddosSettings.burstThreshold`<br/>*Integer* | The number of requests per two seconds that can trigger DDoS protection
-`ddosSettings.subSecondBurstThreshold`<br/>*Integer* | The number of requests per 0.1 seconds that can trigger DDoS protection
+`ddosSettings.globalThreshold`<br/>*Integer* | The number of overall requests per ten seconds that can trigger DDoS protection.
+`ddosSettings.burstThreshold`<br/>*Integer* | The number of requests per two seconds that can trigger DDoS protection.
+`ddosSettings.subSecondBurstThreshold`<br/>*Integer* | The number of requests per 0.1 seconds that can trigger DDoS protection.
 `apiUrls`<br/>*array* | List of configured API urls.
 `monitoringEnabled`<br/>*boolean* | If the monitoring mode is enabled.
 `listPolicyGroups`<br/>*object* | An object containing the list of policy groups.
@@ -492,8 +492,6 @@ curl -X PATCH \
 
 ```json
 {
-  "siteId": "c0ddc1b3-b390-4f39-b200-5c0323ca306e",
-  "stackId": "3df12b20-758e-4143-a706-46e724d335fc",
   "listPolicyGroups": {
     "policyGroups": [
       {
@@ -534,17 +532,12 @@ curl -X PATCH \
 
 Edit the WAF settings for a site in a given [environment](#administration-environments).
 
-Required | &nbsp;
-------- | -----------
-`siteId`<br/>*string* | The ID of the site that the WAF settings belongs to.
-`stackId`<br/>*string* | The ID of the stack that a site belongs to.
-
 Attributes | &nbsp;
 ------- | -----------
 `ddosSettings`<br/>*object* | The DDoS Setting containing the different threshold values.
-`ddosSettings.globalThreshold`<br/>*Integer* | The number of overall requests per ten seconds that can trigger DDoS protection
-`ddosSettings.burstThreshold`<br/>*Integer* | The number of requests per two seconds that can trigger DDoS protection
-`ddosSettings.subSecondBurstThreshold`<br/>*Integer* | The number of requests per 0.1 seconds that can trigger DDoS protection
+`ddosSettings.globalThreshold`<br/>*Integer* | The number of overall requests per ten seconds that can trigger DDoS protection.
+`ddosSettings.burstThreshold`<br/>*Integer* | The number of requests per two seconds that can trigger DDoS protection.
+`ddosSettings.subSecondBurstThreshold`<br/>*Integer* | The number of requests per 0.1 seconds that can trigger DDoS protection.
 `apiUrls`<br/>*array* | List of configured API urls.
 `monitoringEnabled`<br/>*boolean* | If the monitoring mode is enabled.
 `listPolicyGroups`<br/>*object* | An object containing the list of policy groups.

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -536,8 +536,8 @@ Edit the WAF settings for a site in a given [environment](#administration-enviro
 
 Required | &nbsp;
 ------- | -----------
-`siteId`<br/>*UUID*  | A site's unique identifier. 
-`stackId`<br/>*UUID*  | The ID of the stack that a site belongs to.
+`siteId`<br/>*string* | The ID of the site that the WAF settings belongs to.
+`stackId`<br/>*string* | The ID of the stack that a site belongs to.
 
 Attributes | &nbsp;
 ------- | -----------


### PR DESCRIPTION
### Fixes [MC-13958](https://cloud-ops.atlassian.net/browse/MC-13958)

#### Changes made
<!-- Changes should match the template provided below -->
- Added doc for editing waf settings (patch)

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/208

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->