### PR TITLE
MC-16115: added doc for list and get

### DIFF
--- a/source/includes/administration/_tax_providers.md
+++ b/source/includes/administration/_tax_providers.md
@@ -10,7 +10,7 @@ on the billing details (i.e. billing address) and mapping of tax codes to produc
 
 Retrieves a list of tax providers configured for a reseller.
 
-> Note: You must have the Reseller billing permission on the target reseller. If the caller does not have the correct permissions or the reseller with the ID provided does not exist a 404 Not Found will be returned  
+> Note: You must have the Reseller billing permission on the target reseller. If the caller does not have the correct permissions or the reseller with the ID provided does not exist then a `404 Not Found` response will be returned.
 
 ```shell
 # Retrieve tax providers
@@ -43,9 +43,9 @@ curl "https://cloudmc_endpoint/rest/tax_providers?reseller_id=23910576-d29f-4c14
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the tax provider.
-`reseller.id`<br/>*UUID* | UUID of the reseller to which the tax provider belongs. (AKA an organization id that is a reseller)
+`reseller.id`<br/>*UUID* | UUID of the reseller to which the tax provider belongs (AKA an organization id that is a reseller).
 `type`<br/>*string* | The type of tax provider. Possible values are: `AVALARA`.
-`state`<br/>*enum"  | The state of the tax provider. Possible values are: `CONFIGURED`, `CONFIGURING`, `ERROR`
+`state`<br/>*enum"  | The state of the tax provider. Possible values are: `CONFIGURED`, `CONFIGURING`, `ERROR`.
 `createdDate`<br/>*string* | The date the tax provider was created.
 `updatedDate`<br/>*string* | The last date the tax provider was updated.
 `configurationAttributes`<br/>*Object* | The configuration attributes associated to the provider type. This depends on the provider type.
@@ -58,7 +58,7 @@ Attributes | &nbsp;
 
 Retrieves a list of tax providers configured for a reseller.
 
-> Note: You must have the Reseller billing permission on the owner of the tax provider requested. If the caller does not have the correct permissions or the tax provider for the given ID does not exist a 404 Not Found will be returned
+> Note: You must have the Reseller billing permission on the owner of the tax provider requested. If the caller does not have the correct permissions or the tax provider for the given ID does not exist, then a `404 Not Found` response will be returned.
 
 ```shell
 # Retrieve a specific tax provider
@@ -89,9 +89,9 @@ curl "https://cloudmc_endpoint/rest/tax_providers/f26e66a4-755c-4867-b565-ad68aa
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the tax provider.
-`reseller.id`<br/>*UUID* | UUID of the reseller to which the tax provider belongs. (AKA an organization id that is a reseller)
+`reseller.id`<br/>*UUID* | UUID of the reseller to which the tax provider belongs (AKA an organization id that is a reseller).
 `type`<br/>*string* | The type of tax provider. Possible values are: `AVALARA`.
-`state`<br/>*enum"  | The state of the tax provider. Possible values are: `CONFIGURED`, `CONFIGURING`, `ERROR`
+`state`<br/>*enum"  | The state of the tax provider. Possible values are: `CONFIGURED`, `CONFIGURING`, `ERROR`.
 `createdDate`<br/>*string* | The date the tax provider was created.
 `updatedDate`<br/>*string* | The last date the tax provider was updated.
 `configurationAttributes`<br/>*Object* | The configuration attributes associated to the provider type. This depends on the provider type.

--- a/source/includes/administration/_tax_providers.md
+++ b/source/includes/administration/_tax_providers.md
@@ -10,9 +10,11 @@ on the billing details (i.e. billing address) provided by the reseller.
 
 Retrieves a list of tax providers configured for a reseller.
 
+> Note: You must have the Reseller billing permission on the target reseller. If the caller does not have the correct permissions or the reseller with the ID provided does not exist a 404 Not Found will be returned  
+
 ```shell
 # Retrieve tax providers
-curl "https://cloudmc_endpoint/rest/tax_providers" \
+curl "https://cloudmc_endpoint/rest/tax_providers?reseller_id=23910576-d29f-4c14-b663-31d728ff49a5" \
    -H "MC-Api-Key: your_api_key"
 ```
 > The above command returns a JSON structured like this:
@@ -55,6 +57,8 @@ Attributes | &nbsp;
 `GET /tax_providers/:id`
 
 Retrieves a list of tax providers configured for a reseller.
