### PR TITLE
MC-14911: updated docs to include promote panel

### DIFF
--- a/source/includes/administration/_custom_navigation.md
+++ b/source/includes/administration/_custom_navigation.md
@@ -123,6 +123,7 @@ Attributes | &nbsp;
 `tabs.workspace`<br/>*String* | The workspace name for a tab of type `SERVICE`. 
 `tabs.key`<br/>*String* | The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentPicker`<br/>*boolean* | Skip the environment picker if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`. 
+`tabs.promotePanel`<br/>*boolean* | Promote the menu items from the tab's workspace to the main menu. Configurable for a tab of type `SERVICE`.
 
 <!-------------------- Create CUSTOM NAV -------------------->
 ### Create custom navigation
@@ -148,6 +149,19 @@ Attributes | &nbsp;
         "fr": "Usagers"
       }
     },
+    {
+      "type": "SERVICE",
+      "name": {
+        "en": "Edge compute",
+        "fr": "Edge compute"
+      },
+      "serviceConnection": {
+        "id": "2d49e70f-e4f8-43e3-b730-92328174214sa21"
+      },
+      "workspace": "compute",
+      "promotePanel": true,
+      "skipEnvironmentPicker": true
+		},
     {
       "type": "COMING_SOON",
       "name": {
@@ -179,11 +193,27 @@ Attributes | &nbsp;
         "key": "users"
       },
       {
+        "workspace": "compute",
+        "name": {
+          "en": "Edge compute",
+          "fr": "Edge compute"
+        },
+        "icon": "fa fa-server",
+        "rank": 1,
+        "skipEnvironmentPicker": true,
+        "id": "6080bdb2-ceda-4774-aa28-c7f98cd804a4",
+        "promotePanel": true,
+        "type": "SERVICE",
+        "serviceConnection": {
+          "id": "2d49e70f-e4f8-43e3-b730-92328174214sa21"
+        }
+      },
+      {
         "name": {
           "en": "hot new feature",
           "fr": "hot new feature fr"
         },
-        "rank": 1,
+        "rank": 2,
         "id": "cb36c538-6f6b-47af-bfa8-daad56ce58ed",
         "type": "COMING_SOON"
       }
@@ -210,6 +240,8 @@ Optional | &nbsp;
 `tabs.workspace`<br/>*String* | *Required* if type `SERVICE`. The workspace name for a tab of type `SERVICE`. 
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentPicker`<br/>*boolean* | Skip the environment picker if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
+`tabs.promotePanel`<br/>*boolean* | Promote the menu items from the tab's workspace to the main menu. Configurable for a tab of type `SERVICE`.
+
 
 <!-------------------- Update CUSTOM NAV -------------------->
 ### Update custom navigation
@@ -268,6 +300,7 @@ Optional | &nbsp;
 `tabs.workspace`<br/>*String* | *Required* if type `SERVICE`. The workspace name for a tab of type `SERVICE`. 
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentPicker`<br/>*boolean* | Skip the environment picker if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
+`tabs.promotePanel`<br/>*boolean* | Promote the menu items from the tab's workspace to the main menu. Configurable for a tab of type `SERVICE`.
 
 <!-------------------- Delete CUSTOM NAV -------------------->
 

--- a/source/includes/administration/_custom_navigation.md
+++ b/source/includes/administration/_custom_navigation.md
@@ -161,7 +161,7 @@ Attributes | &nbsp;
       "workspace": "compute",
       "promotePanel": true,
       "skipEnvironmentPicker": true
-		},
+    },
     {
       "type": "COMING_SOON",
       "name": {


### PR DESCRIPTION
### Fixes [MC-14911](https://cloud-ops.atlassian.net/browse/MC-14911)

#### Changes made
<!-- Changes should match the template provided below -->
- Updated docs to include promote panel option

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->