### PR TITLE
MC-15238: Added documentation for add discount

### DIFF
--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -47,17 +47,17 @@ Optional Query Parameters | &nbsp;
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the discount.
-`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discounts. To provide a 20 percent discount, set the discount value to 20.
-`durationMonths`<br/>*integer* | Duration of the discount. If not provided the discount will last indefinitely once applied to a customer, or until credit values are reached.
+`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discounts. All pricing products specified will have the discount value applied to them.
+`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely once applied to a customer, or until credit values are reached.
 `type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
-`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the package..
+`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the package. .
 `discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
 `isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false.
-`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products specified will have the discount value applied to them.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All products within the categories specified will have the discount value applied to them.
 `name`<br/>*Map[String, String]* | Map of language short codes to name translations for the discount.
 `appliedPricing`<br/>*Object* | The object representing the applied pricing owning the discount.
 `appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
-`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount.
+`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `startDate`<br/>*date* | The start date of the discount.
 `cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it.
 `status`<br/>*enum* | The status of the discount. Possible values are : UPCOMING, CURRENT, ENDED.

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -40,24 +40,24 @@ curl "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6
   ]
 }
 ```
+Optional Query Parameters | &nbsp;
+---------- | -----------
+`type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
 
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the discount.
-`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount.
-`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired product IDs and discounts. To provide a 20 percent discount, set the discount value to 20.
-`durationMonths`<br/>*integer* | Duration of the discount.
+`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discounts. To provide a 20 percent discount, set the discount value to 20.
+`durationMonths`<br/>*integer* | Duration of the discount. If not provided the discount will last indefinitely once applied to a customer, or until credit values are reached.
 `type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
-`packageDiscount`<br/>*BigDecimal* | The discount applied to a package.
+`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the package..
 `discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
 `isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false.
-`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between the desired categories IDs and discounts. To provide a 20 percent discount, set the discount value to 20.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All products within the categories specified will have the discount value applied to them.
 `name`<br/>*Map[String, String]* | Map of language short codes to name translations for the discount.
 `appliedPricing`<br/>*Object* | The object representing the applied pricing owning the discount.
 `appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
+`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount.
 `startDate`<br/>*date* | The start date of the discount.
+`cutoffDate`<br/>*date* | The end date of the discount availability.
 `status`<br/>*enum* | The status of the discount. Possible values are : UPCOMING, CURRENT, ENDED.
-
-Optional Query Parameters | &nbsp;
----------- | -----------
-`type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -70,7 +70,7 @@ Attributes | &nbsp;
 
 `POST /applied_pricings/:applied_pricing_id/discounts`
 
