### PR TITLE
Add api docs for create and update billing provider

### DIFF
--- a/source/includes/administration/_billing_providers.md
+++ b/source/includes/administration/_billing_providers.md
@@ -31,7 +31,7 @@ curl "https://cloudmc_endpoint/rest/billing_providers" \
       "updatedDate": "2021-05-07T19:21:20Z",
       "defaultForType": true,
       "configurationAttributes": {
-        "creditCards": "American Express,MasterCard,Visa,Discover"
+        "creditCards": "American Express,Mastercard,Visa,Discover"
       }
     }
   ]
@@ -47,7 +47,7 @@ Attributes | &nbsp;
 `providerType`<br/>*string* | The provider for the associated type.
 `createdDate`<br/>*string* | The date the billing provider was created.
 `updatedDate`<br/>*string* | The last date the billing provider was updated.
-`defaultForType`<br/>*UUID* | If this billing provider is the default for the specified type.
+`defaultForType`<br/>*boolean* | If this billing provider is the default for the specified type.
 `configurationAttributes`<br/>*Object* | The configuration attribute associated to the provider type. [See possible values](#administration-provider-type-configuration-attribute)
 
 
@@ -79,7 +79,7 @@ curl "https://cloudmc_endpoint/rest/billing_providers/f26e66a4-755c-4867-b565-ad
     "updatedDate": "2021-05-07T19:21:20Z",
     "defaultForType": true,
     "configurationAttributes": {
-      "creditCards": "American Express,MasterCard,Visa,Discover"
+      "creditCards": "American Express,Mastercard,Visa,Discover"
     }
   }
 }
@@ -94,17 +94,8 @@ Attributes | &nbsp;
 `providerType`<br/>*string* | The provider for the associated type.
 `createdDate`<br/>*string* | The date the billing provider was created.
 `updatedDate`<br/>*string* | The last date the billing provider was updated.
