### PR TITLE
MC-15283: deactivate doc

### DIFF
--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -7,7 +7,7 @@ The discount allows the assignment of a percentage discount or credit to an appl
 
 `GET /applied_pricings/:applied_pricing_id/discounts?type=:type`
 
-Retrieves the list of discounts associated with an applied pricing.
+Retrieve the list of discounts associated with an applied pricing.
 
 ```shell
 # Retrieve applied pricing list
@@ -69,7 +69,7 @@ Attributes | &nbsp;
 
 `GET /applied_pricings/:applied_pricing_id/discounts/:id`
 
-Retrieves a discount's details.
+Retrieve a discount's details.
 
 ```shell
 # Retrieve applied pricing list
@@ -128,7 +128,7 @@ Attributes | &nbsp;
 
 `POST /applied_pricings/:applied_pricing_id/discounts`
 
-Creates a new discount 
+Create a new discount 
 
 ```shell
 # Creates a new discount
@@ -279,7 +279,7 @@ Optional | &nbsp;
 
 `DELETE /applied_pricings/:applied_pricing_id/discounts/:id`
 
-Deletes a discount. This operation can only be performed on discounts that have status UPCOMING.
+Delete a discount. This operation can only be performed on discounts that have status UPCOMING.
 
 ```shell
 curl -X DELETE "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/18db7bc6-8be1-48bb-bab1-77a7d696fa3b" \
@@ -298,7 +298,7 @@ curl -X DELETE "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45c
 
 `PUT /applied_pricings/:applied_pricing_id/discounts/:id/deactivate`
 
-Deactivates a discount. This operation can only be performed on discounts that have status CURRENT or ENDED.
+Deactivate a discount. This operation can only be performed on discounts that have status CURRENT or ENDED.
 Deactivated is a final state, cannot be reactivated.
 
 ```shell

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -334,16 +334,3 @@ curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b
   }
 }
 ```
-
-Optional | &nbsp;
-------- | -----------
-`name`<br/>*Map[String, String]* | The name translations of the discount.
-`startDate`<br/>*date* | The start date of the discount.
-`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
-`discountScope`<br/>*enum* | The scope of the discount. It can be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
-`isDeactivated`<br/>*boolean* | If true, the discount is deactivated. Deactivated is a final state, it cannot be reactivated.
-`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing. Only required if the scope is "ALL_PRODUCTS". The value must be between (0,100] for a percentage discount and greater than 0 for a credit.
-`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
-`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discount values. All pricing products specified will have the discount value applied to them. Required to be non-empty if scope is "PRODUCTS". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
-`cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date. 
-`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.

--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -279,7 +279,7 @@ Optional | &nbsp;
 
 `DELETE /applied_pricings/:applied_pricing_id/discounts/:id`
 
-Delete a discount. This operation can only be performed on discounts that have state UPCOMING.
+Deletes a discount. This operation can only be performed on discounts that have status UPCOMING.
 
 ```shell
 curl -X DELETE "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/18db7bc6-8be1-48bb-bab1-77a7d696fa3b" \
@@ -293,3 +293,57 @@ curl -X DELETE "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45c
   "taskStatus": "SUCCESS"
 }
 ```
+
+### Deactivate discount
+
+`PUT /applied_pricings/:applied_pricing_id/discounts/:id/deactivate`
+
+Deactivates a discount. This operation can only be performed on discounts that have status CURRENT or ENDED.
+Deactivated is a final state, cannot be reactivated.
+
+```shell
+curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6be8a45845/discounts/18db7bc6-8be1-48bb-bab1-77a7d696fa3b/deactivate" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+      "applyToNewCustomersOnly": false,
+      "discountedProducts": {},
+      "durationMonths": 4,
+      "type": "PERCENTAGE",
+      "discountScope": "CATEGORIES",
+      "isDeactivated": true,
+      "discountedCategories": {
+        "8cf73cc0-b86e-49b4-a102-6102894f7955": 2, 
+        "00358632-5c9a-4164-a9a9-df271a9c06a9": 22
+      },  
+      "name": {
+        "en": "End of summer Discount",
+        "fr": "Réduction estival fin d'été"
+      },
+      "id": "18db7bc6-8be1-48bb-bab1-77a7d696fa3b",
+      "appliedPricing": {
+        "id": "efd32752-c6f2-45cf-b494-cc6be8a45845"
+      },
+      "startDate": "2020-07-23T00:00:00.000Z",
+      "cutoffDate": "2020-08-24T00:00:00.000Z",
+      "status": "ENDED"
+  }
+}
+```
+
+Optional | &nbsp;
+------- | -----------
+`name`<br/>*Map[String, String]* | The name translations of the discount.
+`startDate`<br/>*date* | The start date of the discount.
+`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
+`discountScope`<br/>*enum* | The scope of the discount. It can be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
+`isDeactivated`<br/>*boolean* | If true, the discount is deactivated. Deactivated is a final state, it cannot be reactivated.
+`packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing. Only required if the scope is "ALL_PRODUCTS". The value must be between (0,100] for a percentage discount and greater than 0 for a credit.
+`discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
+`discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discount values. All pricing products specified will have the discount value applied to them. Required to be non-empty if scope is "PRODUCTS". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
+`cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date. 
+`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.


### PR DESCRIPTION
### Fixes [MC-15283](https://cloud-ops.atlassian.net/browse/MC-15283)

#### Changes made
-Doc for deactivate discount.

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->