### PR TITLE
MC-15614: Added API docs

### DIFF
--- a/source/includes/stackpath/_dns_zones.md
+++ b/source/includes/stackpath/_dns_zones.md
@@ -197,3 +197,53 @@ Attributes | &nbsp;
 ------- | -----------
 `taskId` <br/>*string* | The task id related to the DNS zone deletion.
 `taskStatus` <br/>*string* | The status of the operation.
+
+
+
+<!-------------------- IMPORT DNS ZONE RECORDS -------------------->
+
+### Import DNS zone records
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnszones/9ae3717a-006a-4aa7-b64b-8bc8d2f2d6e5?operation=import"
+```
+> Request body example:
+
+```json
+{
+  "records": [
+    {
+      "name": "*",
+      "type": "NS",
+      "ttl": 3600,
+      "data": "ns1.above.com.",
+      "weight": 1
+    }
+  ]
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnszones/:id?operation=import</code>
+
+Import DNS records into a DNS zone in a given [environment](#administration-environments).
+
+Optional | &nbsp;
+------- | -----------
+`records`<br/>*Array[Object]* | The list of DNS records to import.
+`records.type`<br/>*String* | A zone record's type. Zone record types describe the zone record's behavior. Supported values are A, AAAA, CAA, CNAME, MX, SRV, TXT or NS.  Required for each record.
+`records.name`<br/>*String* | The name of the record. Use the value "@" to denote current root domain name. Required for each record.
+`records.data`<br/>*String* |  A zone record's value. Required for each record.
+`records.ttl`<br/>*integer* | A zone record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients. Required for each record.
+`records.weight`<br/>*integer* | A zone record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.


### PR DESCRIPTION
### Fixes [MC-15614](https://cloud-ops.atlassian.net/browse/MC-15614)

#### Changes made
<!-- Changes should match the template provided below -->
- Added import dns record api

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/632

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->