### PR TITLE
MC-14932: Rename skipEnvironmentPicker to skipEnvironmentList

### DIFF
--- a/source/includes/administration/_custom_navigation.md
+++ b/source/includes/administration/_custom_navigation.md
@@ -122,7 +122,7 @@ Attributes | &nbsp;
 `tabs.serviceConnection`<br/>*UUID* | The service connection id for a tab of type `SERVICE`.
 `tabs.workspace`<br/>*String* | The workspace name for a tab of type `SERVICE`. 
 `tabs.key`<br/>*String* | The view key for a tab of type `SYSTEM`. 
-`tabs.skipEnvironmentPicker`<br/>*boolean* | Skip the environment picker if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`. 
+`tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`. 
 
 <!-------------------- Create CUSTOM NAV -------------------->
 ### Create custom navigation
@@ -209,7 +209,7 @@ Optional | &nbsp;
 `tabs.serviceConnection`<br/>*UUID* | *Required* if type `SERVICE`. The service connection id for a tab of type `SERVICE`.
 `tabs.workspace`<br/>*String* | *Required* if type `SERVICE`. The workspace name for a tab of type `SERVICE`. 
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
-`tabs.skipEnvironmentPicker`<br/>*boolean* | Skip the environment picker if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
+`tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 
 <!-------------------- Update CUSTOM NAV -------------------->
 ### Update custom navigation
@@ -267,7 +267,7 @@ Optional | &nbsp;
 `tabs.serviceConnection`<br/>*UUID* | *Required* if type `SERVICE`. The service connection id for a tab of type `SERVICE`.
 `tabs.workspace`<br/>*String* | *Required* if type `SERVICE`. The workspace name for a tab of type `SERVICE`. 
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
-`tabs.skipEnvironmentPicker`<br/>*boolean* | Skip the environment picker if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
+`tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 
 <!-------------------- Delete CUSTOM NAV -------------------->
 


### PR DESCRIPTION
### Fixes [MC-14932](https://cloud-ops.atlassian.net/browse/MC-14932)

#### Changes made
<!-- Changes should match the template provided below -->
- Rename skipEnvironmentPicker to skipEnvironmentList

#### Related PRs
- [Core 1325](https://github.com/cloudops/cloudmc-core/pull/1325)
- [Core 1325](https://github.com/cloudops/cloudmc-core/pull/1567)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->