### PR TITLE
MC-15609: doc for delete zone

### DIFF
--- a/source/includes/stackpath/_dns_zones.md
+++ b/source/includes/stackpath/_dns_zones.md
@@ -106,3 +106,32 @@ Attributes | &nbsp;
 `disabled`<br/>*boolean* | Whether or not a zone has been disabled by the user.
 `verified`<br/>*string* | The date a zone's nameservers were last audited by StackPath.
 `status`<br/>*string* | The status of the zone. It can either be `ACTIVE`, `INACTIVE`.
+
+<!-------------------- DELETE A DNS ZONE -------------------->
+
+#### Delete a DNS zone
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnszones/9ae3717a-006a-4aa7-b64b-8bc8d2f2d6e5"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "ef70cafa-0544-4709-a66a-c68595ee105a",
+  "taskStatus": "SUCCESS"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnszones/:id</code>
+
+Delete a DNS zone
+
+The following attributes are returned as part of the response.
+
+Attributes | &nbsp;
+------- | -----------
+`taskId` <br/>*string* | The task id related to the firewall rule deletion.
+`taskStatus` <br/>*string* | The status of the operation.

--- a/source/includes/stackpath/_dns_zones.md
+++ b/source/includes/stackpath/_dns_zones.md
@@ -133,5 +133,5 @@ The following attributes are returned as part of the response.
 
 Attributes | &nbsp;
 ------- | -----------
-`taskId` <br/>*string* | The task id related to the firewall rule deletion.
+`taskId` <br/>*string* | The task id related to the DNS zone deletion.
 `taskStatus` <br/>*string* | The status of the operation.


### PR DESCRIPTION
### Fixes [MC-15609](https://cloud-ops.atlassian.net/browse/MC-15609)

#### Changes made
-Doc added for delete DNS zone

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/608

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->