### PR TITLE
add storage section to docs

### DIFF
--- a/source/includes/aws/_storage.md
+++ b/source/includes/aws/_storage.md
@@ -1,0 +1,1 @@
+## Storage

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -225,6 +225,8 @@ includes:
   - aws
   - aws/compute
   - aws/instances
+  - aws/storage
+  - aws/volumes
 
 search: true
 ---


### PR DESCRIPTION
We were missing the index reference to the storage section in our API docs