-Retrieves the list of discounts associated with an applied pricing.
+Creates a new discount 
 
 ```shell
 # Creates a new discount

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -44,7 +44,7 @@ curl "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the discount.
-`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount..
+`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount.
 `discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired product IDs and discounts. To provide a 20 percent discount, set the discount value to 20.
 `durationMonths`<br/>*integer* | Duration of the discount.
 `type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -1,0 +1,63 @@
+## Discounts
+
+<!-------------------- LIST DISCOUNTS -------------------->
+### List discounts
+
+`GET /applied_pricings/:applied_pricing_id/discounts?type=:type`
+
+Retrieves the list of discounts associated with an applied pricing.
+
+```shell
+# Retrieve applied pricing list
+curl "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts?type=PERCENTAGE" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "applyToNewCustomersOnly": true,
+      "discountedProducts": {},
+      "durationMonths": 22354,
+      "type": "PERCENTAGE",
+      "packageDiscount": 20.0,
+      "discountScope": "ALL_PRODUCTS",
+      "isDeactivated": true,
+      "discountedCategories": {},
+      "name": {
+        "en": "Summer Discount",
+        "fr": "Réduction Estival"
+      },
+      "id": "18db7bc6-8be1-48bb-bab1-77a7d696fa3b",
+      "appliedPricing": {
+        "id": "efd32752-c6f2-45cf-b494-cc6be8a45845"
+      },
+      "startDate": "2021-07-20T15:57:16.132Z",
+      "status": "CURRENT"
+    }
+  ]
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the discount.
+`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount..
+`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired product IDs and discounts. To provide a 20 percent discount, set the discount value to 20.
+`durationMonths`<br/>*integer* | Duration of the discount.
+`type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
+`packageDiscount`<br/>*BigDecimal* | The discount applied to a package.
+`discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
+`isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false..
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between the desired categories IDs and discounts. To provide a 20 percent discount, set the discount value to 20.
+`name`<br/>*Map[String, String]* | Map of language short codes to name translations for the discount.
+`appliedPricing`<br/>*Object* | The object representing the applied pricing owning the discount.
+`appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
+`startDate`<br/>*date* | The start date of the discount.
+`status`<br/>*enum* | The status of the discount. Possible values are : UPCOMING, CURRENT, ENDED.
+
+Optional Query Parameters | &nbsp;
+---------- | -----------
+`type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -50,7 +50,7 @@ Attributes | &nbsp;
 `type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
 `packageDiscount`<br/>*BigDecimal* | The discount applied to a package.
 `discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
-`isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false..
+`isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false.
 `discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between the desired categories IDs and discounts. To provide a 20 percent discount, set the discount value to 20.
 `name`<br/>*Map[String, String]* | Map of language short codes to name translations for the discount.
 `appliedPricing`<br/>*Object* | The object representing the applied pricing owning the discount.

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -55,14 +55,14 @@ Attributes | &nbsp;
 `packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing.
 `discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
 `isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false.
-`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within the categories specified will have the discount value applied to them.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them.
 `name`<br/>*Map[String, String]* | The name translations of the discount.
-`appliedPricing`<br/>*Object* | The object representing the applied pricing owning the discount.
+`appliedPricing`<br/>*Object* | The applied pricing being discounted.
 `appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
 `applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `startDate`<br/>*date* | The start date of the discount.
 `cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date.
-`status`<br/>*enum* | The status of the discount. Possible values are : UPCOMING, CURRENT, ENDED.
+`status`<br/>*enum* | The status of the discount. Possible values are: UPCOMING, CURRENT, ENDED.
 
 
 <!-------------------- CREATE DISCOUNTS -------------------->
@@ -130,12 +130,12 @@ curl -X POST "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-
 Required | &nbsp;
 ------- | -----------
 `name`<br/>*Map[String, String]* | The name translations of the discount.
-`type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
+`type`<br/>*enum* | The type of the discount. It can be either "PERCENTAGE" or "CREDIT".
 `startDate`<br/>*date* | The start date of the discount.
 `applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
-`discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
+`discountScope`<br/>*enum* | The scope of the discount. It can be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
 `packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing. Only required if the scope is "ALL_PRODUCTS". The value must be between (0,100] for a percentage discount and greater than 0 for a credit.
-`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within the categories specified will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
 `discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discount values. All pricing products specified will have the discount value applied to them. Required to be non-empty if scope is "PRODUCTS". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
 
 Optional | &nbsp;

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -1,5 +1,7 @@
 ## Discounts
 
+The discount allows the assignment of a percentage discount or credit to an applied pricing.
+
 <!-------------------- LIST DISCOUNTS -------------------->
 ### List discounts
 
@@ -48,16 +50,95 @@ Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the discount.
 `discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discounts. All pricing products specified will have the discount value applied to them.
-`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely once applied to a customer, or until credit values are reached.
+`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
 `type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
-`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the package. .
+`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing.
 `discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
 `isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false.
-`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All products within the categories specified will have the discount value applied to them.
-`name`<br/>*Map[String, String]* | Map of language short codes to name translations for the discount.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within the categories specified will have the discount value applied to them.
+`name`<br/>*Map[String, String]* | The name translations of the discount.
 `appliedPricing`<br/>*Object* | The object representing the applied pricing owning the discount.
 `appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
 `applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `startDate`<br/>*date* | The start date of the discount.
