### PR TITLE
Docs/mc 15831 set billable org info

### DIFF
--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -826,7 +826,7 @@ curl -X DELETE "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc
 ### Set billable organization information
 `PUT /organizations/:organization_id/billable`
 
-Update the applied pricing packages of an organization, or set an organization as billable. If the organization does not have a billable organization info, it creates one and and applies the pricing package on it.
+Set the organization to billable and update the billable organization information.
 
 ```shell
 # Update billable organization info

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -898,7 +898,7 @@ curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e30
 Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the pricing package.
-`offerTyoe`<br/>*string* | The offer type of the pricing package.
+`offerType`<br/>*string* | The offer type of the pricing package.
 `pricingDefinition`<br/>*Object* | The pricing definition associated with the pricing package.
 `pricingDefinition.id`<br/>*UUID* | The UUID of the pricing.
 `organization`<br/>*Object* | The object representing the organization owning the pricing package.

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -819,3 +819,125 @@ Returns an HTTP status code 200, with an empty response body.
 # Retrieve the organization's billing information
 curl -X DELETE "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e301bf5b86a/billing_info" \
    -H "MC-Api-Key: your_api_key"
+```
+
+
+<!-------------------- UPDATE BILLABLE ORGANIZATION INFORMATION -------------------->
+### Set billable organization information
+`PUT /organizations/:organization_id/billable`
+
+Update the applied pricing packages of an organization, or set an organization as billable. If the organization does not have a billable organization info, it creates one and and applies the pricing package on it.
+
+```shell
+# Update billable organization info
+curl -X PUT "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e301bf5b86a/billable" \
+   -H "MC-Api-Key: your_api_key" \
+   -H "Content-Type: application/json" \
+   -d "request_body"
+```
+> Request body example:
+
+```json
+{
+   "id": "39f6260d-f0ca-4be9-93c4-46405d471c04",
+   "billableStart": "2015-01-18",
+	"pricingPackage": {
+		"id": "58bad1de-1f87-422b-b44f-27ed58889272"
+	}
+}
+```
+
+Required | &nbsp;
+---- | ----
+`id`<br/>*UUID* | The id of the udpated billable organization information.
+`billableStart`<br/>*string*  | The date the organization became billable, in YYYY-MM-DD format.
+`pricingPackage.id`<br/>*UUID* | The id of the pricing package applied on the organization.
+
+The responses' `data` field contains the updated billable organizaiton info with its `id`, as well as with the `organizationId` and `pricingPackage`.
+
+<!-------------------- LIST APPLICABLE PRICING PACKAGES TO ORG -------------------->
+### List applicable pricing packages to an organization
+
+`GET /organizations/:organization_id/pricing_packages`
+
+Retrieves a list of applicable pricing packages to an organization.
+
+```shell
+# Retrieve visible organizations
+curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e301bf5b86a/pricing_packages" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "offerType": "30-day-trial",
+      "pricingDefinition": {
+        "id": "c9a396f1-690a-4201-a3bf-b1da37221acc"
+      },
+      "scopeOrganization": {
+        "id": "de6cf332-14b2-4da8-8522-3dfe12fcd0da"
+      },
+      "endDate": "2022-09-14T00:00:00Z",
+      "organization": {
+        "id": "de6cf332-14b2-4da8-8522-3dfe12fcd0da"
+      },
+      "name": {
+        "en": "Applied Pricing",
+        "fr": "Applied Pricing"
+      },
+      "currency": "CAD",
+      "id": "92041aa8-7784-45b0-aa85-76376ede784d",
+      "creationDate": "2021-09-13T15:18:38.000Z",
+      "scopeQualifier": "ORG_TREE",
+      "startDate": "2021-09-22T20:09:32.084Z"
+    },
+    {
+      "pricingDefinition": {
+        "id": "c9a396f1-690a-4201-a3bf-b1da37221acc"
+      },
+      "scopeOrganization": {
+        "id": "de6cf332-14b2-4da8-8522-3dfe12fcd0da"
+      },
+      "endDate": "2022-09-14T00:00:00Z",
+      "organization": {
+        "id": "de6cf332-14b2-4da8-8522-3dfe12fcd0da"
+      },
+      "name": {
+        "en": "Applied Pricing 5",
+        "fr": "Applied Pricing"
+      },
+      "currency": "CAD",
+      "id": "e9b3a643-8518-4aeb-a82e-3e89983f4321",
+      "creationDate": "2021-09-13T15:11:16.000Z",
+      "scopeQualifier": "ORG_TREE",
+      "startDate": "2021-09-22T20:10:07.140Z"
+    }
+  ]
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`id`<br/>*UUID* | The UUID of the applied pricing.
+`pricingDefinition`<br/>*Object* | The pricing definition associated with the applied pricing.
+`pricingDefinition.id`<br/>*UUID* | The UUID of the pricing.
+`pricingDefinition.supportedCurrencies`<br/>*Array[string]* | The list of currencies associated to the pricing.
+`pricingDefinition.organization.id`<br/>*UUID* | The UUID of the organization owning of the pricing definition.
+`pricingDefinition.name`<br/>*Object* | Mapped object containing the pricing name in different languages.
+`pricingDefinition.description`<br/>*Object* | Mapped object containing the pricing description in different languages.
+`pricingDefinition.effectiveDate`<br/>*date* | The date to which the pricing will be applicable from.
+`organization`<br/>*Object* | The object representing the organization owning the applied pricing.
+`organization.id`<br/>*UUID* | The UUID of the organization.
+`organization.name`<br/>*string* | The name of the organization.
+`startDate`<br/>*date* | The start date of the applied pricing.
+`endDate`<br/>*date* | The end date of the applied pricing. If it is not present, there is no end date defined.
+`currency`<br/>*string* | The currency associated to the applied pricing.
+`scopeQualifier`<br/>*string* | Scope qualifier of the applied pricing. Possible values are : GLOBAL, ORG_TOPLEVEL, ORG_SUBS, ORG_BASE, ORG_TREE.
+`scopeOrganization`<br/>*Object* | The organization to which the scope is applied to.
+`scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
+`scopeOrganization.name`<br/>*string* | The name of the organization.
+`creationDate`<br/>*Object* | The date the applied pricing was created.
+`status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, FUTURE.

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -853,8 +853,6 @@ Required | &nbsp;
 `billableStart`<br/>*string*  | The date the organization became billable, in YYYY-MM-DD format.
 `pricingPackage.id`<br/>*UUID* | The id of the pricing package applied on the organization.
 
-The responses' `data` field contains the updated billable organizaiton info with its `id`, as well as with the `organizationId` and `pricingPackage`.
-
 <!-------------------- LIST APPLICABLE PRICING PACKAGES TO ORG -------------------->
 ### List applicable pricing packages to an organization
 

--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -853,6 +853,10 @@ Required | &nbsp;
 `billableStart`<br/>*string*  | The date the organization became billable, in YYYY-MM-DD format.
 `pricingPackage.id`<br/>*UUID* | The id of the pricing package applied on the organization.
 
+Optional | &nbsp;
+---- | ----
+`billableEnd`<br/>*string*  | The date the organization stops being billable, in YYYY-MM-DD format.
+
 <!-------------------- LIST APPLICABLE PRICING PACKAGES TO ORG -------------------->
 ### List applicable pricing packages to an organization
 
@@ -875,9 +879,6 @@ curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e30
       "pricingDefinition": {
         "id": "c9a396f1-690a-4201-a3bf-b1da37221acc"
       },
-      "scopeOrganization": {
-        "id": "de6cf332-14b2-4da8-8522-3dfe12fcd0da"
-      },
       "endDate": "2022-09-14T00:00:00Z",
       "organization": {
         "id": "de6cf332-14b2-4da8-8522-3dfe12fcd0da"
@@ -886,32 +887,9 @@ curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e30
         "en": "Applied Pricing",
         "fr": "Applied Pricing"
       },
-      "currency": "CAD",
       "id": "92041aa8-7784-45b0-aa85-76376ede784d",
       "creationDate": "2021-09-13T15:18:38.000Z",
-      "scopeQualifier": "ORG_TREE",
       "startDate": "2021-09-22T20:09:32.084Z"
-    },
-    {
-      "pricingDefinition": {
-        "id": "c9a396f1-690a-4201-a3bf-b1da37221acc"
-      },
-      "scopeOrganization": {
-        "id": "de6cf332-14b2-4da8-8522-3dfe12fcd0da"
-      },
-      "endDate": "2022-09-14T00:00:00Z",
-      "organization": {
-        "id": "de6cf332-14b2-4da8-8522-3dfe12fcd0da"
-      },
-      "name": {
-        "en": "Applied Pricing 5",
-        "fr": "Applied Pricing"
-      },
-      "currency": "CAD",
-      "id": "e9b3a643-8518-4aeb-a82e-3e89983f4321",
-      "creationDate": "2021-09-13T15:11:16.000Z",
-      "scopeQualifier": "ORG_TREE",
-      "startDate": "2021-09-22T20:10:07.140Z"
     }
   ]
 }
@@ -919,23 +897,13 @@ curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e30
 
 Attributes | &nbsp;
 ---- | -----------
-`id`<br/>*UUID* | The UUID of the applied pricing.
-`pricingDefinition`<br/>*Object* | The pricing definition associated with the applied pricing.
+`id`<br/>*UUID* | The UUID of the pricing package.
+`offerTyoe`<br/>*string* | The offer type of the pricing package.
+`pricingDefinition`<br/>*Object* | The pricing definition associated with the pricing package.
 `pricingDefinition.id`<br/>*UUID* | The UUID of the pricing.
-`pricingDefinition.supportedCurrencies`<br/>*Array[string]* | The list of currencies associated to the pricing.
-`pricingDefinition.organization.id`<br/>*UUID* | The UUID of the organization owning of the pricing definition.
-`pricingDefinition.name`<br/>*Object* | Mapped object containing the pricing name in different languages.
-`pricingDefinition.description`<br/>*Object* | Mapped object containing the pricing description in different languages.
-`pricingDefinition.effectiveDate`<br/>*date* | The date to which the pricing will be applicable from.
-`organization`<br/>*Object* | The object representing the organization owning the applied pricing.
+`organization`<br/>*Object* | The object representing the organization owning the pricing package.
 `organization.id`<br/>*UUID* | The UUID of the organization.
-`organization.name`<br/>*string* | The name of the organization.
-`startDate`<br/>*date* | The start date of the applied pricing.
-`endDate`<br/>*date* | The end date of the applied pricing. If it is not present, there is no end date defined.
-`currency`<br/>*string* | The currency associated to the applied pricing.
-`scopeQualifier`<br/>*string* | Scope qualifier of the applied pricing. Possible values are : GLOBAL, ORG_TOPLEVEL, ORG_SUBS, ORG_BASE, ORG_TREE.
-`scopeOrganization`<br/>*Object* | The organization to which the scope is applied to.
-`scopeOrganization.id`<br/>*UUID* | The UUID of the organization.
-`scopeOrganization.name`<br/>*string* | The name of the organization.
-`creationDate`<br/>*Object* | The date the applied pricing was created.
-`status`<br/>*string* | The status of the applied pricing. Possible values are : ACTIVE, EXPIRED, FUTURE.
+`startDate`<br/>*date* | The start date of the pricing package.
+`endDate`<br/>*date* | The end date of the pricing package. If it is not present, there is no end date defined.
+`creationDate`<br/>*Object* | The date the pricing package was created.
+`name` <br/>*Object* | A map of language keys to the name of the pricing package in the specified language. 


### PR DESCRIPTION
### Fixes [MC-15831](https://cloud-ops.atlassian.net/browse/MC-15831)

#### Changes made
Add documentation for setting billable org info

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->