### PR TITLE
MC-14798: Added get and list billing proviers api

### DIFF
--- a/source/includes/administration/_billing.md
+++ b/source/includes/administration/_billing.md
@@ -1,0 +1,1 @@
+## Billing

--- a/source/includes/administration/_billing_providers.md
+++ b/source/includes/administration/_billing_providers.md
@@ -1,6 +1,6 @@
 ### Billing providers
 
-The billing providers are the different configuration to configure and charge organizations.
+The billing providers are the different payment processing tools that can be used to charge organizations.
 
 <!-------------------- LIST BILLING PROVIDERS -------------------->
 #### List billing providers
@@ -41,7 +41,7 @@ curl "https://cloudmc_endpoint/rest/billing_providers" \
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the billing provider.
-`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the billing provider. This can only be a organization which is root or reseller.
+`organization.id`<br/>*UUID* | UUID of the organization to which belongs the billing provider. This can only be a organization which is root or reseller.
 `name`<br/>*Object* | The name object of the billing provider.
 `type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
 `providerType`<br/>*string* | The provider for the associated type.
@@ -88,7 +88,7 @@ curl "https://cloudmc_endpoint/rest/billing_providers/f26e66a4-755c-4867-b565-ad
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the billing provider.
-`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the billing provider. This can only be a organization which is root or reseller.
+`organization.id`<br/>*UUID* | UUID of the organization to which belongs the billing provider. This can only be a organization which is root or reseller.
 `name`<br/>*Object* | The name object of the billing provider.
 `type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
 `providerType`<br/>*string* | The provider for the associated type.

--- a/source/includes/administration/_billing_providers.md
+++ b/source/includes/administration/_billing_providers.md
@@ -100,8 +100,8 @@ Attributes | &nbsp;
 <!-------------------- PROVIDER TYPE ATTRIBUTES -------------------->
 #### Provider type configuration attribute
 
-Here are the attributes for the `CREDIT_CARD` providers
+Here are the attributes for the `CREDIT_CARD` providers.
 
 Provider | Attributes | &nbsp;
 ---- | ---- | -----------
-all | `creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field
+all | `creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field.

--- a/source/includes/administration/_billing_providers.md
+++ b/source/includes/administration/_billing_providers.md
@@ -1,0 +1,107 @@
+### Billing providers
+
+The billing providers are the different configuration to configure and charge organizations.
+
+<!-------------------- LIST BILLING PROVIDERS -------------------->
+#### List billing providers
+
+`GET /billing_providers`
+
+Retrieves a list of billing providers configured in the system.
+
+```shell
+# Retrieve billing providers list
+curl "https://cloudmc_endpoint/rest/billing_providers" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "f26e66a4-755c-4867-b565-ad68aa515237",
+      "organization": {
+        "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+      },
+      "name": "Chase Credit Card (Dev)",
+      "type": "CREDIT_CARD",
+      "providerType": "chaseCreditCard",
+      "createdDate": "2021-05-07T19:21:20Z",
+      "updatedDate": "2021-05-07T19:21:20Z",
+      "defaultForType": true,
+      "configurationAttributes": {
+        "creditCards": "American Express, MasterCard, Visa, Discover"
+      }
+    }
+  ]
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the billing provider.
+`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the billing provider. This can only be a organization which is root or reseller.
+`name`<br/>*Object* | The name object of the billing provider.
+`type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
+`providerType`<br/>*string* | The provider for the associated type.
+`createdDate`<br/>*string* | The date the billing provider was created.
+`updatedDate`<br/>*string* | The last date the billing provider was updated.
+`defaultForType`<br/>*UUID* | If this billing provider is the default for the specified type.
+`configurationAttributes`<br/>*Object* | The configuration attribute associated to the provider type. [See possible values](#administration-provider-type-configuration-attribute)
+
+
+<!-------------------- GET BILLING PROVIDER -------------------->
+#### Retrieve a billing provider
+
+`GET /billing_providers/:id`
+
+Retrieve a billing provider's details.
+
+```shell
+# Retrieve a billing provider's details
+curl "https://cloudmc_endpoint/rest/billing_providers/f26e66a4-755c-4867-b565-ad68aa515237" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "f26e66a4-755c-4867-b565-ad68aa515237",
+    "organization": {
+      "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+    },
+    "name": "Chase Credit Card (Dev)",
+    "type": "CREDIT_CARD",
+    "providerType": "chaseCreditCard",
+    "createdDate": "2021-05-07T19:21:20Z",
+    "updatedDate": "2021-05-07T19:21:20Z",
+    "defaultForType": true,
+    "configurationAttributes": {
+      "creditCards": "American Express, MasterCard, Visa, Discover"
+    }
+  }
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the billing provider.
+`organization.id`<br/>*UUID* | UUID of the organisation to which belongs the billing provider. This can only be a organization which is root or reseller.
+`name`<br/>*Object* | The name object of the billing provider.
+`type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
+`providerType`<br/>*string* | The provider for the associated type.
+`createdDate`<br/>*string* | The date the billing provider was created.
+`updatedDate`<br/>*string* | The last date the billing provider was updated.
+`defaultForType`<br/>*UUID* | If this billing provider is the default for the specified type.
+`configurationAttributes`<br/>*Object* | The configuration attribute associated to the provider type. [See possible values](#administration-provider-type-configuration-attribute) 
+
+<!-------------------- PROVIDER TYPE ATTRIBUTES -------------------->
+#### Provider type configuration attribute
+
+Here are the attributes for the `CREDIT_CARD` providers
+
+Provider | Attributes | &nbsp;
+---- | ---- | -----------
+all | `creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -34,6 +34,8 @@ includes:
   - administration/custom_fields
   - administration/quotas
   - administration/activity_log
+  - administration/billing
+  - administration/billing_providers
   - cloudstack
   - cloudstack/compute # Compute section
   - cloudstack/instances


### PR DESCRIPTION
### Fixes [MC-14798](https://cloud-ops.atlassian.net/browse/MC-14798)

#### Changes made
<!-- Changes should match the template provided below -->
- Added the billing providers list and get

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->