-`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it.
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date.
 `status`<br/>*enum* | The status of the discount. Possible values are : UPCOMING, CURRENT, ENDED.
+
+
+<!-------------------- CREATE DISCOUNTS -------------------->
+### Create discounts
+
+`POST /applied_pricings/:applied_pricing_id/discounts`
+
+Retrieves the list of discounts associated with an applied pricing.
+
+```shell
+# Creates a new discount
+curl -X POST "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts" \
+   -H "MC-Api-Key: your_api_key"
+```
+> Request body example:
+
+```json
+{
+  "name": {
+    "en": "Summer Discount",
+    "fr": "Réduction Estival"
+  },
+  "startDate": "2021-07-23T00:00:00.000Z",
+  "type": "PERCENTAGE",
+  "durationMonths": 4,
+  "discountedProducts": {},
+  "discountedCategories": {
+    "8cf73cc0-b86e-49b4-a102-6102894f7955": 2, 
+    "00358632-5c9a-4164-a9a9-df271a9c06a9": 22
+  },
+  "discountScope": "CATEGORIES", 
+  "cutoffDate": "2021-07-24T00:00:00.000Z",
+  "applyToNewCustomersOnly": false,
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+      "applyToNewCustomersOnly": false,
+      "discountedProducts": {},
+      "durationMonths": 4,
+      "type": "PERCENTAGE",
+      "discountScope": "CATEGORIES",
+      "discountedCategories": {
+        "8cf73cc0-b86e-49b4-a102-6102894f7955": 2, 
+        "00358632-5c9a-4164-a9a9-df271a9c06a9": 22
+      },  
+      "name": {
+        "en": "Summer Discount",
+        "fr": "Réduction Estival"
+      },
+      "id": "18db7bc6-8be1-48bb-bab1-77a7d696fa3b",
+      "appliedPricing": {
+        "id": "efd32752-c6f2-45cf-b494-cc6be8a45845"
+      },
+      "startDate": "2021-07-23T00:00:00.000Z",
+      "cutoffDate": "2021-07-24T00:00:00.000Z",
+  }
+}
+```
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*Map[String, String]* | The name translations of the discount.
+`type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
+`startDate`<br/>*date* | The start date of the discount.
+`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
+`discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
+`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing. Only required if the scope is "ALL_PRODUCTS". The value must be between (0,100] for a percentage discount and greater than 0 for a credit.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within the categories specified will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
+`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discount values. All pricing products specified will have the discount value applied to them. Required to be non-empty if scope is "PRODUCTS". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
+
+Optional | &nbsp;
+------- | -----------
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date. 
+`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -53,11 +53,11 @@ Attributes | &nbsp;
 `packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the package..
 `discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
 `isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false.
-`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All products within the categories specified will have the discount value applied to them.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products specified will have the discount value applied to them.
 `name`<br/>*Map[String, String]* | Map of language short codes to name translations for the discount.
 `appliedPricing`<br/>*Object* | The object representing the applied pricing owning the discount.
 `appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
 `applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount.
 `startDate`<br/>*date* | The start date of the discount.
-`cutoffDate`<br/>*date* | The end date of the discount availability.
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it.
 `status`<br/>*enum* | The status of the discount. Possible values are : UPCOMING, CURRENT, ENDED.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -22,6 +22,7 @@ includes:
   - administration/products
   - administration/pricings
   - administration/applied_pricings
+  - administration/discounts
   - administration/authentication
   - administration/identity_providers
   - administration/service_providers


### PR DESCRIPTION
### Fixes [MC-15238](https://cloud-ops.atlassian.net/browse/MC-15238)

#### Changes made
<!-- Changes should match the template provided below -->
- Added documentation for add discount 
- Updated list discounts to be consistent 

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->