### PR TITLE
MC-15297: doc for retainEnvironment on tabs

### DIFF
--- a/source/includes/administration/_custom_navigation.md
+++ b/source/includes/administration/_custom_navigation.md
@@ -124,7 +124,7 @@ Attributes | &nbsp;
 `tabs.key`<br/>*String* | The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 `tabs.showSubTabs`<br/>*boolean* | Whether or not to show the subtabs, as defined by the plugin, underneath the menu tab. Configurable for a tab of type `SERVICE`.
-`tabs.retainEnvironment`<br/>*boolean* | Skip the environment picker and retain the environment context when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
+`tabs.retainEnvironment`<br/>*boolean* | Retain the selected environment when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
 
 <!-------------------- Create CUSTOM NAV -------------------->
 ### Create custom navigation
@@ -242,7 +242,7 @@ Optional | &nbsp;
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 `tabs.showSubTabs`<br/>*boolean* | Whether or not to show the subtabs, as defined by the plugin, underneath the menu tab. Configurable for a tab of type `SERVICE`.
-`tabs.retainEnvironment`<br/>*boolean* | Skip the environment picker and retain the environment context when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
+`tabs.retainEnvironment`<br/>*boolean* | Retain the selected environment when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
 
 <!-------------------- Update CUSTOM NAV -------------------->
 ### Update custom navigation
@@ -302,7 +302,7 @@ Optional | &nbsp;
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 `tabs.showSubTabs`<br/>*boolean* | Whether or not to show the subtabs, as defined by the plugin, underneath the menu tab. Configurable for a tab of type `SERVICE`.
-`tabs.retainEnvironment`<br/>*boolean* | Skip the environment picker and retain the environment context when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
+`tabs.retainEnvironment`<br/>*boolean* | Retain the selected environment when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
 
 <!-------------------- Delete CUSTOM NAV -------------------->
 

--- a/source/includes/administration/_custom_navigation.md
+++ b/source/includes/administration/_custom_navigation.md
@@ -302,7 +302,7 @@ Optional | &nbsp;
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 `tabs.showSubTabs`<br/>*boolean* | Whether or not to show the subtabs, as defined by the plugin, underneath the menu tab. Configurable for a tab of type `SERVICE`.
-`tabs.retainEnvironment`<br/>*Boolean* | Retain the selected environment when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
+`tabs.retainEnvironment`<br/>*boolean* | Retain the selected environment when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
 
 <!-------------------- Delete CUSTOM NAV -------------------->
 

--- a/source/includes/administration/_custom_navigation.md
+++ b/source/includes/administration/_custom_navigation.md
@@ -302,7 +302,7 @@ Optional | &nbsp;
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 `tabs.showSubTabs`<br/>*boolean* | Whether or not to show the subtabs, as defined by the plugin, underneath the menu tab. Configurable for a tab of type `SERVICE`.
-`tabs.retainEnvironment`<br/>*boolean* | Retain the selected environment when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
+`tabs.retainEnvironment`<br/>*Boolean* | Retain the selected environment when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
 
 <!-------------------- Delete CUSTOM NAV -------------------->
 

--- a/source/includes/administration/_custom_navigation.md
+++ b/source/includes/administration/_custom_navigation.md
@@ -124,6 +124,8 @@ Attributes | &nbsp;
 `tabs.key`<br/>*String* | The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 `tabs.showSubTabs`<br/>*boolean* | Whether or not to show the subtabs, as defined by the plugin, underneath the menu tab. Configurable for a tab of type `SERVICE`.
+`tabs.retainEnvironment`<br/>*boolean* | Skip the environment picker and retain the environment context when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
+
 <!-------------------- Create CUSTOM NAV -------------------->
 ### Create custom navigation
 
@@ -240,6 +242,7 @@ Optional | &nbsp;
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 `tabs.showSubTabs`<br/>*boolean* | Whether or not to show the subtabs, as defined by the plugin, underneath the menu tab. Configurable for a tab of type `SERVICE`.
+`tabs.retainEnvironment`<br/>*boolean* | Skip the environment picker and retain the environment context when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
 
 <!-------------------- Update CUSTOM NAV -------------------->
 ### Update custom navigation
@@ -299,6 +302,8 @@ Optional | &nbsp;
 `tabs.key`<br/>*String* |  *Required* if type `SYSTEM`. The view key for a tab of type `SYSTEM`. 
 `tabs.skipEnvironmentList`<br/>*boolean* | Skip the environment list if there is a single environment associated with the service tab. Configurable for a tab of type `SERVICE`.
 `tabs.showSubTabs`<br/>*boolean* | Whether or not to show the subtabs, as defined by the plugin, underneath the menu tab. Configurable for a tab of type `SERVICE`.
+`tabs.retainEnvironment`<br/>*boolean* | Skip the environment picker and retain the environment context when navigating between tabs with the same service connection. Configurable for a tab of type `SERVICE`. 
+
 <!-------------------- Delete CUSTOM NAV -------------------->
 
 ### Delete custom navigation


### PR DESCRIPTION
### Fixes [MC-15297](https://cloud-ops.atlassian.net/browse/MC-15297)

#### Changes made
Add retainEnvironment boolean.

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->