### PR TITLE
MC-15611: doc for create and update dns record

### DIFF
--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -203,7 +203,7 @@ curl -X PUT \
 }
 ```
 
-<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords?zoneId=:zoneId</code>
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords/:id?zoneId=:zoneId</code>
 
 Update a DNS record in a given [environment](#administration-environments).
 

--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -169,6 +169,7 @@ Required | &nbsp;
 `data`<br/>*string* | A DNS record's value.
 
 Optional | &nbsp;
+------- | -----------
 `weight` <br/>*int* | A DNS record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
 
 <!-------------------- UPDATE A DNS RECORD -------------------->
@@ -218,6 +219,7 @@ Required | &nbsp;
 `data`<br/>*string* | A DNS record's value.
 
 Optional | &nbsp;
+------- | -----------
 `weight` <br/>*int* | A DNS record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
 
 <!-------------------- DELETE A DNS RECORD -------------------->

--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -159,7 +159,7 @@ Create a DNS record in a given [environment](#administration-environments).
 
 Query Params | &nbsp;
 ---- | -----------
-`zoneId`<br/>*UUID* | The ID of the zone for which we want to delete the record. This parameter is required.
+`zoneId`<br/>*UUID* | The ID of the zone for which we want to create the record. This parameter is required.
 
 Required | &nbsp;
 ------- | -----------
@@ -209,7 +209,7 @@ Update a DNS record in a given [environment](#administration-environments).
 
 Query Params | &nbsp;
 ---- | -----------
-`zoneId`<br/>*UUID* | The ID of the zone for which we want to delete the record. This parameter is required.
+`zoneId`<br/>*UUID* | The ID of the zone for which we want to update the record. This parameter is required.
 
 Required | &nbsp;
 ------- | -----------

--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -122,6 +122,100 @@ Attributes | &nbsp;
 `created`<br/>*string* | The date on which the DNS record was created.
 `updated`<br/>*string* | The date on which the DNS record was last updated.
 
+<!-------------------- CREATE A DNS RECORD -------------------->
+
+#### Create a DNS record
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnsrecords?zoneId=337c7c26-31f4-4b2e-83dc-126exxxxxxWr"
+```
+> Request body example for creating a DNS record:
+
+```json
+{
+  "name": "*",
+  "type": "NS",
+  "ttl": 3600,
+  "data": "ns1.above.com.",
+  "weight": 1
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords?zoneId=:zoneId</code>
+
+Create a DNS record in a given [environment](#administration-environments).
+
+Query Params | &nbsp;
+---- | -----------
+`zoneId`<br/>*UUID* | The ID of the zone for which we want to delete the record. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`name`<br/>*string* | The name of the record. Use the value "@" to denote current root domain name.
+`type`<br/>*string* | A DNS record's type. DNS record types describe the record's behavior.
+`ttl` <br/>*int* | A DNS record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients.
+`data`<br/>*string* | A DNS record's value.
+`weight` <br/>*int* | A DNS record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
+
+<!-------------------- UPDATE A DNS RECORD -------------------->
+
+#### Update a DNS record
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request_body" \
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnsrecords/0a18b323-72df-447a-af81-08a2ea62re45?zoneId=337c7c26-31f4-4b2e-83dc-126exxxxxxWr&operation=edit"
+```
+> Request body example for creating a DNS record:
+
+```json
+{
+  "name": "*",
+  "type": "NS",
+  "ttl": 3600,
+  "data": "ns1.above.com.",
+  "weight": 1
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "7135ae25-8488-4bc5-a289-285c84a00a84",
+  "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords?zoneId=:zoneId&operation=edit</code>
+
+Update a DNS record in a given [environment](#administration-environments).
+
+Query Params | &nbsp;
+---- | -----------
+`zoneId`<br/>*UUID* | The ID of the zone for which we want to delete the record. This parameter is required.
+
+Attributes | &nbsp;
+------- | -----------
+`name`<br/>*string* | The name of the record. Use the value "@" to denote current root domain name.
+`type`<br/>*string* | A DNS record's type. DNS record types describe the record's behavior.
+`ttl` <br/>*int* | A DNS record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients.
+`data`<br/>*string* | A DNS record's value.
+`weight` <br/>*int* | A DNS record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
+
 <!-------------------- DELETE A DNS RECORD -------------------->
 
 #### Delete a DNS record

--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -161,12 +161,14 @@ Query Params | &nbsp;
 ---- | -----------
 `zoneId`<br/>*UUID* | The ID of the zone for which we want to delete the record. This parameter is required.
 
-Attributes | &nbsp;
+Required | &nbsp;
 ------- | -----------
 `name`<br/>*string* | The name of the record. Use the value "@" to denote current root domain name.
 `type`<br/>*string* | A DNS record's type. DNS record types describe the record's behavior.
 `ttl` <br/>*int* | A DNS record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients.
 `data`<br/>*string* | A DNS record's value.
+
+Optional | &nbsp;
 `weight` <br/>*int* | A DNS record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
 
 <!-------------------- UPDATE A DNS RECORD -------------------->
@@ -174,10 +176,10 @@ Attributes | &nbsp;
 #### Update a DNS record
 
 ```shell
-curl -X POST \
+curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
    -d "request_body" \
-   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnsrecords/0a18b323-72df-447a-af81-08a2ea62re45?zoneId=337c7c26-31f4-4b2e-83dc-126exxxxxxWr&operation=edit"
+   "https://cloudmc_endpoint/api/v1/services/stackpath/test-area/dnsrecords/0a18b323-72df-447a-af81-08a2ea62re45?zoneId=337c7c26-31f4-4b2e-83dc-126exxxxxxWr"
 ```
 > Request body example for creating a DNS record:
 
@@ -200,7 +202,7 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords?zoneId=:zoneId&operation=edit</code>
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords?zoneId=:zoneId&operation=edit</code>
 
 Update a DNS record in a given [environment](#administration-environments).
 
@@ -208,12 +210,14 @@ Query Params | &nbsp;
 ---- | -----------
 `zoneId`<br/>*UUID* | The ID of the zone for which we want to delete the record. This parameter is required.
 
-Attributes | &nbsp;
+Required | &nbsp;
 ------- | -----------
 `name`<br/>*string* | The name of the record. Use the value "@" to denote current root domain name.
 `type`<br/>*string* | A DNS record's type. DNS record types describe the record's behavior.
 `ttl` <br/>*int* | A DNS record's time to live. A record's TTL is the number of seconds that the record should be cached by DNS resolvers. Use lower TTL values if you expect zone records to change often. Use higher TTL values for records that won't change to prevent extra DNS lookups by clients.
 `data`<br/>*string* | A DNS record's value.
+
+Optional | &nbsp;
 `weight` <br/>*int* | A DNS record's priority. A resource record is replicated in StackPath's DNS infrastructure the number of times of the record's weight, giving it a more likely response to queries if a zone has records with the same name and type.
 
 <!-------------------- DELETE A DNS RECORD -------------------->

--- a/source/includes/stackpath/_dns_records.md
+++ b/source/includes/stackpath/_dns_records.md
@@ -203,7 +203,7 @@ curl -X PUT \
 }
 ```
 
-<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords?zoneId=:zoneId&operation=edit</code>
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/dnsrecords?zoneId=:zoneId</code>
 
 Update a DNS record in a given [environment](#administration-environments).
 


### PR DESCRIPTION
### Fixes [MC-15611](https://cloud-ops.atlassian.net/browse/MC-15611)
### Fixes [MC-15612](https://cloud-ops.atlassian.net/browse/MC-15612)

#### Changes made
-Doc for create dns record
-Doc for update dns record

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->