### PR TITLE
Fix custom navigation resource endpoint

### DIFF
--- a/source/includes/administration/_custom_navigation.md
+++ b/source/includes/administration/_custom_navigation.md
@@ -5,7 +5,7 @@ Custom navigation API allows to customize the navigation per-reseller. Most nota
 <!-------------------- List CUSTOM NAV -------------------->
 ### List custom navigation
 
-`GET /custom_navigation`
+`GET /navigation`
 
 ```shell
 
@@ -47,7 +47,7 @@ Attributes | &nbsp;
 <!-------------------- Get CUSTOM NAV -------------------->
 ### Get custom navigation
 
-`GET /custom_navigation/:id`
+`GET /navigation/:id`
 
 
 ```shell
@@ -123,7 +123,7 @@ Attributes | &nbsp;
 <!-------------------- Create CUSTOM NAV -------------------->
 ### Create custom navigation
 
-`POST /custom_navigation`
+`POST /navigation`
 
 ```shell 
   --request POST \
@@ -208,7 +208,7 @@ Optional | &nbsp;
 <!-------------------- Update CUSTOM NAV -------------------->
 ### Update custom navigation
 
-`PUT /custom_navigation/:id`
+`PUT /navigation/:id`
 
 ```shell 
 curl --request PUT \
@@ -265,7 +265,7 @@ Optional | &nbsp;
 
 ### Delete custom navigation
 
-`DELETE /custom_navigation/:id`
+`DELETE /navigation/:id`
 
 ```shell 
 curl --request DELETE \


### PR DESCRIPTION
### Fix custom navigation endpoint

#### Changes made
- Should be `/navigation` as pointed out by @jasondias9 

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->