### PR TITLE
MC-16537: Drop invoice.total, only use invoice.detail.total

### DIFF
--- a/source/includes/administration/_invoices.md
+++ b/source/includes/administration/_invoices.md
@@ -358,12 +358,11 @@ Attributes | &nbsp;
 `dueDate`<br/>*date* | The date the invoice is due.
 `organization.id`<br/>*UUID* | The UUID of the organization the invoice belongs to.
 `organization.name`<br/>*string* | The name of the organization the invoice belongs to.
-`total`<br/>*BigDecimal* | The invoice total after discounts, taxes and credits.
 `balance`<br/>*BigDecimal* | The invoice's remaining balance.
 `detail`<br/>*Object* | The invoice detail contains a currency and a list of categories. Each category has a list of products.
 `detail.currency`<br/>*string* | The short-name of the currency.
 `detail.subTotal`<br/>*string* | A string containing the total before taxes and credits.
-`detail.total`<br/>*string* | A string containing the total after taxes and credits.
+`detail.total`<br/>*string* | The invoice total after discounts, taxes and credits.
 `detail.startDate`<br/>*string* | An ISO-8601 instant format string representing the start of the invoice detail report.
 `detail.endDate`<br/>*string* | An ISO-8601 instant format string representing the end of the invoice detail report.
 `detail.adjustments`<br/>*Array[Object]* | The adjustments applied to the invoice. An adjustment tracks the application of a discount, a credit or a tax.
@@ -780,12 +779,11 @@ Attributes | &nbsp;
 `dueDate`<br/>*date* | The date the invoice is due.
 `organization.id`<br/>*UUID* | The UUID of the organization the invoice belongs to.
 `organization.name`<br/>*string* | The name of the organization the invoice belongs to.
-`total`<br/>*BigDecimal* | The invoice total after discounts, taxes and credits.
 `balance`<br/>*BigDecimal* | The invoice's remaining balance.
 `detail`<br/>*Object* | The invoice detail contains a currency and a list of categories. Each category has a list of products.
 `detail.currency`<br/>*string* | The short-name of the currency.
 `detail.subTotal`<br/>*string* | A string containing the total before taxes and credits.
-`detail.total`<br/>*string* | A string containing the total after taxes and credits.
+`detail.total`<br/>*string* | The invoice total after discounts, taxes and credits.
 `detail.startDate`<br/>*string* | An ISO-8601 instant format string representing the start of the invoice detail report.
 `detail.endDate`<br/>*string* | An ISO-8601 instant format string representing the end of the invoice detail report.
 `detail.adjustments`<br/>*Array[Object]* | The adjustments applied to the invoice. An adjustment tracks the application of a discount, a credit or a tax.
@@ -1197,12 +1195,11 @@ Attributes | &nbsp;
 `dueDate`<br/>*date* | The date the invoice is due.
 `organization.id`<br/>*UUID* | The UUID of the organization the invoice belongs to.
 `organization.name`<br/>*string* | The name of the organization the invoice belongs to.
-`total`<br/>*BigDecimal* | The invoice total after discounts, taxes and credits.
 `balance`<br/>*BigDecimal* | The invoice's remaining balance.
 `detail`<br/>*Object* | The invoice detail contains a currency and a list of categories. Each category has a list of products.
 `detail.currency`<br/>*string* | The short-name of the currency.
 `detail.subTotal`<br/>*string* | A string containing the total before taxes and credits.
-`detail.total`<br/>*string* | A string containing the total after taxes and credits.
+`detail.total`<br/>*string* | The invoice total after discounts, taxes and credits.
 `detail.startDate`<br/>*string* | An ISO-8601 instant format string representing the start of the invoice detail report.
 `detail.endDate`<br/>*string* | An ISO-8601 instant format string representing the end of the invoice detail report.
 `detail.adjustments`<br/>*Array[Object]* | The adjustments applied to the invoice. An adjustment tracks the application of a discount, a credit or a tax.

--- a/source/includes/administration/_invoices.md
+++ b/source/includes/administration/_invoices.md
@@ -362,7 +362,7 @@ Attributes | &nbsp;
 `detail`<br/>*Object* | The invoice detail contains a currency and a list of categories. Each category has a list of products.
 `detail.currency`<br/>*string* | The short-name of the currency.
 `detail.subTotal`<br/>*string* | A string containing the total before taxes and credits.
-`detail.total`<br/>*string* | The invoice total after discounts, taxes and credits.
+`detail.total`<br/>*string* | The invoice total after discounts, taxes, and credits.
 `detail.startDate`<br/>*string* | An ISO-8601 instant format string representing the start of the invoice detail report.
 `detail.endDate`<br/>*string* | An ISO-8601 instant format string representing the end of the invoice detail report.
 `detail.adjustments`<br/>*Array[Object]* | The adjustments applied to the invoice. An adjustment tracks the application of a discount, a credit or a tax.
@@ -783,7 +783,7 @@ Attributes | &nbsp;
 `detail`<br/>*Object* | The invoice detail contains a currency and a list of categories. Each category has a list of products.
 `detail.currency`<br/>*string* | The short-name of the currency.
 `detail.subTotal`<br/>*string* | A string containing the total before taxes and credits.
-`detail.total`<br/>*string* | The invoice total after discounts, taxes and credits.
+`detail.total`<br/>*string* | The invoice total after discounts, taxes, and credits.
 `detail.startDate`<br/>*string* | An ISO-8601 instant format string representing the start of the invoice detail report.
 `detail.endDate`<br/>*string* | An ISO-8601 instant format string representing the end of the invoice detail report.
 `detail.adjustments`<br/>*Array[Object]* | The adjustments applied to the invoice. An adjustment tracks the application of a discount, a credit or a tax.
@@ -1199,7 +1199,7 @@ Attributes | &nbsp;
 `detail`<br/>*Object* | The invoice detail contains a currency and a list of categories. Each category has a list of products.
 `detail.currency`<br/>*string* | The short-name of the currency.
 `detail.subTotal`<br/>*string* | A string containing the total before taxes and credits.
-`detail.total`<br/>*string* | The invoice total after discounts, taxes and credits.
+`detail.total`<br/>*string* | The invoice total after discounts, taxes, and credits.
 `detail.startDate`<br/>*string* | An ISO-8601 instant format string representing the start of the invoice detail report.
 `detail.endDate`<br/>*string* | An ISO-8601 instant format string representing the end of the invoice detail report.
 `detail.adjustments`<br/>*Array[Object]* | The adjustments applied to the invoice. An adjustment tracks the application of a discount, a credit or a tax.


### PR DESCRIPTION
### Fixes [MC-16537](https://cloud-ops.atlassian.net/browse/MC-16537)

#### Code walkthrough : none

#### Issue
Currently, our invoice model has a `total` which is taken from the `detail.total` upon generation.
1. Data duplication, since the two values should always be the same
2. Inconsistent display of total when invoice is in `usage_pending` and `draft` state between invoice view and PDF
3. `usage_pending` invoices are created with `detail.subTotal = detail.total = null`. This presents an issue when the invoice is auto-drafted.

#### Solution
Use `detail.total` everywhere.
1. Drop `invoice.total` from model and database.
2. Always show $0.00 rather than showing N/A for `usage_pending` invoices (update views to be consistent withthe PDF)
3. Always set `detail.subTotal = detail.total = 0.00` when creating an invoice detail. This will resolve issues with `usage_pending` invoices becoming automatically drafted without a subtotal/total.

#### Related PRs
- https://github.com/cloudops/cloudmc-core/pull/1657
- https://github.com/cloudops/cloudmc-ui/pull/2033
