### PR TITLE
MC-13940 Add api docs for the create delivery rules.

### DIFF
--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -69,8 +69,7 @@ curl -X POST \
   {
     "trigger": "HEADER",
     "operator": "MATCHES",
-    "target": "my-header",
-    "httpMethods": ["GET"]
+    "target": "my-header"
   }],
   "deliveryRuleActions": [
     {
@@ -109,7 +108,7 @@ Required| &nbsp;
 `trigger`<br/>*Enum* | Trigger for the condition. Possible values: `COOKIE`, `HEADER`, `HTTP_METHOD`, `STATUS_CODE`, and `URL`.
 `operator`<br/>*Enum* | Operator for the condition. Possible values: `EQUALS`, `MATCHES`, and `MATCHES_REGULAR_EXPRESSION`.
 `target`<br/>*String* | The target of the condition.
-`httpMethods`<br/>*Array[Enum]* | HTTP methods for the condition. Possible values are: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIONS`.
+`httpMethods`<br/>*Array[Enum]* | HTTP methods for the condition. Possible values are: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIONS`. This fields is only used when `trigger` is set to `HTTP_METHOD`.
 
 #### Action
 

--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -102,10 +102,6 @@ Required| &nbsp;
 `deliveryRuleConditions`<br/>*Array[[Condition](#stackpath-condition)]* | At least one condition.
 `deliveryRuleActions`<br/>*Array[[Action](#stackpath-action)]* | At least one action.
 
-Optional| &nbsp;
-------------------------| -----------
-`slug`<br/>*string* | A delivery rule's programmatic name.
-
 #### Condition
 
 Required| &nbsp;

--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -122,7 +122,7 @@ Possible Attributes| &nbsp;
 `cdnHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
 `cacheTtl`<br/>*Number* | Time to live of the cache.
 `redirectUrl`<br/>*String* | The url to redirect to.
-`headerPattern`<br/>*String* | The header to set to modifier the response.
+`headerPattern`<br/>*String* | The header to set the modifier in the response.
 `passphrase`<br/>*String* | The passphrase for signing the url.
 `passphraseField`<br/>*String* | The passphrase field for signing the url.
 `md5TokenField`<br/>*String* | The MD5 token field for signing the url.

--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -65,13 +65,13 @@ curl -X POST \
 ```js
 {
  "name": "rule",
-  "deliveryRuleConditions": [
+  "conditions": [
   {
     "trigger": "HEADER",
     "operator": "MATCHES",
     "target": "my-header"
   }],
-  "deliveryRuleActions": [
+  "actions": [
     {
       "actionType": "REDIRECT",
       "redirectUrl": "https://my-url.com"
@@ -98,8 +98,8 @@ Query Params | &nbsp;
 Required| &nbsp;
 ------------------------| -----------
 `name`<br/>*string* | The name of the delivery rule.
-`deliveryRuleConditions`<br/>*Array[[Condition](#stackpath-condition)]* | At least one condition.
-`deliveryRuleActions`<br/>*Array[[Action](#stackpath-action)]* | At least one action.
+`conditions`<br/>*Array[[Condition](#stackpath-condition)]* | At least one condition.
+`actions`<br/>*Array[[Action](#stackpath-action)]* | At least one action.
 
 #### Condition
 

--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -49,6 +49,91 @@ Attributes | &nbsp;
 `stackId`<br/>*string* | The ID of the stack that the delivery rule belongs to.
 `siteId`<br/>*string* | The ID of the site that the delivery rule is applied to.
 
+<!-------------------- CREATE A DELIVERY RULE -------------------->
+
+### Create a delivery rule
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliveryrules?siteId=f9dea588-d7ab-4f42-b6e6-4b85f273f3db"
+```
+
+> Request body example for creating a delivery rule:
+
+```js
+{
+ "name": "rule",
+  "deliveryRuleConditions": [
+  {
+    "trigger": "HEADER",
+    "operator": "MATCHES",
+    "target": "my-header",
+    "httpMethods": ["GET"]
+  }],
+  "deliveryRuleActions": [
+    {
+      "actionType": "REDIRECT",
+      "redirectUrl": "https://my-url.com"
+    }]
+}
+```
+
+> The above commands return a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliveryrules?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Delivery Rules which allow you to modify CDN settings based on a number of elements like URL, HTTP headers, and more.
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to create the delivery rule. This parameter is required.
+
+Required| &nbsp;
+------------------------| -----------
+`name`<br/>*string* | The name of the delivery rule.
+`deliveryRuleConditions`<br/>*Array[[Condition](#stackpath-condition)]* | At least one condition.
+`deliveryRuleActions`<br/>*Array[[Action](#stackpath-action)]* | At least one action.
+
+Optional| &nbsp;
+------------------------| -----------
+`slug`<br/>*string* | A delivery rule's programmatic name.
+
+#### Condition
+
+Required| &nbsp;
+------------------------| -----------
+`trigger`<br/>*Enum* | Trigger for the condition. Possible values: `COOKIE`, `HEADER`, `HTTP_METHOD`, `STATUS_CODE`, and `URL`.
+`operator`<br/>*Enum* | Operator for the condition. Possible values: `EQUALS`, `MATCHES`, and `MATCHES_REGULAR_EXPRESSION`.
+`target`<br/>*String* | The target of the condition.
+`httpMethods`<br/>*Array[Enum]* | HTTP methods for the condition. Possible values are: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIONS`.
+
+#### Action
+
+The action attributes needed to be passed will vary depending on the condition being specified.
+
+Possible Attributes| &nbsp;
+------------------------| -----------
+`actionType`<br/>*Enum* | The type of action. Possible values: `ADD_RESPONSE_HEADER`, `ADD_HEADER_TO_ORIGIN`,`ADD_HEADER_TO_CDN`, `NEVER_EXPIRE`, `DO_NOT_CACHE`, `CACHE`, `REDIRECT`, `HIDE_HEADER`, `MODIFY_HEADER`, `SIGN_URL`, and `BYPASS_CACHE`.
+`responseHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
+`originHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
+`cdnHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
+`cacheTtl`<br/>*Number* | Time to live of the cache.
+`redirectUrl`<br/>*String* | The url to redirect to.
+`headerPattern`<br/>*String* | The header to set to modifier the response.
+`passphrase`<br/>*String* | The passphrase for signing the url.
+`passphraseField`<br/>*String* | The passphrase field for signing the url.
+`md5TokenField`<br/>*String* | The MD5 token field for signing the url.
+`ipAddressFilter`<br/>*String* | The ip address filter for signing the url.
+`urlSignaturePathLength`<br/>*String* | The url signature path length for signing the url.
+
 <!-------------------- DELETE A DELIVERY RULE -------------------->
 
 ### Delete a delivery rule


### PR DESCRIPTION
### Fixes [MC-13940](https://cloud-ops.atlassian.net/browse/MC-13940)

#### Changes made
<!-- Changes should match the template provided below -->
- Add docs for the create delivery rule API.

Please note that this will likely need additional changes once https://github.com/cloudops/cloudmc-api-docs/pull/355 is merged.

#### Related PRs
- https://github.com/cloudops/cloudmc-api-docs/pull/355

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->