### PR TITLE
[Add] delete EdgeSSL certificate api doc

### DIFF
--- a/source/includes/stackpath/_certificates.md
+++ b/source/includes/stackpath/_certificates.md
@@ -50,3 +50,37 @@ Attributes | &nbsp;
 ------- | -----------
 `taskId` <br/>*string* | The task id related to creation of the Certificate.
 `taskStatus` <br/>*string* | The status of the operation.
+
+
+<!-------------------- DELETE A CERTIFICATE -------------------->
+
+### Delete a certificate
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/certificates/2318483?siteId=6f6c1724-c306-433c-9e09-95227edc7c6c"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "ef70cafa-0544-4709-a66a-c68595ee105a",
+  "taskStatus": "SUCCESS"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/certificates/:id?siteId=:siteId</code>
+
+Delete a certificate.
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to delete the certificate. This parameter is required.
+
+The following attributes are returned as part of the response.
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the certificate deletion.
+`taskStatus` <br/>*string* | The status of the operation.


### PR DESCRIPTION
### Fixes [MC-14431](https://cloud-ops.atlassian.net/browse/MC-14431)

#### Changes made
<!-- Changes should match the template provided below -->
- API docs for delete SP// EdgeSSL certificate

![image](https://user-images.githubusercontent.com/20757399/114008511-b2c86480-9838-11eb-8bac-8b0781b5ed7c.png)


#### Related PRs
- [https://github.com/cloudops/cloudmc-stackpath-plugin/pull/282](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/282) 

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->