### PR TITLE
MC-13956: document patch CDN settings

### DIFF
--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -319,11 +319,11 @@ Attributes | &nbsp;
 `queryStringControl`<br/>*String* | The strategy for caching query strings. Can be `IGNORE`, `CACHE_ALL` or `CUSTOM`. 
 `customCachedQueryStrings`<br/>*Array[String]* | List of custom cached query strings. Only visible if the `queryStringControl` attribute is `CUSTOM`.
 `dynamicCachingByHeaderEnabled`<br/>*Boolean* | Whether or not to enable dynamic caching by headers.
-`customCachedHeaders`<br/>*Array[String]*  | A list of custom cached headers. Only visible if `dynamicCachingByHeaderEnabled` is enabled. 
+`customCachedHeaders`<br/>*Array[String]*  | A list of custom cached headers. Only visible if `dynamicCachingByHeaderEnabled` is true. 
 `gzipCompressionEnabled`<br/>*Boolean* | Whether or not to enable gzip compression.
-`gzipCompressionLevel`<br/>*Integer* | The level for the gzip compression. Values are between `1` to `6`. Only visible is `gzipCompressionEnabled` is enabled.
+`gzipCompressionLevel`<br/>*Integer* | The level for the gzip compression. Values are between `1` to `6`. Only visible is `gzipCompressionEnabled` is true.
 `contentPersistenceEnabled`<br/>*Boolean* | Whether or not make cached content available after its expiration time.
-`maximumStaleFileTtl`<br/>*Integer*  | The maximum time to live for stale files, in seconds. Only visible if `contentPersistenceEnabled` is enabled. 
+`maximumStaleFileTtl`<br/>*Integer*  | The maximum time to live for stale files, in seconds. Only visible if `contentPersistenceEnabled` is true.
 `varyHeaderEnabled`<br/>*Boolean* | Whether or not to enable honoring the vary header in a request.
 `browserCacheTtl`<br/>*Integer*  | Sets the default browser expiration time for cached assets, in seconds. 
 `corsHeaderEnabled`<br/>*Boolean* | Sets the Access-Control-Allow-Origin header to allow browsers to access this domain from other origins.
@@ -331,11 +331,11 @@ Attributes | &nbsp;
 `originsToAllowCors`<br/>*Array[String]* | A list of origins to allow cors requests from. Only visible if `allowedCorsOrigins` is set to `SPECIFY_ORIGINS`.
 `http2SupportEnabled`<br/>*Boolean* | Whether or not to enable supporting applications using HTTP/2 protocol.
 `http2ServerPushEnabled`<br/>*Boolean* | Whether or not to push assets to the client or browser (user) in advance (before the user requests these assets) which enables faster load times.
-`linkHeader`<br/>*String* | The link header for http2ServerPush, only visible if `http2ServerPushEnabled` is enabled. 
+`linkHeader`<br/>*String* | The link header for http2ServerPush, only visible if `http2ServerPushEnabled` is true.
 `canonicalHeaderEnabled`<br/>*Boolean* | Whether or not to enable setting Link: <http://{hostname}/URI>; rel="canonical" header on each response.
-`canonicalHeader`<br/>*String* | The hostname for the canonicalHeader, only visible if `canonicalHeaderEnabled` is enabled. 
+`canonicalHeader`<br/>*String* | The hostname for the canonicalHeader, only visible if `canonicalHeaderEnabled` is true.
 `urlCachingEnabled`<br/>*Boolean* | Whether or not to enable caching of URLs without file extensions.
-`urlCachingTtl`<br/>*Integer* | The time to live for the url cache. Only visible if `urlCachingEnabled` is enabled. 
+`urlCachingTtl`<br/>*Integer* | The time to live for the url cache. Only visible if `urlCachingEnabled` is true.
 
 <!-------------------- EDIT CDN SETTINGS -------------------->
 