-`defaultForType`<br/>*UUID* | If this billing provider is the default for the specified type.
+`defaultForType`<br/>*boolean* | If this billing provider is the default for the specified type.
 `configurationAttributes`<br/>*Object* | The configuration attribute associated to the provider type. [See possible values](#administration-provider-type-configuration-attribute) 
-
-<!-------------------- PROVIDER TYPE ATTRIBUTES -------------------->
-#### Provider type configuration attribute
-
-Here are the attributes for the `CREDIT_CARD` providers.
-
-Provider | Attributes | &nbsp;
----- | ---- | -----------
-all | `creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field.
 
 <!-------------------- CREATE BILLING PROVIDER -------------------->
 
@@ -125,14 +116,15 @@ curl -X POST "https://cloudmc_endpoint/rest/billing_providers" \
 ```js
 {
   "name": "Chase Credit Card (Dev)",
-	"organization": {
-			"id": "23910576-d29f-4c14-b663-31d728ff49a5"
-	},
-	"type": "CREDIT_CARD",
+  "organization": {
+    "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+  },
+  "type": "CREDIT_CARD",
   "providerType": "chaseCreditCard",
-	"configurationAttributes": {
-		"creditCards": "Visa, Mastercard, American Express, Discover"
-	} 
+  "defaultForType": false,
+  "configurationAttributes": {
+    "creditCards": "Visa, Mastercard, American Express, Discover"
+  }
 }
 ```
 > The above command return JSON structured like this:
@@ -164,18 +156,21 @@ Required | &nbsp;
 `type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
 `providerType`<br/>*string* | The provider for the associated type.
 `configurationAttributes`<br/>*Object* | The configuration attribute associated to the provider type. [See possible values](#administration-provider-type-configuration-attribute) 
-`configurationAttributes.creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field.
 
-<!-------------------- UPDATE IDPS -------------------->
+Optional | &nbsp;
+------- | -----------
+`defaultForType`<br/>*UUID* | If this billing provider is the default for the specified type.
+
+<!-------------------- UPDATE BILLING PROVIDER -------------------->
 
 #### Update billing provider
 
 `PUT /billing_providers/:id`
 
-Update an existing identity provider.
+Update an existing billing provider.
 
 ```shell
-# Updates an existing identity provider
+# Updates an existing billing provider
 curl -X PUT "https://cloudmc_endpoint/rest/billing_providers/c84cfe41-929b-47c9-bde4-b55a10bd2774" \
    -H "MC-Api-Key: your_api_key"
 ```
@@ -185,14 +180,15 @@ curl -X PUT "https://cloudmc_endpoint/rest/billing_providers/c84cfe41-929b-47c9-
 ```js
 {
   "name": "Chase Credit Card (Dev)",
-	"organization": {
-			"id": "23910576-d29f-4c14-b663-31d728ff49a5"
-	},
-	"type": "CREDIT_CARD",
+  "organization": {
+    "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+  },
+  "type": "CREDIT_CARD",
   "providerType": "chaseCreditCard",
-	"configurationAttributes": {
-		"creditCards": "Visa, Mastercard, American Express, Discover"
-	} 
+  "defaultForType": false,
+  "configurationAttributes": {
+    "creditCards": "Visa, Mastercard, American Express, Discover"
+  }
 }
 ```
 > The above command return JSON structured like this:
@@ -203,10 +199,10 @@ curl -X PUT "https://cloudmc_endpoint/rest/billing_providers/c84cfe41-929b-47c9-
     "createdDate": "2021-05-17T20:32:07Z",
     "organization": {
       "id": "23910576-d29f-4c14-b663-31d728ff49a5"
-	  },
+    },
     "name": "Chase Credit Card (Dev)",
     "configurationAttributes": {
-      "creditCards": "Visa, MasterCard, American Express"
+      "creditCards": "Visa, Mastercard, American Express"
     },
     "defaultForType": false,
     "id": "c84cfe41-929b-47c9-bde4-b55a10bd2774",
@@ -224,7 +220,28 @@ Required | &nbsp;
 `type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
 `providerType`<br/>*string* | The provider for the associated type.
 `configurationAttributes`<br/>*Object* | The configuration attribute associated to the provider type. [See possible values](#administration-provider-type-configuration-attribute) 
-`configurationAttributes.creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field.
+
+Optional | &nbsp;
+------- | -----------
+`defaultForType`<br/>*boolean* | If this billing provider is the default for the specified type.
+
+<!-------------------- PROVIDER TYPE ATTRIBUTES -------------------->
+#### Provider type configuration attribute
+
+Here are the attributes for the `CREDIT_CARD` providers.
+
+Provider | Attributes | &nbsp;
+---- | ---- | -----------
+all | `creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field. Possible values are 'Visa', 'Mastercard', 'American Express', 'Discover.
+chaseCreditCard | `hostname`<br/>*string* | Hosted payment hostname.
+chaseCreditCard | `secureId`<br/>*string* | Unique value identifying the client’s Hosted Payment account.
+chaseCreditCard | `secureToken`<br/>*string* | Unique value associated with Hosted Payment account.
+chaseCreditCard | `cssURL`<br/>*string* | Sets the URL of the CSS file used to style the payment form. This value overrides the URL set in the Hosted Payment Page Admin screen.
+chaseCreditCard | `orbitalHostname`<br/>*string* | Orbital API hostname.
+chaseCreditCard | `orbitalUsername`<br/>*string* | Orbital Connection Username set up on Orbital Gateway.
+chaseCreditCard | `orbitalPassword`<br/>*string* | Orbital Connection Password used in conjunction with Orbital Username.
+chaseCreditCard | `orbitalMerchantTerminal`<br/>*string* | Orbital API merchant terminal ID.
+chaseCreditCard | `orbitalMerchantBin`<br/>*string* | Orbital API merchant BIN number.
 
 <!-------------------- DELETE BILLING PROVIDER -------------------->
 #### Delete a billing provider

--- a/source/includes/administration/_billing_providers.md
+++ b/source/includes/administration/_billing_providers.md
@@ -31,7 +31,7 @@ curl "https://cloudmc_endpoint/rest/billing_providers" \
       "updatedDate": "2021-05-07T19:21:20Z",
       "defaultForType": true,
       "configurationAttributes": {
-        "creditCards": "American Express, MasterCard, Visa, Discover"
+        "creditCards": "American Express,MasterCard,Visa,Discover"
       }
     }
   ]
@@ -42,7 +42,7 @@ Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the billing provider.
 `organization.id`<br/>*UUID* | UUID of the organization to which belongs the billing provider. This can only be a organization which is root or reseller.
-`name`<br/>*Object* | The name object of the billing provider.
+`name`<br/>*string* | The name of the billing provider object.
 `type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
 `providerType`<br/>*string* | The provider for the associated type.
 `createdDate`<br/>*string* | The date the billing provider was created.
@@ -79,7 +79,7 @@ curl "https://cloudmc_endpoint/rest/billing_providers/f26e66a4-755c-4867-b565-ad
     "updatedDate": "2021-05-07T19:21:20Z",
     "defaultForType": true,
     "configurationAttributes": {
-      "creditCards": "American Express, MasterCard, Visa, Discover"
+      "creditCards": "American Express,MasterCard,Visa,Discover"
     }
   }
 }
@@ -89,7 +89,7 @@ Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the billing provider.
 `organization.id`<br/>*UUID* | UUID of the organization to which belongs the billing provider. This can only be a organization which is root or reseller.
-`name`<br/>*Object* | The name object of the billing provider.
+`name`<br/>*string* | The name of the billing provider object.
 `type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
 `providerType`<br/>*string* | The provider for the associated type.
 `createdDate`<br/>*string* | The date the billing provider was created.
@@ -105,6 +105,126 @@ Here are the attributes for the `CREDIT_CARD` providers.
 Provider | Attributes | &nbsp;
 ---- | ---- | -----------
 all | `creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field.
+
+<!-------------------- CREATE BILLING PROVIDER -------------------->
+
+#### Create a billing provider
+
+`POST /billing_providers`
+
+Create a new billing provider.
+
+```shell
+# Creates a new billing provider
+curl -X POST "https://cloudmc_endpoint/rest/billing_providers" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```js
+{
+  "name": "Chase Credit Card (Dev)",
+	"organization": {
+			"id": "23910576-d29f-4c14-b663-31d728ff49a5"
+	},
+	"type": "CREDIT_CARD",
+  "providerType": "chaseCreditCard",
+	"configurationAttributes": {
+		"creditCards": "Visa, Mastercard, American Express, Discover"
+	} 
+}
+```
+> The above command return JSON structured like this:
+
+```js
+{
+  "data": {
+    "createdDate": "2021-05-17T19:59:33.387453Z",
+    "organization": {
+      "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+    },
+    "name": "testing API",
+    "configurationAttributes": {
+      "creditCards": "Visa, Mastercard, American Express, Discover"
+    },
+    "defaultForType": false,
+    "id": "8db7cd13-b309-4fb9-b022-1632dbd165d0",
+    "updatedDate": "2021-05-17T19:59:33.387477Z",
+    "type": "CREDIT_CARD",
+    "providerType": "chaseCreditCard"
+  }
+}
+```
+
+Required | &nbsp;
+---------- | -----------
+`name`<br/>*string* | The name of the billing provider object.
+`organization.id`<br/>*UUID* | UUID of the organization to which belongs the billing provider. This can only be a organization which is root or reseller.
+`type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
+`providerType`<br/>*string* | The provider for the associated type.
+`configurationAttributes`<br/>*Object* | The configuration attribute associated to the provider type. [See possible values](#administration-provider-type-configuration-attribute) 
+`configurationAttributes.creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field.
+
+<!-------------------- UPDATE IDPS -------------------->
+
+#### Update billing provider
+
+`PUT /billing_providers/:id`
+
+Update an existing identity provider.
+
+```shell
+# Updates an existing identity provider
+curl -X PUT "https://cloudmc_endpoint/rest/billing_providers/c84cfe41-929b-47c9-bde4-b55a10bd2774" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```js
+{
+  "name": "Chase Credit Card (Dev)",
+	"organization": {
+			"id": "23910576-d29f-4c14-b663-31d728ff49a5"
+	},
+	"type": "CREDIT_CARD",
+  "providerType": "chaseCreditCard",
+	"configurationAttributes": {
+		"creditCards": "Visa, Mastercard, American Express, Discover"
+	} 
+}
+```
+> The above command return JSON structured like this:
+
+```js
+{
+  "data": {
+    "createdDate": "2021-05-17T20:32:07Z",
+    "organization": {
+      "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+	  },
+    "name": "Chase Credit Card (Dev)",
+    "configurationAttributes": {
+      "creditCards": "Visa, MasterCard, American Express"
+    },
+    "defaultForType": false,
+    "id": "c84cfe41-929b-47c9-bde4-b55a10bd2774",
+    "updatedDate": "2021-05-17T21:09:49Z",
+    "type": "CREDIT_CARD",
+    "providerType": "chaseCreditCard"
+  }
+}
+```
+
+Required | &nbsp;
+---------- | -----------
+`name`<br/>*string* | The name of the billing provider object.
+`organization.id`<br/>*UUID* | UUID of the organization to which belongs the billing provider. This can only be a organization which is root or reseller.
+`type`<br/>*string* | The type of billing provider. Possible values are: `CREDIT_CARD`.
+`providerType`<br/>*string* | The provider for the associated type.
+`configurationAttributes`<br/>*Object* | The configuration attribute associated to the provider type. [See possible values](#administration-provider-type-configuration-attribute) 
+`configurationAttributes.creditCards`<br/>*string* | The type of credit card accepted. This is a comma separated field.
 
 <!-------------------- DELETE BILLING PROVIDER -------------------->
 #### Delete a billing provider


### PR DESCRIPTION
### Fixes [MC-14793](https://cloud-ops.atlassian.net/browse/MC-14793])

#### Changes made
- added docs for create, update billing service provider

#### Related PRs
- [core](https://github.com/cloudops/cloudmc-core/pull/1276)
- [ui](https://github.com/cloudops/cloudmc-ui/pull/1442)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->