### PR TITLE
Updated custom purge docs

### DIFF
--- a/source/includes/stackpath/_cdn.md
+++ b/source/includes/stackpath/_cdn.md
@@ -179,15 +179,37 @@ curl -X POST \
    "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/cdnsettings/9f236f19-55db-411f-9f05-bd79dc91a69b?operation=purge"
 ```
 
-> Request body example:
+> Request body example for URL purge type:
+
+```json
+{
+  "purgeType":"URL",
+  "items": [
+    {
+      "url": "http://<domain-name>",
+      "recursive": true,
+      "purgeAllDynamic": true,
+      "headers": [],
+      "purgeSelector": {
+        "selectorName": "(?i)<header_name>",
+        "selectorValue": "<header_value>",
+        "selectorType": "HEADER",
+        "selectorValueDelimiter": ""
+      }
+    }
+  ]
+}
+```
+
+> Request body example for PATH purge type:
 
 ```json
 {
   "purgeType":"PATH",
   "items": [
     {
-      "url": "//<domain_name>/path/to/file",
-      "recursive": true,
+      "url": "/path/to/file",
+      "recursive": false,
       "purgeAllDynamic": false,
       "headers": [],
       "purgeSelector": {


### PR DESCRIPTION

#### Changes made
<!-- Changes should match the template provided below -->
- Updated docs for Custom purge. For PATH purge type, user just provides the path.

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->