### PR TITLE
Feature/MC-13939 List custom rules

### DIFF
--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -218,7 +218,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/customrules?siteId=<a href="#stackpath-site">:siteId</a></code>
 
-Create a site in a given [environment](#administration-environments).
+Create a custom rule in a given [environment](#administration-environments).
 
 Query Params | &nbsp;
 ---- | -----------

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -157,8 +157,6 @@ Attributes | &nbsp;
 `conditions.endValue`<br/>*string* | Second value of the condition. Only for condition of type `IP_RANGE`.
 
 
-
-
 <!-------------------- CREATE A CUSTOM RULE -------------------->
 
 #### Create a custom rule
@@ -246,3 +244,37 @@ Optional | &nbsp;
 `pathRegExp`<br/>*string* | The regex expression that the path must match for the rule to trigger. Default is '/'. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to. Only for rule of type `REQUEST_RATE`.
+
+
+<!-------------------- DELETE A CUSTOM RULE -------------------->
+
+#### Delete a custom rule
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/customrules/1585477?siteId=1b1cd7e6-41ab-4e0f-a59a-5c4b89da1b36"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "c39f0c66-04a0-40cf-aa2e-485f50a27561",
+  "taskStatus": "SUCCESS"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/customrules/:id?siteId=<a href="#stackpath-site">:siteId</a></code>
+
+Delete a custom rule
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to delete the custom rule. This parameter is required.
+
+The following attributes are returned as part of the response.
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the custom rule deletion.
+`taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -78,7 +78,7 @@ Attributes | &nbsp;
 `actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
 `statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`. 
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
-`duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
@@ -145,7 +145,7 @@ Attributes | &nbsp;
 `actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
 `statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`. 
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
-`duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -1,0 +1,157 @@
+### Custom Rules
+
+Deploy and manage Custom Rules used to control and limit access to your sites. 
+
+<!-------------------- LIST CUSTOM RULES -------------------->
+
+#### List custom rules
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/customrules?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "1580676",
+      "stackId": "7fbea2c0-17d0-41df-b0b1-4d5c95cXXX",
+      "siteId": "0a57855b-26d8-4e8f-8b77-429997c7c5fb",
+      "name": "testrequestrate",
+      "notes": "test-note",
+      "type": "WAF",
+      "enabled": true,
+      "action": "BLOCK",
+      "actionDuration": "0s",
+      "statusCode": "FORBIDDEN_403",
+      "conditions": [
+        {
+          "type": "IP",
+          "operation": "EQUAL",
+          "value": "120.1.1.1"
+        }
+      ]
+    },
+    {
+      "id": "1580692",
+      "stackId": "7fbea2c0-17d0-41df-b0b1-4d5c95cXXX",
+      "siteId": "0a57855b-26d8-4e8f-8b77-429997c7c5fb",
+      "name": "testipwafrule",
+      "notes": "",
+      "type": "REQUEST_RATE",
+      "enabled": true,
+      "action": "ALLOW",
+      "actionDuration": "0s",
+      "statusCode": "TOO_MANY_REQUESTS_429",
+      "nbRequest": 20,
+      "duration": 60,
+      "pathRegExp": "/",
+      "httpMethods": [],
+      "ipAddresses": []
+    }
+  ],
+  "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/customrules?siteId=<a href="#stackpath-site">:siteId</a></code>
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which the custom rule is applied to. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The unique identifier for the rule.
+`stackId`<br/>*UUID* | The ID of the stack for which the custom rule is applied to.
+`siteId`<br/>*UUID* | The ID of the site for which the custom rule is applied to.
+`name`<br/>*string* | The name of the rule.
+`notes`<br/>*string* | Notes 
+`type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
+`enabled`<br/>*boolean* | Whether or not the rule is enabled.
+`action`<br/>*string* | Either ALLOW or BLOCK.
+`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests.
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request
+`nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
+`ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
+`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger.
+`conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
+`conditions.operation`<br/>*string* | Operation of the condition, one of: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `NOT_CONTAINS`, `BETWEEN` or `NOT_BETWEEN`.
+`conditions.header`<br/>*string* | Value of the header. Only for condition operation of type `HEADER`.
+`conditions.value`<br/>*string* | Value for which the condition holds.
+`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition operation of type `IP_RANGE`.
+
+
+<!-------------------- RETRIEVE A RULE -------------------->
+
+#### Retrieve a custom rule 
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/customrules/1580676?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+      "id": "1580676",
+      "stackId": "7fbea2c0-17d0-41df-b0b1-4d5c95cXXX",
+      "siteId": "0a57855b-26d8-4e8f-8b77-429997c7c5fb",
+      "name": "testrequestrate",
+      "notes": "test-note",
+      "type": "WAF",
+      "enabled": true,
+      "action": "BLOCK",
+      "actionDuration": "0s",
+      "statusCode": "FORBIDDEN_403",
+      "conditions": [
+        {
+          "type": "IP",
+          "operation": "EQUAL",
+          "value": "120.1.1.1"
+        }
+      ]
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/customrules/:id?siteId=<a href="#stackpath-site">:siteId</a></code>
+
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which the custom rule is applied to. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The unique identifier for the rule.
+`stackId`<br/>*UUID* | The ID of the stack for which the custom rule is applied to.
+`siteId`<br/>*UUID* | The ID of the site for which the custom rule is applied to.
+`name`<br/>*string* | The name of the rule.
+`notes`<br/>*string* | Notes 
+`type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
+`enabled`<br/>*boolean* | Whether or not the rule is enabled.
+`action`<br/>*string* | Either ALLOW or BLOCK.
+`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests.
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request
+`nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
+`ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
+`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger.
+`conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
+`conditions.operation`<br/>*string* | Operation of the condition, one of: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `NOT_CONTAINS`, `BETWEEN` or `NOT_BETWEEN`.
+`conditions.header`<br/>*string* | Value of the header. Only for condition operation of type `HEADER`.
+`conditions.value`<br/>*string* | Value for which the condition holds.
+`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition operation of type `IP_RANGE`.

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -74,7 +74,7 @@ Attributes | &nbsp;
 `notes`<br/>*string* | The description notes of the rule.
 `type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
 `enabled`<br/>*boolean* | Whether or not the rule is enabled.
-`action`<br/>*string* | Either ALLOW or BLOCK.
+`action`<br/>*string* | Action to be taken when the rule is met. Possible values are `ALLOW`, `BLOCK`, `CAPTCHA`,`HANDSHAKE` or `MONITOR`.
 `actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
 `statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`. 
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
@@ -141,7 +141,7 @@ Attributes | &nbsp;
 `notes`<br/>*string* | The description notes of the rule.
 `type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
 `enabled`<br/>*boolean* | Whether or not the rule is enabled.
-`action`<br/>*string* | Either ALLOW or BLOCK.
+`action`<br/>*string* | Action to be taken when the rule is met. Possible values are `ALLOW`, `BLOCK`, `CAPTCHA`,`HANDSHAKE` or `MONITOR`.
 `actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
 `statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`. 
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -218,7 +218,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/customrules?siteId=<a href="#stackpath-site">:siteId</a></code>
 
-Create a custom rule in a given [environment](#administration-environments).
+Create a custom rule for a site in a given [environment](#administration-environments).
 
 Query Params | &nbsp;
 ---- | -----------

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -80,7 +80,7 @@ Attributes | &nbsp;
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
-`httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
+`httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`. Possible values are: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, `OPTION`, `CONNECT`, `TRACE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
 `conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
@@ -147,7 +147,7 @@ Attributes | &nbsp;
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
-`httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
+`httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`. Possible values are: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `PATCH`, `OPTION`, `CONNECT`, `TRACE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
 `conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -71,12 +71,12 @@ Attributes | &nbsp;
 `stackId`<br/>*UUID* | The ID of the stack for which the custom rule is applied to.
 `siteId`<br/>*UUID* | The ID of the site for which the custom rule is applied to.
 `name`<br/>*string* | The name of the rule.
-`notes`<br/>*string* | Notes 
+`notes`<br/>*string* | The description notes of the rule.
 `type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
 `enabled`<br/>*boolean* | Whether or not the rule is enabled.
 `action`<br/>*string* | Either ALLOW or BLOCK.
 `actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests.
-`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request.
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
@@ -138,12 +138,12 @@ Attributes | &nbsp;
 `stackId`<br/>*UUID* | The ID of the stack for which the custom rule is applied to.
 `siteId`<br/>*UUID* | The ID of the site for which the custom rule is applied to.
 `name`<br/>*string* | The name of the rule.
-`notes`<br/>*string* | Notes 
+`notes`<br/>*string* | The description notes of the rule.
 `type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
 `enabled`<br/>*boolean* | Whether or not the rule is enabled.
 `action`<br/>*string* | Either ALLOW or BLOCK.
 `actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests.
-`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request.
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -75,19 +75,19 @@ Attributes | &nbsp;
 `type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
 `enabled`<br/>*boolean* | Whether or not the rule is enabled.
 `action`<br/>*string* | Either ALLOW or BLOCK.
-`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests.
-`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request.
+`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`. 
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
-`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger.
+`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
 `conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
-`conditions.operation`<br/>*string* | Operation of the condition, one of: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `NOT_CONTAINS`, `BETWEEN` or `NOT_BETWEEN`.
-`conditions.header`<br/>*string* | Value of the header. Only for condition operation of type `HEADER`.
+`conditions.operation`<br/>*string* | Operation of the condition, one of: <ul><li>`EQUAL`, `NOT_EQUAL` for all condition type except `IP_RANGE`</li>, <li>`CONTAINS`, `NOT_CONTAINS` for condition type `HEADER`, `URL` and `USER_AGENT`</li><li>`BETWEEN` or `NOT_BETWEEN` only for condition type `IP_RANGE`</li></ul>.
+`conditions.header`<br/>*string* | Value of the header. Only for condition of type `HEADER`.
 `conditions.value`<br/>*string* | Value for which the condition holds.
-`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition operation of type `IP_RANGE`.
+`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition of type `IP_RANGE`.
 
 
 <!-------------------- RETRIEVE A RULE -------------------->
@@ -142,16 +142,109 @@ Attributes | &nbsp;
 `type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
 `enabled`<br/>*boolean* | Whether or not the rule is enabled.
 `action`<br/>*string* | Either ALLOW or BLOCK.
-`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests.
-`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request.
+`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`. 
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
-`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger.
+`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
 `conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
-`conditions.operation`<br/>*string* | Operation of the condition, one of: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `NOT_CONTAINS`, `BETWEEN` or `NOT_BETWEEN`.
-`conditions.header`<br/>*string* | Value of the header. Only for condition operation of type `HEADER`.
+`conditions.operation`<br/>*string* | Operation of the condition, one of: <ul><li>`EQUAL`, `NOT_EQUAL` for all condition type except `IP_RANGE`</li>, <li>`CONTAINS`, `NOT_CONTAINS` for condition type `HEADER`, `URL` and `USER_AGENT`</li><li>`BETWEEN` or `NOT_BETWEEN` only for condition type `IP_RANGE`</li></ul>.
+`conditions.header`<br/>*string* | Value of the header. Only for condition of type `HEADER`.
 `conditions.value`<br/>*string* | Value for which the condition holds.
-`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition operation of type `IP_RANGE`.
+`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition of type `IP_RANGE`.
+
+
+
+
+<!-------------------- CREATE A CUSTOM RULE -------------------->
+
+#### Create a custom rule
+
+```shell
+curl -X POST \
+    -H "MC-Api-Key: your_api_key" \
+    -d "request_body" \
+    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/customrules?siteId=0a57855b-26d8-4e8f-8b77-429997c7c5fb"
+```
+> Request body example for a custom rule with conditions:
+
+```json
+{
+  "name": "firewall-allow",
+  "notes": "some firewall note",
+  "type": "WAF",
+  "action": "BLOCK",
+  "actionDuration": "0s",
+  "statusCode": "FORBIDDEN_403",
+  "conditions": [
+    {
+      "type": "IP",
+      "operation": "EQUAL",
+      "value": "120.1.1.1"
+    }
+  ]
+}
+```
+
+> Request body example for a custom role with request rate:
+
+```json
+{
+  "name": "firewall-deny",
+  "notes": "Deny rule",
+  "type": "REQUEST_RATE",
+  "enabled": true,
+  "action": "BLOCK",
+  "actionDuration": "0s",
+  "statusCode": "TOO_MANY_REQUESTS_429",
+  "nbRequest": 20,
+  "duration": 60,
+  "pathRegExp": "/",
+  "httpMethods": ["GET"],
+  "ipAddresses": ["192.168.2.1"]
+}
+```
+> The above commands return a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/customrules?siteId=<a href="#stackpath-site">:siteId</a></code>
+
+Create a site in a given [environment](#administration-environments).
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which the custom rule is applied to. This parameter is required.
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*string* | The name of the rule.
+`type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
+`action`<br/>*string* | Action to be taken when the rule is met. Possible values are `ALLOW`, `BLOCK`, `CAPTCHA`,`HANDSHAKE` or `MONITOR`.
+`nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
+`conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
+`conditions.operation`<br/>*string* | Operation of the condition, one of: <ul><li>`EQUAL`, `NOT_EQUAL` for all condition type except `IP_RANGE`</li>, <li>`CONTAINS`, `NOT_CONTAINS` for condition type `HEADER`, `URL` and `USER_AGENT`</li><li>`BETWEEN` or `NOT_BETWEEN` only for condition type `IP_RANGE`</li></ul>.
+`conditions.header`<br/>*string* | Value of the header. Only for condition of type `HEADER`.
+`conditions.value`<br/>*string* | Value for which the condition holds.
+`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition of type `IP_RANGE`.
+
+Optional | &nbsp;
+------- | -----------
+`notes`<br/>*string* | The description notes of the rule.
+`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`. 
+`pathRegExp`<br/>*string* | The regex expression that the path must match for the rule to trigger. Default is '/'. Only for rule of type `REQUEST_RATE`.
+`httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
+`ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to. Only for rule of type `REQUEST_RATE`.
+
+

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -1,6 +1,6 @@
 ### Custom Rules
 
-Deploy and manage Custom Rules used to control and limit access to your sites. 
+Manage custom rules used to control and limit access to your sites. 
 
 <!-------------------- LIST CUSTOM RULES -------------------->
 
@@ -74,20 +74,20 @@ Attributes | &nbsp;
 `notes`<br/>*string* | The description notes of the rule.
 `type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
 `enabled`<br/>*boolean* | Whether or not the rule is enabled.
-`action`<br/>*string* | Either ALLOW or BLOCK.
-`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests.
-`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request.
+`action`<br/>*string* | Action to be taken when the rule is met. Possible values are `ALLOW`, `BLOCK`, `CAPTCHA`,`HANDSHAKE` or `MONITOR`.
+`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`.
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
-`duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
-`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger.
+`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
 `conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
-`conditions.operation`<br/>*string* | Operation of the condition, one of: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `NOT_CONTAINS`, `BETWEEN` or `NOT_BETWEEN`.
-`conditions.header`<br/>*string* | Value of the header. Only for condition operation of type `HEADER`.
+`conditions.operation`<br/>*string* | Operation of the condition, one of: <ul><li>`EQUAL`, `NOT_EQUAL` for all condition type except `IP_RANGE`</li>, <li>`CONTAINS`, `NOT_CONTAINS` for condition type `HEADER`, `URL` and `USER_AGENT`</li><li>`BETWEEN` or `NOT_BETWEEN` only for condition type `IP_RANGE`</li></ul>.
+`conditions.header`<br/>*string* | Value of the header. Only for condition of type `HEADER`.
 `conditions.value`<br/>*string* | Value for which the condition holds.
-`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition operation of type `IP_RANGE`.
+`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition of type `IP_RANGE`.
 
 
 <!-------------------- RETRIEVE A RULE -------------------->
@@ -141,17 +141,17 @@ Attributes | &nbsp;
 `notes`<br/>*string* | The description notes of the rule.
 `type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
 `enabled`<br/>*boolean* | Whether or not the rule is enabled.
-`action`<br/>*string* | Either ALLOW or BLOCK.
-`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests.
-`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request.
+`action`<br/>*string* | Action to be taken when the rule is met. Possible values are `ALLOW`, `BLOCK`, `CAPTCHA`,`HANDSHAKE` or `MONITOR`.
+`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`.
 `nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
-`duration`<br/>*long* | Duration of the session's lifetime for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
-`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger.
+`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
 `conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
-`conditions.operation`<br/>*string* | Operation of the condition, one of: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `NOT_CONTAINS`, `BETWEEN` or `NOT_BETWEEN`.
-`conditions.header`<br/>*string* | Value of the header. Only for condition operation of type `HEADER`.
+`conditions.operation`<br/>*string* | Operation of the condition, one of: <ul><li>`EQUAL`, `NOT_EQUAL` for all condition type except `IP_RANGE`</li>, <li>`CONTAINS`, `NOT_CONTAINS` for condition type `HEADER`, `URL` and `USER_AGENT`</li><li>`BETWEEN` or `NOT_BETWEEN` only for condition type `IP_RANGE`</li></ul>.
+`conditions.header`<br/>*string* | Value of the header. Only for condition of type `HEADER`.
 `conditions.value`<br/>*string* | Value for which the condition holds.
-`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition operation of type `IP_RANGE`.
+`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition of type `IP_RANGE`.

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -81,7 +81,7 @@ Attributes | &nbsp;
 `duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
-`ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
+`ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
 `conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
 `conditions.operation`<br/>*string* | Operation of the condition, one of: <ul><li>`EQUAL`, `NOT_EQUAL` for all condition type except `IP_RANGE`</li>, <li>`CONTAINS`, `NOT_CONTAINS` for condition type `HEADER`, `URL` and `USER_AGENT`</li><li>`BETWEEN` or `NOT_BETWEEN` only for condition type `IP_RANGE`</li></ul>.
@@ -148,7 +148,7 @@ Attributes | &nbsp;
 `duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `pathRegExp`<br/>*string* | The regex expression present in the path for the rule to trigger. Only for rule of type `REQUEST_RATE`.
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
-`ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to.Only for rule of type `REQUEST_RATE`.
+`ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
 `conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
 `conditions.operation`<br/>*string* | Operation of the condition, one of: <ul><li>`EQUAL`, `NOT_EQUAL` for all condition type except `IP_RANGE`</li>, <li>`CONTAINS`, `NOT_CONTAINS` for condition type `HEADER`, `URL` and `USER_AGENT`</li><li>`BETWEEN` or `NOT_BETWEEN` only for condition type `IP_RANGE`</li></ul>.

--- a/source/includes/stackpath/_predefined_edgerules.md
+++ b/source/includes/stackpath/_predefined_edgerules.md
@@ -1,0 +1,101 @@
+### Predefined EdgeRules
+
+The predefined EdgeRules let you configure how StackPath responds to requests to your website. These predefined EdgeRules only work with domains that resolve to StackPath.
+
+<!-------------------- LIST PREDEFINED EDGERULES -------------------->
+
+#### List predefined EdgeRules
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/predefinededgerules/dcc2771d-a524-4f8c-a666-f699985d6961"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "allowEmptyReferrer": false,
+    "forceWwwEnabled": true,
+    "id": "c988cc62-24e7-4850-9a81-95f51af0a68e",
+    "pseudoStreamingEnabled": true,
+    "referrerList": [
+      "cloudmc.io",
+      "saas.cloudmc.io"
+    ],
+    "referrerProtectionEnabled": true,
+    "robotsTxtEnabled": true,
+    "robotsTxtFile": "User-agent: *\nDisallow:",
+    "scopeId": "e9e48610-3ba6-471a-96f4-7cf18cb73455",
+    "stackId": "1f259d02-db66-4a93-8402-a0725a00a02a",
+    
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/predefinededgerules/<a href="#stackpath-site">:siteId</a></code>
+
+Retrieve the configuration of all predefined EdgeRules in a given [environment](#administration-environments) within a site.
+
+Attributes | &nbsp;
+------- | -----------
+`allowEmptyReferrer`<br/>*boolean* | Whether or not empty referrer is allowed.
+`forceWwwEnabled`<br/>*boolean* | Whether or not redirecting every request to a www subdomain is enabled.
+`id`<br/>*UUID* | This ID is same as the siteId to which the predefined EdgeRules belong.
+`pseudoStreamingEnabled`<br/>*boolean* | Whether or not seeking random locations within MP4 or FLV files without downloading the entire video is enabled.
+`referrerList`<br/>*Array[string]* | The list of domains authorized to access content from the site's root scope. Wildcards can be used to specify multiple websites hosted on the same domain.
+`referrerProtectionEnabled`<br/>*boolean* | Whether or not referrer protection is enabled. This rule is used to allow only requests whose referrer header matches a URL that you specified.
+`robotsTxtEnabled`<br/>*boolean* | Whether or not custom robot.txt support is enabled. This rule is used to configure which pages or files search engine crawlers can or cannot index from the site.
+`robotsTxtFile`<br/>*string* | This field represents the robots.txt file contents. `NOTE:` When you first enable the `robotsTxtEnabled` rule, by default, the robots.txt will populate with a rule to disallow all indexing for CDN content. Any change made with this rule will override the contents of the robots.txt file on origin server.
+`scopeId`<br/>*UUID* | The ID of the CDN site's root scope that the predefined rules belongs to.
+`stackId`<br/>*UUID* | The ID of the stack that the predefined rules belong to.
+
+<!-------------------- EDIT PREDEFINED EDGERULES  -------------------->
+
+#### Edit a predefined EdgeRules
+
+```shell
+curl -X PATCH \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/predefinededgerules/dcc2771d-a524-4f8c-a666-f699985d6961"
+```
+
+> Request body example:
+
+```json
+{
+  "allowEmptyReferrer": true,
+  "forceWwwEnabled": true,
+  "pseudoStreamingEnabled": true,
+  "referrerList": [
+    "cloudmc.com",
+    "saas.cloudmc.com"
+  ],
+  "referrerProtectionEnabled": true,
+  "robotsTxtEnabled": true,
+  "robotsTxtFile": "User-agent: *\nDisallow:",
+}
+```
+
+> The above commands return a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+<code>PATCH /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/predefinededgerules/<a href="#stackpath-sites">:siteId</a></code>
+
+
+Optional| &nbsp;
+------------------------| -----------
+`allowEmptyReferrer`<br/>*boolean* | Whether or not empty referrer is allowed.
+`forceWwwEnabled`<br/>*boolean* | Whether or not redirecting every request to a www subdomain is enabled.
+`pseudoStreamingEnabled`<br/>*boolean* | Whether or not seeking random locations within MP4 or FLV files without downloading the entire video is enabled.
+`referrerList`<br/>*Array[string]* | The list of domains authorized to access content from the site's root scope. Wildcards can be used to specify multiple websites hosted on the same domain.
+`referrerProtectionEnabled`<br/>*boolean* | Whether or not referrer protection is enabled. This rule is used to allow only requests whose referrer header matches a URL that you specified.
+`robotsTxtEnabled`<br/>*boolean* | Whether or not custom robot.txt support is enabled.
+`robotsTxtFile`<br/>*string* | This field represents the robots.txt file contents. `NOTE:` To update the `robotsTxtFile` content, the `robotsTxtEnabled` flag should be included in the request payload.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -195,6 +195,7 @@ includes:
   - stackpath/delivery_domains
   - stackpath/cdn
   - stackpath/delivery_rules
+  - stackpath/custom_rules
   - stackpath/waf
   - stackpath/firewall_rules
   - stackpath/scripts

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -202,6 +202,7 @@ includes:
   - stackpath/edgessl
   - stackpath/edgessl_settings
   - stackpath/certificates
+  - stackpath/predefined_edgerules
   - stackpath/instances
   - stackpath/images
   - stackpath/network_policy_rules


### PR DESCRIPTION
### Fixes [MC-13939](https://cloud-ops.atlassian.net/browse/MC-13939)

#### Changes made
- Added the GET all and get specific custom rule documentation

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/296

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->