### PR TITLE
Feature/mc 13945 delete custom rules

### DIFF
--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -155,3 +155,37 @@ Attributes | &nbsp;
 `conditions.header`<br/>*string* | Value of the header. Only for condition operation of type `HEADER`.
 `conditions.value`<br/>*string* | Value for which the condition holds.
 `conditions.endValue`<br/>*string* | Second value of the condition. Only for condition operation of type `IP_RANGE`.
+
+
+<!-------------------- DELETE A SITE -------------------->
+
+#### Delete a custom rule
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/customrules/1585477?siteId=1b1cd7e6-41ab-4e0f-a59a-5c4b89da1b36"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "c39f0c66-04a0-40cf-aa2e-485f50a27561",
+  "taskStatus": "SUCCESS"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/customrules/:id?siteId=<a href="#stackpath-site">:siteId</a></code>
+
+Delete a custom rule
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which to delete the custom rule. This parameter is required.
+
+The following attributes are returned as part of the response.
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the custom rule deletion.
+`taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -157,7 +157,7 @@ Attributes | &nbsp;
 `conditions.endValue`<br/>*string* | Second value of the condition. Only for condition operation of type `IP_RANGE`.
 
 
-<!-------------------- DELETE A SITE -------------------->
+<!-------------------- DELETE A CUSTOM RULE -------------------->
 
 #### Delete a custom rule
 

--- a/source/includes/stackpath/_predefined_edgerules.md
+++ b/source/includes/stackpath/_predefined_edgerules.md
@@ -1,0 +1,101 @@
+### Predefined EdgeRules
+
+The predefined EdgeRules let you configure how StackPath responds to requests to your website. These predefined EdgeRules only work with domains that resolve to StackPath.
+
+<!-------------------- LIST PREDEFINED EDGERULES -------------------->
+
+#### List predefined EdgeRules
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/predefinededgerules/dcc2771d-a524-4f8c-a666-f699985d6961"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "allowEmptyReferrer": false,
+    "forceWwwEnabled": true,
+    "id": "c988cc62-24e7-4850-9a81-95f51af0a68e",
+    "pseudoStreamingEnabled": true,
+    "referrerList": [
+      "cloudmc.io",
+      "saas.cloudmc.io"
+    ],
+    "referrerProtectionEnabled": true,
+    "robotsTxtEnabled": true,
+    "robotsTxtFile": "User-agent: *\nDisallow:",
+    "scopeId": "e9e48610-3ba6-471a-96f4-7cf18cb73455",
+    "stackId": "1f259d02-db66-4a93-8402-a0725a00a02a",
+    
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/predefinededgerules/<a href="#stackpath-site">:siteId</a></code>
+
+Retrieve the configuration of all predefined EdgeRules in a given [environment](#administration-environments) within a site.
+
+Attributes | &nbsp;
+------- | -----------
+`allowEmptyReferrer`<br/>*boolean* | Whether or not empty referrer is allowed.
+`forceWwwEnabled`<br/>*boolean* | Whether or not redirecting every request to a www subdomain is enabled.
+`id`<br/>*UUID* | This ID is same as the siteId to which the predefined EdgeRules belong.
+`pseudoStreamingEnabled`<br/>*boolean* | Whether or not seeking random locations within MP4 or FLV files without downloading the entire video is enabled.
+`referrerList`<br/>*Array[string]* | The list of domains authorized to access content from the site's root scope. Wildcards can be used to specify multiple websites hosted on the same domain.
+`referrerProtectionEnabled`<br/>*boolean* | Whether or not referrer protection is enabled. This rule is used to allow only requests whose referrer header matches a URL that you specified.
+`robotsTxtEnabled`<br/>*boolean* | Whether or not custom robot.txt support is enabled. This rule is used to configure which pages or files search engine crawlers can or cannot index from the site.
+`robotsTxtFile`<br/>*string* | This field represents the robots.txt file contents. `NOTE:` When you first enable the `robotsTxtEnabled` rule, by default, the robots.txt will populate with a rule to disallow all indexing for CDN content. Any change made with this rule will override the contents of the robots.txt file on origin server.
+`scopeId`<br/>*UUID* | The ID of the CDN site's root scope that the predefined rules belongs to.
+`stackId`<br/>*UUID* | The ID of the stack that the predefined rules belong to.
+
+<!-------------------- EDIT PREDEFINED EDGERULES  -------------------->
+
+#### Edit a predefined EdgeRules
+
+```shell
+curl -X PATCH \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/predefinededgerules/dcc2771d-a524-4f8c-a666-f699985d6961"
+```
+
+> Request body example:
+
+```json
+{
+  "allowEmptyReferrer": true,
+  "forceWwwEnabled": true,
+  "pseudoStreamingEnabled": true,
+  "referrerList": [
+    "cloudmc.com",
+    "saas.cloudmc.com"
+  ],
+  "referrerProtectionEnabled": true,
+  "robotsTxtEnabled": true,
+  "robotsTxtFile": "User-agent: *\nDisallow:",
+}
+```
+
+> The above commands return a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+<code>PATCH /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/predefinededgerules/<a href="#stackpath-sites">:siteId</a></code>
+
+
+Optional| &nbsp;
+------------------------| -----------
+`allowEmptyReferrer`<br/>*boolean* | Whether or not empty referrer is allowed.
+`forceWwwEnabled`<br/>*boolean* | Whether or not redirecting every request to a www subdomain is enabled.
+`pseudoStreamingEnabled`<br/>*boolean* | Whether or not seeking random locations within MP4 or FLV files without downloading the entire video is enabled.
+`referrerList`<br/>*Array[string]* | The list of domains authorized to access content from the site's root scope. Wildcards can be used to specify multiple websites hosted on the same domain.
+`referrerProtectionEnabled`<br/>*boolean* | Whether or not referrer protection is enabled. This rule is used to allow only requests whose referrer header matches a URL that you specified.
+`robotsTxtEnabled`<br/>*boolean* | Whether or not custom robot.txt support is enabled.
+`robotsTxtFile`<br/>*string* | This field represents the robots.txt file contents. `NOTE:` To update the `robotsTxtFile` content, the `robotsTxtEnabled` flag should be included in the request payload.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -201,6 +201,7 @@ includes:
   - stackpath/edgessl
   - stackpath/edgessl_settings
   - stackpath/certificates
+  - stackpath/predefined_edgerules
   - stackpath/instances
   - stackpath/images
   - stackpath/network_policy_rules


### PR DESCRIPTION
### Fixes [MC-13945](https://cloud-ops.atlassian.net/browse/MC-13945)

#### Changes made
<!-- Changes should match the template provided below -->
- Added docs for delete operation for custom rules

#### Related PRs
- [MC-13945](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/336)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->