### PR TITLE
MC-16534: Add bccEmails to billing settings doc

### DIFF
--- a/source/includes/administration/_billing_settings.md
+++ b/source/includes/administration/_billing_settings.md
@@ -27,6 +27,7 @@ curl "https://cloudmc_endpoint/api/rest/reseller/settings/billing/find?organizat
     "daysBeforeAutoDraft": 3,
     "daysBeforeAutoApproval": 3,
     "daysBeforeAutoPayment": 5,
+    "bccEmails": ["finance.support@company.com", "monitoring@company.com"],
     "daysBeforeCardWarnings": [30],
     "customerInformation": ["accountId"],
     "address": ["Address line 1", "Address line 2", "etc."],
@@ -45,6 +46,7 @@ Attributes | &nbsp;
 `daysBeforeAutoDraft`<br/>*integer* | The number of days after the billing date to continue gathering missing customer usage before the invoice is drafted. Cannot be less than 2 days.
 `daysBeforeAutoApproval`<br/>*integer* | The number of days to review a draft invoice before it is automatically issued to the customer.
 `daysBeforeAutoPayment`<br/>*integer* | The number of days after the invoice has been issued before the customer's credit card is automatically charged.
+`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending email to customers upon billing exceptions.
 `daysBeforeCardWarnings`<br/>*Array[integer]* | Specify the number of days before notifying a customer of an expiring credit card. You can specify 1 to 5 values between 1 and 60.
 `customerInformation`<br/>*Array[string]* | The list of client custom fields to display in the invoice.
 `address`<br/>*Array[string]* | The address to display in the invoice. Each address field will be a row in the address block.
@@ -75,6 +77,7 @@ curl "https://cloudmc_endpoint/api/rest/reseller/settings/billing/f7ad28a8-1227-
     "daysBeforeAutoDraft": 3,
     "daysBeforeAutoApproval": 3,
     "daysBeforeAutoPayment": 5,
+    "bccEmails": ["finance.support@company.com", "monitoring@company.com"],
     "daysBeforeCardWarnings": [30],
     "customerInformation": ["accountId"],
     "address": ["Address line 1", "Address line 2", "etc."],
@@ -93,6 +96,7 @@ Attributes | &nbsp;
 `daysBeforeAutoDraft`<br/>*integer* | The number of days after the billing date to continue gathering missing customer usage before the invoice is drafted. Cannot be less than 2 days.
 `daysBeforeAutoApproval`<br/>*integer* | The number of days to review a draft invoice before it is automatically issued to the customer.
 `daysBeforeAutoPayment`<br/>*integer* | The number of days after the invoice has been issued before the customer's credit card is automatically charged.
+`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending email to customers upon billing exceptions.
 `daysBeforeCardWarnings`<br/>*Array[integer]* | Specify the number of days before notifying a customer of an expiring credit card. You can specify 1 to 5 values between 1 and 60.
 `customerInformation`<br/>*Array[string]* | The list of client custom fields to display in the invoice.
 `address`<br/>*Array[string]* | The address to display in the invoice. Each address field will be a row in the address block.
@@ -121,6 +125,7 @@ curl -X POST "https://cloudmc_endpoint/api/rest/reseller/settings/billing" \
   "daysBeforeAutoApproval": 3,
   "daysBeforeAutoPayment": 5,
   "daysBeforeAutoDraft": 3,
+  "bccEmails": ["finance.support@company.com", "monitoring@company.com"],
   "daysBeforeCardWarnings": [30],
   "customerInformation": ["accountId"],
   "address": ["Address line 1", "Address line 2", "etc."],
@@ -141,6 +146,7 @@ curl -X POST "https://cloudmc_endpoint/api/rest/reseller/settings/billing" \
     "daysBeforeAutoDraft": 3,
     "daysBeforeAutoApproval": 3,
     "daysBeforeAutoPayment": 5,
+    "bccEmails": ["finance.support@company.com", "monitoring@company.com"],
     "daysBeforeCardWarnings": [30],
     "customerInformation": ["accountId"],
     "address": ["Address line 1", "Address line 2", "etc."],
@@ -162,6 +168,7 @@ Optional | &nbsp;
 `customerInformation`<br/>*Array[string]* | The list of client custom fields to display in the invoice.
 `address`<br/>*Array[string]* | The address to display in the invoice. Each address field will be a row in the address block.
 `termsAndConditions`<br/>*string* | The terms and conditions to display in the invoice.
