### PR TITLE
MC-14547: update docs for sites

### DIFF
--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -90,7 +90,17 @@ curl -X GET \
       "WAF"
     ],
     "id": "9ae3717a-006a-4aa7-b64b-8bc8d2f2d6e5",
-    "status": "ACTIVE"
+    "status": "ACTIVE",
+    "edgeAddress": "v2a4k7y8.stackpathcdn.com",
+    "anycastIp": "151.139.128.10",
+    "deliveryDomains": [
+    {
+      "domain": "v2a4k7y8.stackpathcdn.com",
+      "validatedAt": "2021-02-26T19:00:15.177411Z"
+    },
+    {
+      "domain": "slow-test.com",
+    }],
   }
 }
 ```
@@ -108,6 +118,11 @@ Attributes | &nbsp;
 `createdAt`<br/>*string* | The date on which the site was created.
 `updatedAt`<br/>*string* | The date on which the site was last updated.
 `services`<br/>*array* | List of services running on the site.
+`edgeAddress`<br/>*string* | The edge address of the site.
+`anycastIp`<br/>*string* | The anycast IP address that domains should be pointed to.
+`deliveryDomains`<br/>*array* | List of delivery domains of the site.
+`deliveryDomains.updatedAt`<br/>*string* | A delivery domain of the site.
+`deliveryDomains.updatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.
 
 <!-------------------- CREATE A SITE -------------------->
 

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -119,7 +119,7 @@ Attributes | &nbsp;
 `updatedAt`<br/>*string* | The date on which the site was last updated.
 `services`<br/>*array* | List of services running on the site.
 `edgeAddress`<br/>*string* | The edge address of the site.
-`anycastIp`<br/>*string* | The anycast IP address that domains should be pointed to.
+`anycastIp`<br/>*string* | The Anycast IP address that domains should be pointed to.
 `deliveryDomains`<br/>*array* | List of delivery domains of the site.
 `deliveryDomains.domain`<br/>*string* | A delivery domain of the site.
 `deliveryDomains.validatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.

--- a/source/includes/stackpath/_sites.md
+++ b/source/includes/stackpath/_sites.md
@@ -121,8 +121,8 @@ Attributes | &nbsp;
 `edgeAddress`<br/>*string* | The edge address of the site.
 `anycastIp`<br/>*string* | The anycast IP address that domains should be pointed to.
 `deliveryDomains`<br/>*array* | List of delivery domains of the site.
-`deliveryDomains.updatedAt`<br/>*string* | A delivery domain of the site.
-`deliveryDomains.updatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.
+`deliveryDomains.domain`<br/>*string* | A delivery domain of the site.
+`deliveryDomains.validatedAt`<br/>*string* | The date the domain was validated to be pointing to Stackpath.
 
 <!-------------------- CREATE A SITE -------------------->
 

--- a/source/includes/stackpath/_workloads.md
+++ b/source/includes/stackpath/_workloads.md
@@ -116,7 +116,7 @@ Retrieve a list of all workloads in a given [environment](#administration-enviro
 Attributes | &nbsp;
 ------- | -----------
 `addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only applicable to workloads of `type` 'CONTAINER'.
-`anycastIpAddress`<br/>*string* | The anycast IP address assigned to a workload. If there is no IP assigned to the workload then the value of this attribute will be `None`.
+`anycastIpAddress`<br/>*string* | The Anycast IP address assigned to a workload. If there is no IP assigned to the workload then the value of this attribute will be `None`.
 `commands`<br/>*Array[string]* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
 `containerEmail` <br/>*string* | The email address to use for the docker registry account. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
@@ -234,7 +234,7 @@ Retrieve a workload in a given [environment](#administration-environments).
 Attributes | &nbsp;
 ------- | -----------
 `addImagePullCredentialsOption`<br/>*boolean* | It is used to indicate if additional credentials to pull container image are provided or not. Only applicable to workloads of `type` 'CONTAINER'.
-`anycastIpAddress`<br/>*string* | The anycast IP address assigned to a workload. If there is no IP assigned to the workload then the value of this attribute will be `None`.
+`anycastIpAddress`<br/>*string* | The Anycast IP address assigned to a workload. If there is no IP assigned to the workload then the value of this attribute will be `None`.
 `commands`<br/>*Array[string]* | The commands that start a container. Only applicable to workloads of `type` 'CONTAINER'.
 `containerEmail` <br/>*string* | The email address to use for the docker registry account. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.
 `containerServer` <br/>*string* | The server that the credentials should be used with. This value will default to the docker hub registry when not set. Only applicable to workloads of `type` 'CONTAINER' and `addImagePullCredentialsOption` is 'true'.


### PR DESCRIPTION
### Fixes [MC-14547](https://cloud-ops.atlassian.net/browse/MC-14547)

#### Changes made
<!-- Changes should match the template provided below -->
- `deliveryDomains` property was added, also added missing properties `edgeAddress` and `anycastIp`

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/373

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->