+
+> Note: You must have the Reseller billing permission on the owner of the tax provider requested. If the caller does not have the correct permissions or the tax provider for the given ID does not exist a 404 Not Found will be returned
 
 ```shell
 # Retrieve a specific tax provider

--- a/source/includes/administration/_tax_providers.md
+++ b/source/includes/administration/_tax_providers.md
@@ -1,0 +1,93 @@
+### Tax providers
+
+A tax provider enables a reseller to map tax codes to monetization products. The tax code provider type will ensure that invoices include taxes based 
+on the billing details (i.e. billing address) provided by the reseller. 
+
+<!-------------------- LIST TAX PROVIDERS -------------------->
+#### List tax providers
+
+`GET /tax_providers`
+
+Retrieves a list of tax providers configured for a reseller.
+
+```shell
+# Retrieve tax providers
+curl "https://cloudmc_endpoint/rest/tax_providers" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "f26e66a4-755c-4867-b565-ad68aa515237",
+      "reseller": {
+        "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+      },
+      "type": "AVALARA",
+      "createdDate": "2021-05-07T19:21:20Z",
+      "updatedDate": "2021-05-07T19:21:20Z",
+      "configurationAttributes": {
+        "companyId": "acme",
+        "username": "username",
+        "password" "password"
+      }
+    }
+  ]
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the tax provider.
+`reseller.id`<br/>*UUID* | UUID of the reseller to which the tax provider belongs. (AKA an organization id that is a reseller)
+`type`<br/>*string* | The type of tax provider. Possible values are: `AVALARA`.
+`state`<br/>*enum"  | The state of the tax provider. Possible values are: `CONFIGURED`, `CONFIGURING`, `ERROR`
+`createdDate`<br/>*string* | The date the tax provider was created.
+`updatedDate`<br/>*string* | The last date the tax provider was updated.
+`configurationAttributes`<br/>*Object* | The configuration attributes associated to the provider type. This depends on the provider type.
+
+
+<!-------------------- GET TAX PROVIDER -------------------->
+#### Get a tax provider
+
+`GET /tax_providers/:id`
+
+Retrieves a list of tax providers configured for a reseller.
+
+```shell
+# Retrieve a specific tax provider
+curl "https://cloudmc_endpoint/rest/tax_providers/f26e66a4-755c-4867-b565-ad68aa515237" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "f26e66a4-755c-4867-b565-ad68aa515237",
+    "reseller": {
+      "id": "23910576-d29f-4c14-b663-31d728ff49a5"
+    },
+    "type": "AVALARA",
+    "createdDate": "2021-05-07T19:21:20Z",
+    "updatedDate": "2021-05-07T19:21:20Z",
+    "configurationAttributes": {
+      "companyId": "acme",
+      "username": "username",
+      "password" "password"
+    }
+  }
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the tax provider.
+`reseller.id`<br/>*UUID* | UUID of the reseller to which the tax provider belongs. (AKA an organization id that is a reseller)
+`type`<br/>*string* | The type of tax provider. Possible values are: `AVALARA`.
+`state`<br/>*enum"  | The state of the tax provider. Possible values are: `CONFIGURED`, `CONFIGURING`, `ERROR`
+`createdDate`<br/>*string* | The date the tax provider was created.
+`updatedDate`<br/>*string* | The last date the tax provider was updated.
+`configurationAttributes`<br/>*Object* | The configuration attributes associated to the provider type. This depends on the provider type.

--- a/source/includes/administration/_tax_providers.md
+++ b/source/includes/administration/_tax_providers.md
@@ -1,7 +1,7 @@
 ### Tax providers
 
-A tax provider enables a reseller to map tax codes to monetization products. The tax code provider type will ensure that invoices include taxes based 
-on the billing details (i.e. billing address) provided by the reseller. 
+A tax provider enables a reseller to map tax codes to monetization products. The tax code provider will ensure that invoices include taxes based 
+on the billing details (i.e. billing address) and mapping of tax codes to product offerings provided by the reseller. 
 
 <!-------------------- LIST TAX PROVIDERS -------------------->
 #### List tax providers


### PR DESCRIPTION
### Fixes [MC-16115](https://cloud-ops.atlassian.net/browse/MC-16115)

#### Changes made

#### Related PRs
- [Core](https://github.com/cloudops/cloudmc-core/pull/1503/)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->