+`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending email to customers upon billing exceptions.
 
 <!-------------------- UPDATE BILLING SETTINGS -------------------->
 #### Update billing settings
@@ -190,6 +197,7 @@ curl -X PUT "https://cloudmc_endpoint/api/rest/reseller/settings/billing/d785ffc
    "daysBeforeAutoDraft": 3,
   "daysBeforeAutoApproval": 3,
   "daysBeforeAutoPayment": 5,
+  "bccEmails": ["finance.support@company.com", "monitoring@company.com"],
   "daysBeforeCardWarnings": [30],
   "customerInformation": ["accountId"],
   "address": ["Address line 1", "Address line 2", "etc."],
@@ -210,6 +218,7 @@ curl -X PUT "https://cloudmc_endpoint/api/rest/reseller/settings/billing/d785ffc
     "daysBeforeAutoDraft": 3,
     "daysBeforeAutoApproval": 3,
     "daysBeforeAutoPayment": 5,
+    "bccEmails": ["finance.support@company.com", "monitoring@company.com"],
     "daysBeforeCardWarnings": [30],
     "customerInformation": ["accountId"],
     "address": ["Address line 1", "Address line 2", "etc."],
@@ -232,6 +241,7 @@ Optional | &nbsp;
 `customerInformation`<br/>*Array[string]* | The list of client custom fields to display in the invoice.
 `address`<br/>*Array[string]* | The address to display in the invoice. Each address field will be a row in the address block.
 `termsAndConditions`<br/>*string* | The terms and conditions to display in the invoice.
+`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending email to customers upon billing exceptions.
 
 <!-------------------- DELETE BILLING SETTINGS -------------------->
 #### Delete billing settings

--- a/source/includes/administration/_billing_settings.md
+++ b/source/includes/administration/_billing_settings.md
@@ -46,7 +46,7 @@ Attributes | &nbsp;
 `daysBeforeAutoDraft`<br/>*integer* | The number of days after the billing date to continue gathering missing customer usage before the invoice is drafted. Cannot be less than 2 days.
 `daysBeforeAutoApproval`<br/>*integer* | The number of days to review a draft invoice before it is automatically issued to the customer.
 `daysBeforeAutoPayment`<br/>*integer* | The number of days after the invoice has been issued before the customer's credit card is automatically charged.
-`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending email to customers upon billing exceptions.
+`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending emails to customers upon billing exceptions.
 `daysBeforeCardWarnings`<br/>*Array[integer]* | Specify the number of days before notifying a customer of an expiring credit card. You can specify 1 to 5 values between 1 and 60.
 `customerInformation`<br/>*Array[string]* | The list of client custom fields to display in the invoice.
 `address`<br/>*Array[string]* | The address to display in the invoice. Each address field will be a row in the address block.
@@ -96,7 +96,7 @@ Attributes | &nbsp;
 `daysBeforeAutoDraft`<br/>*integer* | The number of days after the billing date to continue gathering missing customer usage before the invoice is drafted. Cannot be less than 2 days.
 `daysBeforeAutoApproval`<br/>*integer* | The number of days to review a draft invoice before it is automatically issued to the customer.
 `daysBeforeAutoPayment`<br/>*integer* | The number of days after the invoice has been issued before the customer's credit card is automatically charged.
-`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending email to customers upon billing exceptions.
+`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending emails to customers upon billing exceptions.
 `daysBeforeCardWarnings`<br/>*Array[integer]* | Specify the number of days before notifying a customer of an expiring credit card. You can specify 1 to 5 values between 1 and 60.
 `customerInformation`<br/>*Array[string]* | The list of client custom fields to display in the invoice.
 `address`<br/>*Array[string]* | The address to display in the invoice. Each address field will be a row in the address block.
@@ -168,7 +168,7 @@ Optional | &nbsp;
 `customerInformation`<br/>*Array[string]* | The list of client custom fields to display in the invoice.
 `address`<br/>*Array[string]* | The address to display in the invoice. Each address field will be a row in the address block.
 `termsAndConditions`<br/>*string* | The terms and conditions to display in the invoice.
-`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending email to customers upon billing exceptions.
+`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending emails to customers upon billing exceptions.
 
 <!-------------------- UPDATE BILLING SETTINGS -------------------->
 #### Update billing settings
@@ -241,7 +241,7 @@ Optional | &nbsp;
 `customerInformation`<br/>*Array[string]* | The list of client custom fields to display in the invoice.
 `address`<br/>*Array[string]* | The address to display in the invoice. Each address field will be a row in the address block.
 `termsAndConditions`<br/>*string* | The terms and conditions to display in the invoice.
-`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending email to customers upon billing exceptions.
+`bccEmails`<br/>*Array[string]* | List of email addresses to include as BCC when sending emails to customers upon billing exceptions.
 
 <!-------------------- DELETE BILLING SETTINGS -------------------->
 #### Delete billing settings


### PR DESCRIPTION
### Fixes [MC-16534](https://cloud-ops.atlassian.net/browse/MC-16534)

#### Changes made
- I added a field to the billing settings called bccEmails.
- During the automatic payment job (upon failure of payment) or when sending an email to a customer for an expiring credit card, we add those emails as BCC.

#### Related PRs
- Core: https://github.com/cloudops/cloudmc-core/pull/1660
- UI: https://github.com/cloudops/cloudmc-ui/pull/2035

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->