### PR TITLE
Added api docs for retrieving edgessl settings

### DIFF
--- a/source/includes/stackpath/_edgessl.md
+++ b/source/includes/stackpath/_edgessl.md
@@ -1,0 +1,35 @@
+### EdgeSSL
+
+View and manage SSL settings and certificates. 
+
+<!-------------------- RETRIEVE EDGESSL SETTINGS -------------------->
+
+#### Retrieve EdgeSSL settings
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/edgesslsettings/eb3ecdbe-d73b-40e6-a263-166accba75ed"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "eb3ecdbe-d73b-40e6-a263-166accba75ed",
+    "forceHttps": true,
+    "minTlsVersion": "V1_2"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/edgesslsettings/:id</a></code>
+
+Retrieve the EdgeSSL settings for a site in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*UUID*  | A site's unique identifier. 
+`forceHttps`<br/>*boolean*  | Whether the site redirects all visitors to use HTTPS instead of HTTP. 
+`minTlsVersion`<br/>*string*  | The minimum TLS version clients must have to access the application. 

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -961,4 +961,3 @@ Optional | &nbsp;
 `backupOrigin.username` <br/> *string* | Username to use when authenticating with the backup origin. 
 `backupOrigin.password` <br/> *string* | Password to use when authenticating with the backup origin. 
 `backupOrigin.commonCertificateName` <br/> *string* | Common name to validate SSL origin requests against.
-

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -961,3 +961,36 @@ Optional | &nbsp;
 `backupOrigin.username` <br/> *string* | Username to use when authenticating with the backup origin. 
 `backupOrigin.password` <br/> *string* | Password to use when authenticating with the backup origin. 
 `backupOrigin.commonCertificateName` <br/> *string* | Common name to validate SSL origin requests against.
+
+<!-------------------- RETRIEVE EDGESSL SETTINGS -------------------->
+
+### Retrieve EdgeSSL settings
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/edgesslsettings/eb3ecdbe-d73b-40e6-a263-166accba75ed"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "eb3ecdbe-d73b-40e6-a263-166accba75ed",
+    "forceHttps": true,
+    "minTlsVersion": "V1_2"
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/edgesslsettings/:id</a></code>
+
+Retrieve the EdgeSSL settings for a site in a given [environment](#administration-environments).
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*UUID*  | A site's unique identifier. 
+`forceHttps`<br/>*boolean*  | Whether the site redirects all visitors to use HTTPS instead of HTTP. 
+`minTlsVersion`<br/>*string*  | The minimum TLS version clients must have to access the application. 
+

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -962,35 +962,3 @@ Optional | &nbsp;
 `backupOrigin.password` <br/> *string* | Password to use when authenticating with the backup origin. 
 `backupOrigin.commonCertificateName` <br/> *string* | Common name to validate SSL origin requests against.
 
-<!-------------------- RETRIEVE EDGESSL SETTINGS -------------------->
-
-### Retrieve EdgeSSL settings
-
-```shell
-curl -X GET \
-   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/edgesslsettings/eb3ecdbe-d73b-40e6-a263-166accba75ed"
-```
-
-> The above command returns a JSON structured like this:
-
-```json
-{
-  "data": {
-    "id": "eb3ecdbe-d73b-40e6-a263-166accba75ed",
-    "forceHttps": true,
-    "minTlsVersion": "V1_2"
-  }
-}
-```
-
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/edgesslsettings/:id</a></code>
-
-Retrieve the EdgeSSL settings for a site in a given [environment](#administration-environments).
-
-Attributes | &nbsp;
-------- | -----------
-`id`<br/>*UUID*  | A site's unique identifier. 
-`forceHttps`<br/>*boolean*  | Whether the site redirects all visitors to use HTTPS instead of HTTP. 
-`minTlsVersion`<br/>*string*  | The minimum TLS version clients must have to access the application. 
-

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -189,7 +189,8 @@ includes:
   - swift/objects
   - stackpath
   - stackpath/workloads
-  - stackpath/sites
+  - stackpath/sites # Sites section
+  - stackpath/edgessl
   - stackpath/instances
   - stackpath/images
   - stackpath/delivery_domains


### PR DESCRIPTION
### Fixes [MC-14402](https://cloud-ops.atlassian.net/browse/MC-14402)

#### Changes made
<!-- Changes should match the template provided below -->
- Added API docs for EdgeSSL settings

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->