### PR TITLE
MC-14261 Added doc for get firewall rule (list and single)

### DIFF
--- a/source/includes/stackpath/_firewallrules.md
+++ b/source/includes/stackpath/_firewallrules.md
@@ -43,7 +43,7 @@ curl -X GET \
 
 Query Params | &nbsp;
 ---- | -----------
-`siteId`<br/>*UUID* | The ID of the site for which to list the firewall rules. This parameter is required.
+`siteId`<br/>*UUID* | The ID of the site for which the firewall rule will be applied to. This parameter is required.
 
 Attributes | &nbsp;
 ------- | -----------
@@ -82,7 +82,7 @@ curl -X GET \
 
 Query Params | &nbsp;
 ---- | -----------
-`siteId`<br/>*UUID* | The ID of the site for which the firewall rule resides in. This parameter is required.
+`siteId`<br/>*UUID* | The ID of the site for which the firewall rule will be applied to. This parameter is required.
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/stackpath/_firewallrules.md
+++ b/source/includes/stackpath/_firewallrules.md
@@ -44,6 +44,7 @@ curl -X GET \
 Query Params | &nbsp;
 ---- | -----------
 `siteId`<br/>*UUID* | The ID of the site for which the firewall rule is applied to. This parameter is required.
+`action`<br/>*string* | Filter IP addresses, which are either ALLOW or BLOCK. This parameter is optional. If not provided, it will return both the type of IP addresses.
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/stackpath/_firewallrules.md
+++ b/source/includes/stackpath/_firewallrules.md
@@ -43,7 +43,7 @@ curl -X GET \
 
 Query Params | &nbsp;
 ---- | -----------
-`siteId`<br/>*UUID* | The ID of the site for which the firewall rule will be applied to. This parameter is required.
+`siteId`<br/>*UUID* | The ID of the site for which the firewall rule is applied to. This parameter is required.
 
 Attributes | &nbsp;
 ------- | -----------
@@ -82,7 +82,7 @@ curl -X GET \
 
 Query Params | &nbsp;
 ---- | -----------
-`siteId`<br/>*UUID* | The ID of the site for which the firewall rule will be applied to. This parameter is required.
+`siteId`<br/>*UUID* | The ID of the site for which the firewall rule is applied to. This parameter is required.
 
 Attributes | &nbsp;
 ------- | -----------

--- a/source/includes/stackpath/_firewallrules.md
+++ b/source/includes/stackpath/_firewallrules.md
@@ -1,0 +1,94 @@
+## Firewall Rules
+
+Deploy and manage Firewall Rules used to control and limit access to your sites. 
+
+<!-------------------- LIST FIREWALL RULES -------------------->
+
+### List firewall rules
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/firewallrules?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+        "id": "1533148",
+        "name": "Rule 1 ",
+        "ipStart": "10.10.10.10",
+        "ipEnd": "20.20.20.20",
+        "action": "ALLOW",
+        "enabled": "true"
+    },
+    {
+        "id": "1533345",
+        "name": "Rule 2 ",
+        "ipStart": "192.0.0.1",
+        "ipEnd": "192.1.1.2",
+        "action": "BLOCK",
+        "enabled": "true"
+    }
+  ],
+  "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/firewallrules?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to list the firewall rules. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*UUID* | The unique identifier for the rule.
+`name`<br/>*string* | The name of the rule.
+`ipStart`<br/>*string* | The start ip adress for the rule.
+`ipEnd`<br/>*string* | There end ip adress for the rule.
+`action`<br/>*string* | Either ALLOW or BLOCK.
+`enabled`<br/>*string* | Whether the rule is enabled or not.
+
+<!-------------------- RETRIEVE A RULE -------------------->
+
+### Retrieve a firewall rule 
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/firewallrules/1533148?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data":{
+    "id": "1533148",
+    "name": "Rule 1 ",
+    "ipStart": "10.10.10.10",
+    "ipEnd": "20.20.20.20",
+    "action": "ALLOW",
+    "enabled": "true"
+    },
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/firewallrules/:id?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which the firewall rule resides in. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*UUID* | The unique identifier for the rule.
+`name`<br/>*string* | The name of the rule.
+`ipStart`<br/>*string* | The start ip adress for the rule.
+`ipEnd`<br/>*string* | There end ip adress for the rule.
+`action`<br/>*string* | Either ALLOW or BLOCK.
+`enabled`<br/>*string* | Whether the rule is enabled or not.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -195,6 +195,7 @@ includes:
   - stackpath/network_policy_rules
   - stackpath/delivery_domains
   - stackpath/scripts
+  - stackpath/firewallrules
   - aws
   - aws/compute
   - aws/instances


### PR DESCRIPTION
### Fixes [MC-14261](https://cloud-ops.atlassian.net/browse/MC-14261)

#### Changes made
<!-- Changes should match the template provided below -->
- Added API docs for listing all firewall rules and for a single rule 

#### Related PRs
- [MC-13925](https://cloudops.atlassian.net/browse/MC-13925) (Parent Story, listing all rules)
- [MC-14262](https://cloudops.atlassian.net/browse/MC-14262) (Story where we use the GET for a single rule)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->