### PR TITLE
MC-15962: Migrate discount duration to days

### DIFF
--- a/source/includes/administration/_discounts.md
+++ b/source/includes/administration/_discounts.md
@@ -22,7 +22,7 @@ curl "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6
     {
       "applyToNewCustomersOnly": true,
       "discountedProducts": {},
-      "durationMonths": 22354,
+      "durationDays": 60,
       "type": "PERCENTAGE",
       "packageDiscount": 20.0,
       "discountScope": "ALL_PRODUCTS",
@@ -50,7 +50,7 @@ Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the discount.
 `discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discounts. All pricing products specified will have the discount value applied to them.
-`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
+`durationDays`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
 `type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
 `packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing.
 `discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
@@ -84,7 +84,7 @@ curl "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b494-cc6
     {
       "applyToNewCustomersOnly": true,
       "discountedProducts": {},
-      "durationMonths": 22354,
+      "durationDays": 60,
       "type": "PERCENTAGE",
       "packageDiscount": 20.0,
       "discountScope": "ALL_PRODUCTS",
@@ -109,7 +109,7 @@ Attributes | &nbsp;
 ---- | -----------
 `id`<br/>*UUID* | The UUID of the discount.
 `discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discounts. All pricing products specified will have the discount value applied to them.
-`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
+`durationDays`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
 `type`<br/>*enum* | The type of the discount. It could be either "PERCENTAGE" or "CREDIT".
 `packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the applied pricing.
 `discountScope`<br/>*enum* | The scope of the discount. It could be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
@@ -145,7 +145,7 @@ curl -X POST "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-
   },
   "startDate": "2021-07-23T00:00:00.000Z",
   "type": "PERCENTAGE",
-  "durationMonths": 4,
+  "durationDays": 60,
   "discountedProducts": {},
   "discountedCategories": {
     "8cf73cc0-b86e-49b4-a102-6102894f7955": 2, 
@@ -164,7 +164,7 @@ curl -X POST "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-
   "data": {
       "applyToNewCustomersOnly": false,
       "discountedProducts": {},
-      "durationMonths": 4,
+      "durationDays": 60,
       "type": "PERCENTAGE",
       "discountScope": "CATEGORIES",
       "discountedCategories": {
@@ -199,7 +199,7 @@ Required | &nbsp;
 Optional | &nbsp;
 ------- | -----------
 `cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date. 
-`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
+`durationDays`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
 
 <!-------------------- EDIT DISCOUNT -------------------->
 ### Edit discount
@@ -221,7 +221,7 @@ curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b
     "en": "End of summer Discount",
     "fr": "Réduction estival fin d'été"
   },
-  "durationMonths": 4,
+  "durationDays": 60,
   "discountedProducts": {},
   "discountedCategories": {
     "8cf73cc0-b86e-49b4-a102-6102894f7955": 2, 
@@ -240,7 +240,7 @@ curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b
   "data": {
       "applyToNewCustomersOnly": false,
       "discountedProducts": {},
-      "durationMonths": 4,
+      "durationDays": 60,
       "type": "PERCENTAGE",
       "discountScope": "CATEGORIES",
       "discountedCategories": {
@@ -272,7 +272,7 @@ Optional | &nbsp;
 `discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
 `discountedProducts`<br/>*Map[UUID, BigDecimal]* | A mapping of the desired priced product IDs and discount values. All pricing products specified will have the discount value applied to them. Required to be non-empty if scope is "PRODUCTS". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
 `cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date. 
-`durationMonths`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
+`durationDays`<br/>*integer* | Duration of the discount once it has been applied to a customer. If not provided the discount will last indefinitely, or until credit values are reached.
 
 <!-------------------- DELETE DISCOUNT -------------------->
 ### Delete discount
@@ -312,7 +312,7 @@ curl -X PUT "https://cloudmc_endpoint/rest/applied_pricings/efd32752-c6f2-45cf-b
   "data": {
       "applyToNewCustomersOnly": false,
       "discountedProducts": {},
-      "durationMonths": 4,
+      "durationDays": 60,
       "type": "PERCENTAGE",
       "discountScope": "CATEGORIES",
       "isDeactivated": true,

--- a/source/includes/administration/_invoices.md
+++ b/source/includes/administration/_invoices.md
@@ -136,7 +136,7 @@ curl "https://cloudmc_endpoint/rest/invoices/find/efd32752-c6f2-45cf-b494-cc6be8
               "source": {
                 "applyToNewCustomersOnly": false,
                 "discountedProducts": {},
-                "durationMonths": 6,
+                "durationDays": 60,
                 "type": "PERCENTAGE",
                 "cutoffDate": "2021-09-16T00:00:00Z",
                 "adjustmentReferenceId": "dfbe71e2-113d-4212-a315-b8d755ef02d4",
@@ -187,7 +187,7 @@ curl "https://cloudmc_endpoint/rest/invoices/find/efd32752-c6f2-45cf-b494-cc6be8
               "source": {
                 "applyToNewCustomersOnly": false,
                 "discountedProducts": {},
-                "durationMonths": 12,
+                "durationDays": 60,
                 "type": "PERCENTAGE",
                 "packageDiscount": 23.0,
                 "cutoffDate": "2021-08-29T00:00:00Z",
@@ -558,7 +558,7 @@ curl "https://cloudmc_endpoint/rest/invoices?organization_id=289ec5fb-0970-44e3-
               "source": {
                 "applyToNewCustomersOnly": false,
                 "discountedProducts": {},
-                "durationMonths": 6,
+                "durationDays": 60,
                 "type": "PERCENTAGE",
                 "cutoffDate": "2021-09-16T00:00:00Z",
                 "adjustmentReferenceId": "dfbe71e2-113d-4212-a315-b8d755ef02d4",
@@ -609,7 +609,7 @@ curl "https://cloudmc_endpoint/rest/invoices?organization_id=289ec5fb-0970-44e3-
               "source": {
                 "applyToNewCustomersOnly": false,
                 "discountedProducts": {},
-                "durationMonths": 12,
+                "durationDays": 60,
                 "type": "PERCENTAGE",
                 "packageDiscount": 23.0,
                 "cutoffDate": "2021-08-29T00:00:00Z",
@@ -980,7 +980,7 @@ curl -X PUT "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8
               "source": {
                 "applyToNewCustomersOnly": false,
                 "discountedProducts": {},
-                "durationMonths": 6,
+                "durationDays": 60,
                 "type": "PERCENTAGE",
                 "cutoffDate": "2021-09-16T00:00:00Z",
                 "adjustmentReferenceId": "dfbe71e2-113d-4212-a315-b8d755ef02d4",
@@ -1031,7 +1031,7 @@ curl -X PUT "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8
               "source": {
                 "applyToNewCustomersOnly": false,
                 "discountedProducts": {},
-                "durationMonths": 12,
+                "durationDays": 60,
                 "type": "PERCENTAGE",
                 "packageDiscount": 23.0,
                 "cutoffDate": "2021-08-29T00:00:00Z",


### PR DESCRIPTION
### Fixes [MC-15962](https://cloud-ops.atlassian.net/browse/MC-15962)

#### Changes made
Migrate discount duration from months to days.

#### Related PRs
- https://github.com/cloudops/cloudmc-ui/pull/2023
- https://github.com/cloudops/cloudmc-core/pull/1646

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->