### PR TITLE
MC-13940 Add docs for the update delivery rules.

### DIFF
--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -104,7 +104,7 @@ Required| &nbsp;
 #### Update a delivery rule
 
 ```shell
-curl -X POST \
+curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliveryrules/d065db45-1eba-4c62-a017-d51f2d473d4a?siteId=f9dea588-d7ab-4f42-b6e6-4b85f273f3db"
@@ -136,7 +136,7 @@ curl -X POST \
   "taskStatus": "PENDING"
 }
 ```
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliveryrules/:ruleId?siteId=<a href="#stackpath-sites">:siteId</a></code>
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliveryrules/:ruleId?siteId=<a href="#stackpath-sites">:siteId</a></code>
 
 Query Params | &nbsp;
 ---- | -----------

--- a/source/includes/stackpath/_delivery_rules.md
+++ b/source/includes/stackpath/_delivery_rules.md
@@ -51,7 +51,7 @@ Attributes | &nbsp;
 
 <!-------------------- CREATE A DELIVERY RULE -------------------->
 
-### Create a delivery rule
+#### Create a delivery rule
 
 ```shell
 curl -X POST \
@@ -89,8 +89,6 @@ curl -X POST \
 ```
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliveryrules?siteId=<a href="#stackpath-sites">:siteId</a></code>
 
-Delivery Rules which allow you to modify CDN settings based on a number of elements like URL, HTTP headers, and more.
-
 Query Params | &nbsp;
 ---- | -----------
 `siteId`<br/>*UUID* | The ID of the site for which to create the delivery rule. This parameter is required.
@@ -101,33 +99,53 @@ Required| &nbsp;
 `conditions`<br/>*Array[[Condition](#stackpath-condition)]* | At least one condition.
 `actions`<br/>*Array[[Action](#stackpath-action)]* | At least one action.
 
-#### Condition
+<!-------------------- UPDATE A DELIVERY RULE -------------------->
+
+#### Update a delivery rule
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/deliveryrules/d065db45-1eba-4c62-a017-d51f2d473d4a?siteId=f9dea588-d7ab-4f42-b6e6-4b85f273f3db"
+```
+
+> Request body example for updating a delivery rule:
+
+```js
+{
+  "conditions": [
+  {
+    "trigger": "HEADER",
+    "operator": "MATCHES",
+    "target": "my-header"
+  }],
+  "actions": [
+    {
+      "actionType": "REDIRECT",
+      "redirectUrl": "https://my-url.com"
+    }]
+}
+```
+
+> The above commands return a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/deliveryrules/:ruleId?siteId=<a href="#stackpath-sites">:siteId</a></code>
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to update the delivery rule. This parameter is required.
 
 Required| &nbsp;
 ------------------------| -----------
-`trigger`<br/>*Enum* | Trigger for the condition. Possible values: `COOKIE`, `HEADER`, `HTTP_METHOD`, `STATUS_CODE`, and `URL`.
-`operator`<br/>*Enum* | Operator for the condition. Possible values: `EQUALS`, `MATCHES`, and `MATCHES_REGULAR_EXPRESSION`.
-`target`<br/>*String* | The target of the condition.
-`httpMethods`<br/>*Array[Enum]* | HTTP methods for the condition. Possible values are: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIONS`. This fields is only used when `trigger` is set to `HTTP_METHOD`.
-
-#### Action
-
-The action attributes needed to be passed will vary depending on the condition being specified.
-
-Possible Attributes| &nbsp;
-------------------------| -----------
-`actionType`<br/>*Enum* | The type of action. Possible values: `ADD_RESPONSE_HEADER`, `ADD_HEADER_TO_ORIGIN`,`ADD_HEADER_TO_CDN`, `NEVER_EXPIRE`, `DO_NOT_CACHE`, `CACHE`, `REDIRECT`, `HIDE_HEADER`, `MODIFY_HEADER`, `SIGN_URL`, and `BYPASS_CACHE`.
-`responseHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
-`originHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
-`cdnHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
-`cacheTtl`<br/>*Number* | Time to live of the cache.
-`redirectUrl`<br/>*String* | The url to redirect to.
-`headerPattern`<br/>*String* | The header to set the modifier in the response.
-`passphrase`<br/>*String* | The passphrase for signing the url.
-`passphraseField`<br/>*String* | The passphrase field for signing the url.
-`md5TokenField`<br/>*String* | The MD5 token field for signing the url.
-`ipAddressFilter`<br/>*String* | The ip address filter for signing the url.
-`urlSignaturePathLength`<br/>*String* | The url signature path length for signing the url.
+`conditions`<br/>*Array[[Condition](#stackpath-condition)]* | At least one condition.
+`actions`<br/>*Array[[Action](#stackpath-action)]* | At least one action.
 
 <!-------------------- DELETE A DELIVERY RULE -------------------->
 
@@ -161,3 +179,32 @@ Attributes | &nbsp;
 ------- | -----------
 `taskId` <br/>*string* | The task id related to the delivery rule deletion.
 `taskStatus` <br/>*string* | The status of the operation.
+
+
+##### Condition
+
+Required| &nbsp;
+------------------------| -----------
+`trigger`<br/>*Enum* | Trigger for the condition. Possible values: `COOKIE`, `HEADER`, `HTTP_METHOD`, `STATUS_CODE`, and `URL`.
+`operator`<br/>*Enum* | Operator for the condition. Possible values: `EQUALS`, `MATCHES`, and `MATCHES_REGULAR_EXPRESSION`.
+`target`<br/>*String* | The target of the condition.
+`httpMethods`<br/>*Array[Enum]* | HTTP methods for the condition. Possible values are: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, and `OPTIONS`. This fields is only used when `trigger` is set to `HTTP_METHOD`.
+
+##### Action
+
+The action attributes needed to be passed will vary depending on the condition being specified.
+
+Possible Attributes| &nbsp;
+------------------------| -----------
+`actionType`<br/>*Enum* | The type of action. Possible values: `ADD_RESPONSE_HEADER`, `ADD_HEADER_TO_ORIGIN`,`ADD_HEADER_TO_CDN`, `NEVER_EXPIRE`, `DO_NOT_CACHE`, `CACHE`, `REDIRECT`, `HIDE_HEADER`, `MODIFY_HEADER`, `SIGN_URL`, and `BYPASS_CACHE`.
+`responseHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
+`originHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
+`cdnHeaders`<br/>*Array* | Headers for the actions expressed as a key-value pair.
+`cacheTtl`<br/>*Number* | Time to live of the cache.
+`redirectUrl`<br/>*String* | The url to redirect to.
+`headerPattern`<br/>*String* | The header to set the modifier in the response.
+`passphrase`<br/>*String* | The passphrase for signing the url.
+`passphraseField`<br/>*String* | The passphrase field for signing the url.
+`md5TokenField`<br/>*String* | The MD5 token field for signing the url.
+`ipAddressFilter`<br/>*String* | The ip address filter for signing the url.
+`urlSignaturePathLength`<br/>*String* | The url signature path length for signing the url.


### PR DESCRIPTION
### Fixes [MC-13940](https://cloud-ops.atlassian.net/browse/MC-13940)

#### Changes made
<!-- Changes should match the template provided below -->
- Add the docs for update delivery rule api
- Fix nesting level for the create api which was not at the right level
- Moved the conditions and actions block at the end of the page

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/299

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->