@@ -378,33 +378,25 @@ Optional | &nbsp;
 ------- | -----------
 `cacheExpirePolicy`<br/>*String* | A site's cache expiry policy. Can be `ORIGIN_CONTROLLED`, `SPECIFY_CDN_TTL`, `NEVER_EXPIRE`, or `DO_NOT_CACHE`. 
 `cacheTtl`<br/>*Integer*  | The time to live for the cache, in seconds. Only applies when attribute `cacheExpirePolicy` is `SPECIFY_CDN_TTL`.
-
 `queryStringControl`<br/>*String* | The strategy for caching query strings. Can be `IGNORE`, `CACHE_ALL` or `CUSTOM`. 
 `customCachedQueryStrings`<br/>*Array[String]* | List of custom cached query strings. Only applies when attribute `queryStringControl` is `CUSTOM`.
-
 `dynamicCachingByHeaderEnabled`<br/>*Boolean* | Whether or not to enable dynamic caching by headers.
-`customCachedHeaders`<br/>*Array[String]*  | A list of custom cached headers. Only applies when attribute `dynamicCachingByHeaderEnabled` is enabled. 
-
+`customCachedHeaders`<br/>*Array[String]*  | A list of custom cached headers. Only applies when attribute `dynamicCachingByHeaderEnabled` is true. 
 `gzipCompressionEnabled`<br/>*Boolean* | Whether or not to enable gzip compression.
-`gzipCompressionLevel`<br/>*Integer* | The level for the gzip compression. Values should be between `1` to `6`, where `6` is the default. Only applies when attribute `gzipCompressionEnabled` is enabled.
-
+`gzipCompressionLevel`<br/>*Integer* | The level for the gzip compression. Values should be between `1` to `6`, where `6` is the default. Only applies when attribute `gzipCompressionEnabled` is true.
 `contentPersistenceEnabled`<br/>*Boolean* | Whether or not make cached content available after its expiration time.
-`maximumStaleFileTtl`<br/>*Integer*  | The maximum time to live for stale files, in seconds. Only applies when attribute `contentPersistenceEnabled` is enabled. 
-
+`maximumStaleFileTtl`<br/>*Integer*  | The maximum time to live for stale files, in seconds. Only applies when attribute `contentPersistenceEnabled` is true.
 `varyHeaderEnabled`<br/>*Boolean* | Whether or not to enable honoring the vary header in a request.
-
 `browserCacheTtl`<br/>*Integer*  | Sets the default browser expiration time for cached assets, in seconds.
-
 `corsHeaderEnabled`<br/>*Boolean* | Sets the Access-Control-Allow-Origin header to allow browsers to access this domain from other origins.
 `allowedCorsOrigins`<br/>*String* | The strategy for allowing cors origins. Can be `SPECIFY_ORIGINS` or `ALL_ORIGINS`.
 `originsToAllowCors`<br/>*Array[String]* | A list of origins to allow cors requests from. Only applies when attribute `allowedCorsOrigins` is set to `SPECIFY_ORIGINS`.
-
 `http2SupportEnabled`<br/>*Boolean* | Whether or not to enable supporting applications using HTTP/2 protocol.
-
-`canonicalHeaderEnabled`<br/>*Boolean* | Whether or not to enable setting Link: <http://{hostname}/URI>; rel="canonical" header on each response.`canonicalHeader`<br/>*String* | The hostname for the canonicalHeader, only applies when attribute `canonicalHeaderEnabled` is enabled.
-
+`http2ServerPushEnabled` <br/>*Boolean* | Whether or not to push assets to the client or browser (user) in advance (before the user requests these assets) which enables faster load times.
+`linkHeader`<br/>*String* | The link header for `http2ServerPush`, only visible if `http2ServerPushEnabled` is true.
+`canonicalHeaderEnabled`<br/>*Boolean* | Whether or not to enable setting Link: <http://{hostname}/URI>; rel="canonical" header on each response.`canonicalHeader`<br/>*String* | The hostname for the canonicalHeader, only applies when attribute `canonicalHeaderEnabled` is true.
 `urlCachingEnabled`<br/>*Boolean* | Whether or not to enable caching of URLs without file extensions.
