### PR TITLE
MC-13944: Added docs for edit custom rule

### DIFF
--- a/source/includes/stackpath/_custom_rules.md
+++ b/source/includes/stackpath/_custom_rules.md
@@ -244,6 +244,93 @@ Optional | &nbsp;
 `httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 `ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 
+<!-------------------- EDIT A CUSTOM RULE -------------------->
+
+#### Edit a custom rule
+
+```shell
+curl -X PUT \
+  -H "MC-Api-Key: your_api_key" \
+  -d "request_body" \
+  "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/customrules/1576836?siteId=1c6c127a-bfa4-4c85-a329-13c0581b41eb"
+```
+> Request body example for a custom rule with conditions:
+
+```json
+{
+  "name": "firewalldeny",
+  "notes": "Deny rule",
+  "type": "WAF",
+  "enabled": false,
+  "action": "BLOCK",
+  "actionDuration": "10s",
+  "statusCode": "FORBIDDEN_403",
+  "conditions": [
+    {
+      "type": "IP",
+      "operation": "EQUAL",
+      "value": "172.16.254.14"
+    }
+  ]
+}
+```
+
+> Request body example for a custom role with request rate:
+
+```json
+{
+  "name": "firewalldeny",
+  "notes": "Deny rule",
+  "type": "REQUEST_RATE",
+  "action": "BLOCK",
+  "actionDuration": "0s",
+  "statusCode": "TOO_MANY_REQUESTS_429",
+  "nbRequest": 20,
+  "duration": 60,
+  "pathRegExp": "/",
+  "httpMethods": ["GET"],
+  "ipAddresses": ["192.168.2.1"]
+}
+```
+> The above commands returns a JSON structured like this:
+
+```json
+{
+  "taskId": "8fcf30b0-1644-474d-b150-ac0c6f51bf98",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/customrules/:id?siteId=<a href="#stackpath-site">:siteId</a></code>
+
+Edit a custom rule.
+
+Query Params | &nbsp;
+---- | -----------
+`siteId`<br/>*UUID* | The ID of the site for which the custom rule is applied to. This parameter is required.
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*string* | The name of the rule.
+`type`<br/>*string* | Type of custom rule. One of `REQUEST_RATE` or `WAF`. The fields returned are different based on the type, `REQUEST_RATE` will not return a list of conditions.
+`action`<br/>*string* | Action to be taken when the rule is met. Possible values are `ALLOW`, `BLOCK`, `CAPTCHA`,`HANDSHAKE` or `MONITOR`.
+`nbRequest`<br/>*long* | Number of dynamic page requests made for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`duration`<br/>*long* | Number of seconds that the WAF measures incoming requests over for the rule to trigger. Only for rule of type `REQUEST_RATE`.
+`conditions`<br/>*Array[Object]* | The conditions required for the WAF engine to trigger the rule. All conditions must pass for the rule to trigger. Only for rule of type `WAF`.
+`conditions.type`<br/>*string* | Type of condition, one of: `IP`, `IP_RANGE`, `URL`, `USER_AGENT`, `HEADER`, `HTTP_METHOD`, `FILE_EXTENSION`, `CONTENT_TYPE`, `COUNTRY` or `ORGANIZATION`.
+`conditions.operation`<br/>*string* | Operation of the condition, one of: <ul><li>`EQUAL`, `NOT_EQUAL` for all condition type except `IP_RANGE`</li>, <li>`CONTAINS`, `NOT_CONTAINS` for condition type `HEADER`, `URL` and `USER_AGENT`</li><li>`BETWEEN` or `NOT_BETWEEN` only for condition type `IP_RANGE`</li></ul>.
+`conditions.header`<br/>*string* | Value of the header. Only for condition of type `HEADER`.
+`conditions.value`<br/>*string* | Value for which the condition holds.
+`conditions.endValue`<br/>*string* | Second value of the condition. Only for condition of type `IP_RANGE`.
+
+Optional | &nbsp;
+------- | -----------
+`notes`<br/>*string* | The description notes of the rule.
+`actionDuration`<br/>*string* | How long a rule's block action will apply to subsequent requests in case of the action `BLOCK`. Format is a string with a integer followed by the unit (s for seconds, m for minutes and h for hours e.g. 30s). Default is `0s`
+`statusCode`<br/>*string* | A custom HTTP status code that the WAF returns if a rule blocks a request. Possible values are `FORBIDDEN_403` and `TOO_MANY_REQUESTS_429`. Default is `FORBIDDEN_403`. 
+`pathRegExp`<br/>*string* | The regex expression that the path must match for the rule to trigger. Default is '/'. Only for rule of type `REQUEST_RATE`.
+`httpMethods`<br/>*Array[string]* | List of HTTP methods that the rule will apply to. Only for rule of type `REQUEST_RATE`.
+`ipAddresses`<br/>*Array[string]* | List of IP addresses that the rule will apply to. Only for rule of type `REQUEST_RATE`.
 
 <!-------------------- DELETE A CUSTOM RULE -------------------->
 


### PR DESCRIPTION
### Fixes [MC-13944](https://cloud-ops.atlassian.net/browse/MC-13944)

#### Changes made
<!-- Changes should match the template provided below -->
- Added docs for editing custom rules

#### Related PRs
- [13944](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/333)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->