### PR TITLE
MC-16072 Add tax code docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Option 1: use docker
 
 ```shell
 cd /path/to/repo/cloudmc-api-docs/
-docker-compose up -d
+docker compose up -d
 ```
 
 Option 2: local or vagrant

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
-app:
-  build: .
-  ports:
-    - 4567:4567
-  volumes:
-    - .:/usr/src/app
+version: "3.9"
+
+services:
+  api-docs:
+    build: .
+    ports:
+      - 4567:4567
+    volumes:
+      - .:/usr/src/app

--- a/source/includes/administration/_tax_providers.md
+++ b/source/includes/administration/_tax_providers.md
@@ -95,3 +95,45 @@ Attributes | &nbsp;
 `createdDate`<br/>*string* | The date the tax provider was created.
 `updatedDate`<br/>*string* | The last date the tax provider was updated.
 `configurationAttributes`<br/>*Object* | The configuration attributes associated to the provider type. This depends on the provider type.
+
+
+<!-------------------- GET TAX CODES FROM PROVIDER -------------------->
+
+#### Get a tax codes
+
+`GET /tax_providers/:id/tax-codes`
+
+Retrieves a list of tax codes from the configured tax provider for a reseller organization.
+
+> Note: You must have the Reseller billing permission on the owner of the tax provider requested. If the caller does not have the correct permissions or the tax provider is not configured for the given organization ID or the organization does not exist, then a `404 Not Found` response will be returned. The required ID in the URL is the ID of the reseller organization for which the tax codes are being fetched.
+
+```shell
+# Retrieve tax codes for a given organization
+curl "https://cloudmc_endpoint/rest/tax_providers/f26e66a4-755c-4867-b565-ad68aa515237/tax-codes" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "code": "SW054101",
+      "description": "Cloud Services - SaaS - Service Agreement - Database Products"
+    },
+    {
+      "code": "SW053004",
+      "description": "Cloud Services - SaaS - License Agreement - for business use only"
+    },
+    {
+      "code": "SW056003",
+      "description": "Cloud Services / Platform as a Service (PaaS)"
+    }
+  ]
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`code`<br/>*string* | The code of the tax.
+`description`<br/>*string* | The description of the tax code.

--- a/source/includes/administration/_tax_providers.md
+++ b/source/includes/administration/_tax_providers.md
@@ -99,7 +99,7 @@ Attributes | &nbsp;
 
 <!-------------------- GET TAX CODES FROM PROVIDER -------------------->
 
-#### Get a tax codes
+#### Get tax codes for a given reseller organization
 
 `GET /tax_providers/:id/tax-codes`
 


### PR DESCRIPTION
### Fixes [MC-16072](https://cloud-ops.atlassian.net/browse/MC-16072)

#### Changes made
<!-- Changes should match the template provided below -->
- Added tax code endpoint documentation

- Also updated readme and docker-compose.yaml file.
Now that docker compose is native to the docker CLI, there is no need to force developer to make use of docker-compose command instead of docker compose.
I updated the readme accordingly too.