### PR TITLE
MC-13839 Add api docs

### DIFF
--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -1,0 +1,50 @@
+## Delivery Rules
+
+Set up delivery rules to improve access, security and set custom rules.
+
+<!-------------------- LIST DELIVERY_RULE -------------------->
+
+### List delivery rules
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliveryrules?siteId=dcc2771d-a524-4f8c-a666-f699985d6961"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "fc72c60a-d411-4b35-9deb-9dbc889faf7e",
+      "name": "addHeader",
+      "slug": "portal-ui-custom-1617310238955",
+      "stackId": "fd157f7c-e5cd-439b-b6c5-5864583a8ce8",
+      "siteId": "dcc2771d-a524-4f8c-a666-f699985d6961"
+    },
+    {
+      "id": "d411c60a-d411-4b35-9deb-f699985d6961",
+      "name": "removeHeader",
+      "slug": "portal-ui-custom-1617310238955",
+      "stackId": "fd157f7c-e5cd-439b-b6c5-5864583a8ce8",
+      "siteId": "dcc2771d-a524-4f8c-a666-f699985d6961"  
+    }
+  ],
+  "metadata": {
+    "recordCount": 1
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliveryrules?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Retrieve a list of all delivery rules in a given [environment](#administration-environments) within a site.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*UUID* | A deliveryrule's unique identifier. 
+`name`<br/>*string* | The name of the delivery rule.
+`slug`<br/>*string* | A delivery rule's programmatic name.
+`stackId`<br/>*string* | The ID of the stack that the delivery rule belongs to.
+`siteId`<br/>*string* | The ID of the site that the delivery rule is applied to.

--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -43,7 +43,7 @@ Retrieve a list of all delivery rules in a given [environment](#administration-e
 
 Attributes | &nbsp;
 ------- | -----------
-`id`<br/>*UUID* | A deliveryrule's unique identifier. 
+`id`<br/>*UUID* | A delivery rule's unique identifier. 
 `name`<br/>*string* | The name of the delivery rule.
 `slug`<br/>*string* | A delivery rule's programmatic name.
 `stackId`<br/>*string* | The ID of the stack that the delivery rule belongs to.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -196,6 +196,7 @@ includes:
   - stackpath/firewall_rules
   - stackpath/network_policy_rules
   - stackpath/scripts
+  - stackpath/delivery_rules
   - aws
   - aws/compute
   - aws/instances


### PR DESCRIPTION
### Fixes [MC-13839](https://cloud-ops.atlassian.net/browse/MC-13839)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->