### PR TITLE
MC-15610 Add listing of DNS records

### DIFF
--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -1,10 +1,10 @@
-## DNS Records
+### DNS Records
 
 Create and manage your DNS records associated to your zones.
 
 <!-------------------- LIST DNS RECORDS -------------------->
 
-### List DNS Records
+#### List DNS Records
 
 ```shell
 curl -X GET \
@@ -73,7 +73,7 @@ Attributes | &nbsp;
 
 <!-------------------- RETRIEVE A DNS RECORD -------------------->
 
-### Retrieve a DNS record
+#### Retrieve a DNS record
 
 ```shell
 curl -X GET \

--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -66,7 +66,7 @@ Attributes | &nbsp;
 `type`<br/>*string* | A zone record's type. Zone record types describe the zone record's behavior.
 `classCode`<br/>*string* | A zone record's class code. This is typically "IN" for Internet related resource records.
 `ttl` <br/>*int* | A zone record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients.
-`data`<br/>*string* | A zone record's value. MX record data follows the format `<priority>` `<value>`, without <>s.
+`data`<br/>*string* | A zone record's value.
 `weight` <br/>*int* | A zone record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
 `created`<br/>*string* | The date on which the DNS record was created
 `updated`<br/>*string* | The date on which the DNS record was last updated.
@@ -117,7 +117,7 @@ Attributes | &nbsp;
 `type`<br/>*string* | A zone record's type. Zone record types describe the zone record's behavior.
 `classCode`<br/>*string* | A zone record's class code. This is typically "IN" for Internet related resource records.
 `ttl` <br/>*int* | A zone record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients.
-`data`<br/>*string* | A zone record's value. MX record data follows the format `<priority>` `<value>`, without <>s.
+`data`<br/>*string* | A zone record's value.
 `weight` <br/>*int* | A zone record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
 `created`<br/>*string* | The date on which the DNS record was created
 `updated`<br/>*string* | The date on which the DNS record was last updated.

