### PR TITLE
MC-15987 Add billing emails api documentation

### DIFF
--- a/source/includes/administration/_organizations.md
+++ b/source/includes/administration/_organizations.md
@@ -917,3 +917,61 @@ Attributes | &nbsp;
 `endDate`<br/>*date* | The end date of the pricing package. If it is not present, there is no end date defined.
 `creationDate`<br/>*Object* | The date the pricing package was created.
 `name` <br/>*Object* | A map of language keys to the name of the pricing package in the specified language. 
+
+<!-------------------- LIST ORG BILLING EMAILS -------------------->
+### List billing emails
+
+`GET /organizations/:organization_id/billing_emails`
+
+Retrieves a list of billing emails configured on the org. These emails will also receive billing related emails along with users that have the Admin:Billing role.
+
+```shell
+# Retrieve billing emails
+curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e301bf5b86a/billing_emails" \
+   -H "MC-Api-Key: your_api_key"
+```
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "data": {
+    "billingEmails": {
+      "example@email.com": "John",
+      "billing@company.com": "Billing team"
+    }
+  }
+}
+```
+
+Attributes | &nbsp;
+---- | -----------
+`billingEmails`<br/>*map* | A map of billing emails and names associated with them.
+
+<!-------------------- Update ORG BILLING EMAILS -------------------->
+### Update billing emails
+
+`PUT /organizations/:organization_id/billing_emails`
+
+Update the list of billing emails configured on the org. These emails will also receive billing related emails along with users that have the Admin:Billing role.
+
+```shell
+# Update billing emails
+curl "https://cloudmc_endpoint/api/v1/organizations/87895f43-51c1-43cc-b987-7e301bf5b86a/billing_emails" \
+   -H "MC-Api-Key: your_api_key" \
+   -H "Content-Type: application/json" \
+   -d "request_body"
+```
+> Request body example:
+
+```json
+{
+   "billingEmails": {
+      "example@email.com": "John",
+      "billing@company.com": "Billing team"
+   }
+}
+```
+
+Required | &nbsp;
+---- | ----
+`billingEmails`<br/>*map* | A map of billing emails and names associated with them. There is a maximum of three emails that can be configured. Each entry must have a valid email specified along with a name.


### PR DESCRIPTION
### Fixes [MC-15987](https://cloud-ops.atlassian.net/browse/MC-15987)

#### Changes made
<!-- Changes should match the template provided below -->
- added list billing emails 
- added Update billing emails

#### Related PRs
- [core](https://github.com/cloudops/cloudmc-core/pull/1609)
- [ui](https://github.com/cloudops/cloudmc-ui/pull/1989)
<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->