### PR TITLE
MC-15284: Add edit API documentation

### DIFF
--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -61,7 +61,7 @@ Attributes | &nbsp;
 `appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
 `applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `startDate`<br/>*date* | The start date of the discount.
-`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date.
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date.
 `status`<br/>*enum* | The status of the discount. Possible values are: UPCOMING, CURRENT, ENDED.
 
 <!-------------------- GET DISCOUNT -------------------->
@@ -73,7 +73,7 @@ Retrieves a discount's details.
 
 ```shell
 # Retrieve applied pricing list
-curl "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/08695c90-3e41-4be8-a3a3-df964620ba62" \
+curl "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/18db7bc6-8be1-48bb-bab1-77a7d696fa3b" \
    -H "MC-Api-Key: your_api_key"
 ```
 > The above command returns a JSON structured like this:
@@ -120,7 +120,7 @@ Attributes | &nbsp;
 `appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
 `applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `startDate`<br/>*date* | The start date of the discount.
-`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date.
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date.
 `status`<br/>*enum* | The status of the discount. Possible values are: UPCOMING, CURRENT, ENDED.
 
 <!-------------------- CREATE DISCOUNT -------------------->
@@ -198,7 +198,7 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
-`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date. 
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date. 
 `durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
 
 <!-------------------- EDIT DISCOUNT -------------------->
@@ -210,7 +210,7 @@ Edit an existing discount that hasn't ended. Only the name and cutoff date can b
 
 ```shell
 # Edit an existing discount
-curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/08695c90-3e41-4be8-a3a3-df964620ba62" \
+curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/18db7bc6-8be1-48bb-bab1-77a7d696fa3b" \
    -H "MC-Api-Key: your_api_key"
 ```
 > Request body example:
@@ -271,5 +271,5 @@ Optional | &nbsp;
 `packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing. Only required if the scope is "ALL_PRODUCTS". The value must be between (0,100] for a percentage discount and greater than 0 for a credit.
 `discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
 `discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discount values. All pricing products specified will have the discount value applied to them. Required to be non-empty if scope is "PRODUCTS". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
-`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date. 
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date. 
 `durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -64,9 +64,67 @@ Attributes | &nbsp;
 `cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date.
 `status`<br/>*enum* | The status of the discount. Possible values are: UPCOMING, CURRENT, ENDED.
 
+<!-------------------- GET DISCOUNT -------------------->
+### Get discount
 
-<!-------------------- CREATE DISCOUNTS -------------------->
-### Create discounts
+`GET /applied_pricings/:applied_pricing_id/discounts/:id`
+
+Retrieves a discount's details.
+
+```shell
+# Retrieve applied pricing list
+curl "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/08695c90-3e41-4be8-a3a3-df964620ba62" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "applyToNewCustomersOnly": true,
+      "discountedProducts": {},
+      "durationMonths": 22354,
+      "type": "PERCENTAGE",
+      "packageDiscount": 20.0,
+      "discountScope": "ALL_PRODUCTS",
+      "isDeactivated": true,
+      "discountedCategories": {},
+      "name": {
+        "en": "Summer Discount",
+        "fr": "Réduction Estival"
+      },
+      "id": "18db7bc6-8be1-48bb-bab1-77a7d696fa3b",
+      "appliedPricing": {
+        "id": "efd32752-c6f2-45cf-b494-cc6be8a45845"
+      },
+      "startDate": "2021-07-20T15:57:16.132Z",
+      "status": "CURRENT"
+    }
+  ]
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the discount.
+`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discounts. All pricing products specified will have the discount value applied to them.
+`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
+`type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
+`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing.
+`discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
+`isDeactivated`<br/>*boolean* | Whether or not the discount is deactivated. Defaults to false.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them.
+`name`<br/>*Map[String, String]* | The name translations of the discount.
+`appliedPricing`<br/>*Object* | The applied pricing being discounted.
+`appliedPricing.id`<br/>*UUID* | The UUID of the applied pricing.
+`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
+`startDate`<br/>*date* | The start date of the discount.
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date.
+`status`<br/>*enum* | The status of the discount. Possible values are: UPCOMING, CURRENT, ENDED.
+
+<!-------------------- CREATE DISCOUNT -------------------->
+### Create discount
 
 `POST /applied_pricings/:applied_pricing_id/discounts`
 
@@ -140,5 +198,78 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date. 
+`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
+
+<!-------------------- EDIT DISCOUNT -------------------->
+### Edit discount
+
+`PUT /applied_pricings/:applied_pricing_id/discounts/:id`
+
+Edit an existing discount that hasn't ended. Only the name and cutoff date can be edited for current discount. All fields can be edited for upcoming discounts.
+
+```shell
+# Edit an existing discount
+curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/08695c90-3e41-4be8-a3a3-df964620ba62" \
+   -H "MC-Api-Key: your_api_key"
+```
+> Request body example:
+
+```json
+{
+  "name": {
+    "en": "End of summer Discount",
+    "fr": "Réduction estival fin d'été"
+  },
+  "durationMonths": 4,
+  "discountedProducts": {},
+  "discountedCategories": {
+    "8cf73cc0-b86e-49b4-a102-6102894f7955": 2, 
+    "00358632-5c9a-4164-a9a9-df271a9c06a9": 22
+  },
+  "discountScope": "CATEGORIES", 
+  "cutoffDate": "2021-08-24T00:00:00.000Z",
+  "applyToNewCustomersOnly": false,
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+      "applyToNewCustomersOnly": false,
+      "discountedProducts": {},
+      "durationMonths": 4,
+      "type": "PERCENTAGE",
+      "discountScope": "CATEGORIES",
+      "discountedCategories": {
+        "8cf73cc0-b86e-49b4-a102-6102894f7955": 2, 
+        "00358632-5c9a-4164-a9a9-df271a9c06a9": 22
+      },  
+      "name": {
+        "en": "End of summer Discount",
+        "fr": "Réduction estival fin d'été"
+      },
+      "id": "18db7bc6-8be1-48bb-bab1-77a7d696fa3b",
+      "appliedPricing": {
+        "id": "efd32752-c6f2-45cf-b494-cc6be8a45845"
+      },
+      "startDate": "2021-07-23T00:00:00.000Z",
+      "cutoffDate": "2021-08-24T00:00:00.000Z",
+      "status": "UPCOMING"
+  }
+}
+```
+
+Optional | &nbsp;
+------- | -----------
+`name`<br/>*Map[String, String]* | The name translations of the discount.
+`startDate`<br/>*date* | The start date of the discount.
+`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
+`discountScope`<br/>*enum* | The scope of the discount. It can be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
+`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing. Only required if the scope is "ALL_PRODUCTS". The value must be between (0,100] for a percentage discount and greater than 0 for a credit.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
+`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discount values. All pricing products specified will have the discount value applied to them. Required to be non-empty if scope is "PRODUCTS". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
 `cutoffDate`<br/>*date* | The date on which the discount will no longer be available to customers who have not already received it. If not provided, the discount will always be available after the start date. 
 `durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.


### PR DESCRIPTION
### Fixes [MC-15284](https://cloud-ops.atlassian.net/browse/MC-15284)

#### Changes made
- Added documentation for edit discount

#### Related PRs
- https://github.com/cloudops/cloudmc-api-docs/pull/406

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->