--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -1,0 +1,123 @@
+## DNS Records
+
+Create and manage your DNS records associated to your zones.
+
+<!-------------------- LIST DNS RECORDS -------------------->
+
+### List DNS Records
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnsrecords?zoneId=337c7c26-31f4-4b2e-83dc-126exxxxxxWr"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "4eea2e59-8d06-4f37-8fd1-035e3314dxxD",
+      "stackId": "7fbea2c0-17d0-41df-b0b1-4d5c95234566",
+      "zoneId": "337c7c26-31f4-4b2e-83dc-126exxxxxxWr",
+      "name": "test1",
+      "type": "A",
+      "classCode": "IN",
+      "ttl": 21600,
+      "data": "127.0.0.0",
+      "weight": 1,
+      "created": "2021-07-28T17:14:07.928210Z",
+      "updated": "2021-07-28T17:14:07.928210Z"
+    },
+    {
+      "id": "0a18b323-72df-447a-af81-08a2ea62re45",
+      "stackId": "7fbea2c0-17d0-41df-b0b1-4d5c95234566",
+      "zoneId": "337c7c26-31f4-4b2e-83dc-126exxxxxxWr",
+      "name": "test2",
+      "type": "TXT",
+      "classCode": "IN",
+      "ttl": 300,
+      "data": "123 312 12",
+      "weight": 1,
+      "created": "2021-07-28T17:14:25.229376Z",
+      "updated": "2021-07-28T17:14:25.229376Z"
+    }
+  ],
+  "metadata": {
+    "recordCount": 2
+  }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnszones?zoneId=:zoneId</code>
+
+Retrieve a list of all DNS records in a given DNS zone in an [environment](#administration-environments) .
+
+Query Params | &nbsp;
+---- | -----------
+`zoneId`<br/>*UUID* | The ID of the zone for which we list the records. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | A record's unique identifier. 
+`stackId`<br/>*string* | The ID of the stack that a record belongs to.
+`zoneId`<br/>*string* | The ID of zone that the record belongs to.
+`name`<br/>*string* | The name of the record. Use the value "@" to denote current root domain name.
+`type`<br/>*string* | A zone record's type. Zone record types describe the zone record's behavior.
+`classCode`<br/>*string* | A zone record's class code. This is typically "IN" for Internet related resource records.
+`ttl` <br/>*int* | A zone record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients.
+`data`<br/>*string* | A zone record's value. MX record data follows the format `<priority>` `<value>`, without <>s.
+`weight` <br/>*int* | A zone record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
+`created`<br/>*string* | The date on which the DNS record was created
+`updated`<br/>*string* | The date on which the DNS record was last updated.
+
+<!-------------------- RETRIEVE A DNS RECORD -------------------->
+
+### Retrieve a DNS record
+
+```shell
+curl -X GET \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnsrecord/0a18b323-72df-447a-af81-08a2ea62re45?zoneId=337c7c26-31f4-4b2e-83dc-126exxxxxxWr"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+      "id": "0a18b323-72df-447a-af81-08a2ea62re45",
+      "stackId": "7fbea2c0-17d0-41df-b0b1-4d5c95234566",
+      "zoneId": "337c7c26-31f4-4b2e-83dc-126exxxxxxWr",
+      "name": "test2",
+      "type": "TXT",
+      "classCode": "IN",
+      "ttl": 300,
+      "data": "123 312 12",
+      "weight": 1,
+      "created": "2021-07-28T17:14:25.229376Z",
+      "updated": "2021-07-28T17:14:25.229376Z"
+    }
+}
+```
+
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnszones/id?zoneId=:zoneId</code>
+
+Retrieve a DNS record in a given DNS zone in an [environment](#administration-environments) .
+
+Query Params | &nbsp;
+---- | -----------
+`zoneId`<br/>*UUID* | The ID of the zone for which we want to get the record. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | A record's unique identifier. 
+`stackId`<br/>*string* | The ID of the stack that a record belongs to.
+`zoneId`<br/>*string* | The ID of zone that the record belongs to.
+`name`<br/>*string* | The name of the record. Use the value "@" to denote current root domain name.
+`type`<br/>*string* | A zone record's type. Zone record types describe the zone record's behavior.
+`classCode`<br/>*string* | A zone record's class code. This is typically "IN" for Internet related resource records.
+`ttl` <br/>*int* | A zone record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients.
+`data`<br/>*string* | A zone record's value. MX record data follows the format `<priority>` `<value>`, without <>s.
+`weight` <br/>*int* | A zone record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
+`created`<br/>*string* | The date on which the DNS record was created
+`updated`<br/>*string* | The date on which the DNS record was last updated.

--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -49,7 +49,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnszones?zoneId=:zoneId</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords?zoneId=:zoneId</code>
 
 Retrieve a list of all DNS records in a given DNS zone in an [environment](#administration-environments) .
 
@@ -78,7 +78,7 @@ Attributes | &nbsp;
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnsrecord/0a18b323-72df-447a-af81-08a2ea62re45?zoneId=337c7c26-31f4-4b2e-83dc-126exxxxxxWr"
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnsrecords/0a18b323-72df-447a-af81-08a2ea62re45?zoneId=337c7c26-31f4-4b2e-83dc-126exxxxxxWr"
 ```
 > The above command returns a JSON structured like this:
 
@@ -100,7 +100,7 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnszones/id?zoneId=:zoneId</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords/id?zoneId=:zoneId</code>
 
 Retrieve a DNS record in a given DNS zone in an [environment](#administration-environments) .
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -216,7 +216,7 @@ includes:
   - stackpath/delivery_rules
   - stackpath/images
   - stackpath/dns_zones
-    - stackpath/dns_records
+  - stackpath/dns_records
   - aws
   - aws/compute
   - aws/instances

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -216,6 +216,7 @@ includes:
   - stackpath/delivery_rules
   - stackpath/images
   - stackpath/dns_zones
+    - stackpath/dns_records
   - aws
   - aws/compute
   - aws/instances


### PR DESCRIPTION
### Fixes [MC-15610](https://cloud-ops.atlassian.net/browse/MC-15610)

#### Changes made
- I added the fetcher of DNS records, so added listing and get documentation for the entity

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/615

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->