-`urlCachingTtl`<br/>*Integer* | The time to live for the url cache. Only applies when attribute `urlCachingEnabled` is enabled. 
+`urlCachingTtl`<br/>*Integer* | The time to live for the url cache. Only applies when attribute `urlCachingEnabled` is true.
 
 <!-------------------- PURGE ALL CDN CACHED CONTENT -------------------->
 

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -315,17 +315,17 @@ Attributes | &nbsp;
 ------- | -----------
 `siteId`<br/>*UUID*  | A site's unique identifier. 
 `cacheExpirePolicy`<br/>*String* | A site's cache expiry policy. Can be `ORIGIN_CONTROLLED`, `SPECIFY_CDN_TTL`, `NEVER_EXPIRE`, or `DO_NOT_CACHE`. 
-`cacheTtl`<br/>*Integer*  | The time to live for the cache. Depends on the cache expiry policy.
+`cacheTtl`<br/>*Integer*  | The time to live for the cache, in seconds. Depends on the cache expiry policy.
 `queryStringControl`<br/>*String* | The strategy for caching query strings. Can be `IGNORE`, `CACHE_ALL` or `CUSTOM`. 
-`customCachedQueryStrings`<br/>*Array[String]* | List of custom cached query strings. Only visible if the `queryStringControl` attribute is `CUSTOM`
+`customCachedQueryStrings`<br/>*Array[String]* | List of custom cached query strings. Only visible if the `queryStringControl` attribute is `CUSTOM`.
 `dynamicCachingByHeaderEnabled`<br/>*Boolean* | Whether or not to enable dynamic caching by headers.
 `customCachedHeaders`<br/>*Array[String]*  | A list of custom cached headers. Only visible if `dynamicCachingByHeaderEnabled` is enabled. 
 `gzipCompressionEnabled`<br/>*Boolean* | Whether or not to enable gzip compression.
 `gzipCompressionLevel`<br/>*Integer* | The level for the gzip compression. Values are between `1` to `6`. Only visible is `gzipCompressionEnabled` is enabled.
 `contentPersistenceEnabled`<br/>*Boolean* | Whether or not make cached content available after its expiration time.
-`maximumStaleFileTtl`<br/>*Integer*  | The maximum time to live for stale files. Only visible if `contentPersistenceEnabled` is enabled. 
+`maximumStaleFileTtl`<br/>*Integer*  | The maximum time to live for stale files, in seconds. Only visible if `contentPersistenceEnabled` is enabled. 
 `varyHeaderEnabled`<br/>*Boolean* | Whether or not to enable honoring the vary header in a request.
-`browserCacheTtl`<br/>*Integer*  | Sets the default browser expiration time for cached assets. 
+`browserCacheTtl`<br/>*Integer*  | Sets the default browser expiration time for cached assets, in seconds. 
 `corsHeaderEnabled`<br/>*Boolean* | Sets the Access-Control-Allow-Origin header to allow browsers to access this domain from other origins.
 `allowedCorsOrigins`<br/>*String* | The strategy for allowing cors origins. Can be `SPECIFY_ORIGINS` or `ALL_ORIGINS`.
 `originsToAllowCors`<br/>*Array[String]* | A list of origins to allow cors requests from. Only visible if `allowedCorsOrigins` is set to `SPECIFY_ORIGINS`.
@@ -337,6 +337,74 @@ Attributes | &nbsp;
 `urlCachingEnabled`<br/>*Boolean* | Whether or not to enable caching of URLs without file extensions.
 `urlCachingTtl`<br/>*Integer* | The time to live for the url cache. Only visible if `urlCachingEnabled` is enabled. 
 
+<!-------------------- EDIT CDN SETTINGS -------------------->
+
+### Edit CDN settings
+
+```shell
+curl -X PATCH \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/cdnsettings/9f236f19-55db-411f-9f05-bd79dc91a69b"
+```
+
+> Request body example:
+
+```json
+{
+  "urlCachingEnabled": true,
+  "urlCachingTtl": 1,
+  "canonicalHeaderEnabled": true,
+  "queryStringControl": "CUSTOM",
+  "customCachedQueryStrings": [
+    "help"
+  ]
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "e94d2bb6-059a-4eb6-a14f-7c596a5fdea6",
+  "taskStatus": "SUCCESS"
+}
+```
+
+<code>PATCH /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/cdnsettings/:siteId</a></code>
+
+Edit CDN settings for a site in a given [environment](#administration-environments).
+
+Optional | &nbsp;
+------- | -----------
+`cacheExpirePolicy`<br/>*String* | A site's cache expiry policy. Can be `ORIGIN_CONTROLLED`, `SPECIFY_CDN_TTL`, `NEVER_EXPIRE`, or `DO_NOT_CACHE`. 
+`cacheTtl`<br/>*Integer*  | The time to live for the cache, in seconds. Only applies when attribute `cacheExpirePolicy` is `SPECIFY_CDN_TTL`.
+
+`queryStringControl`<br/>*String* | The strategy for caching query strings. Can be `IGNORE`, `CACHE_ALL` or `CUSTOM`. 
+`customCachedQueryStrings`<br/>*Array[String]* | List of custom cached query strings. Only applies when attribute `queryStringControl` is `CUSTOM`.
+
+`dynamicCachingByHeaderEnabled`<br/>*Boolean* | Whether or not to enable dynamic caching by headers.
+`customCachedHeaders`<br/>*Array[String]*  | A list of custom cached headers. Only applies when attribute `dynamicCachingByHeaderEnabled` is enabled. 
+
+`gzipCompressionEnabled`<br/>*Boolean* | Whether or not to enable gzip compression.
+`gzipCompressionLevel`<br/>*Integer* | The level for the gzip compression. Values should be between `1` to `6`, where `6` is the default. Only applies when attribute `gzipCompressionEnabled` is enabled.
+
+`contentPersistenceEnabled`<br/>*Boolean* | Whether or not make cached content available after its expiration time.
+`maximumStaleFileTtl`<br/>*Integer*  | The maximum time to live for stale files, in seconds. Only applies when attribute `contentPersistenceEnabled` is enabled. 
+
+`varyHeaderEnabled`<br/>*Boolean* | Whether or not to enable honoring the vary header in a request.
+
+`browserCacheTtl`<br/>*Integer*  | Sets the default browser expiration time for cached assets, in seconds.
+
+`corsHeaderEnabled`<br/>*Boolean* | Sets the Access-Control-Allow-Origin header to allow browsers to access this domain from other origins.
+`allowedCorsOrigins`<br/>*String* | The strategy for allowing cors origins. Can be `SPECIFY_ORIGINS` or `ALL_ORIGINS`.
+`originsToAllowCors`<br/>*Array[String]* | A list of origins to allow cors requests from. Only applies when attribute `allowedCorsOrigins` is set to `SPECIFY_ORIGINS`.
+
+`http2SupportEnabled`<br/>*Boolean* | Whether or not to enable supporting applications using HTTP/2 protocol.
+
+`canonicalHeaderEnabled`<br/>*Boolean* | Whether or not to enable setting Link: <http://{hostname}/URI>; rel="canonical" header on each response.`canonicalHeader`<br/>*String* | The hostname for the canonicalHeader, only applies when attribute `canonicalHeaderEnabled` is enabled.
+
+`urlCachingEnabled`<br/>*Boolean* | Whether or not to enable caching of URLs without file extensions.
+`urlCachingTtl`<br/>*Integer* | The time to live for the url cache. Only applies when attribute `urlCachingEnabled` is enabled. 
 
 <!-------------------- PURGE ALL CDN CACHED CONTENT -------------------->
 


### PR DESCRIPTION
### Fixes [MC-13956](https://cloud-ops.atlassian.net/browse/MC-13956)

#### Changes made
- Document patch of `CdnSettings` entity.

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/231

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->