### PR TITLE
MC-17108: Attach Volume Documentation

### DIFF
--- a/source/includes/aws/_volumes.md
+++ b/source/includes/aws/_volumes.md
@@ -234,7 +234,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/volumes/:id</code>
 
-| Attributes                 | &nbsp;                                        |
-|----------------------------|-----------------------------------------------|
-| `taskId` <br/>*string*     | The task id related to the instance deletion. |
-| `taskStatus` <br/>*string* | The status of the operation.                  |
+| Attributes                 | &nbsp;                                          |
+|----------------------------|-------------------------------------------------|
+| `taskId` <br/>*string*     | The task id related to the instance detachment. |
+| `taskStatus` <br/>*string* | The status of the operation.                    |

--- a/source/includes/aws/_volumes.md
+++ b/source/includes/aws/_volumes.md
@@ -231,23 +231,8 @@ curl -X POST \
 > Request body example for a volume:
 ```json
 {
-    "attachmentDeviceName": "/dev/sda1",
     "instanceIdToAttach": "i-0b4e945ee65072b8a",
-    "attachments": [],
-    "availabilityZone": "us-east-1b",
-    "createTime": "2022-02-01T20:24:25.786Z",
-    "encrypted": false,
-    "fastRestored": false,
-    "id": "vol-0c103471947ff275d",
-    "iops": 100,
-    "multiAttachEnabled": true,
-    "name": "vol-0c103471947ff275d",
-    "size": 5,
-    "snapshotId": "",
-    "state": "available",
-    "tags": [],
-    "volumeId": "vol-0c103471947ff275d",
-    "volumeType": "io1"
+    "attachmentDeviceName": "/dev/sda1"
 }
 ```
 

--- a/source/includes/aws/_volumes.md
+++ b/source/includes/aws/_volumes.md
@@ -157,6 +157,53 @@ curl -X DELETE \
 | `taskStatus` <br/>*string* | The status of the operation.                  |
 
 
+<!-------------------- ATTACH A VOLUME -------------------->
+
+#### Attach a volume
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/v1/services/aws/test-area/volumes/vol-0d1f9106cd0e0dff7?operation=attach"
+```
+
+> Request body example for a volume:
+```json
+{
+    "attachmentDeviceName": "/dev/sda1",
+    "instanceIdToAttach": "i-0b4e945ee65072b8a",
+    "attachments": [],
+    "availabilityZone": "us-east-1b",
+    "createTime": "2022-02-01T20:24:25.786Z",
+    "encrypted": false,
+    "fastRestored": false,
+    "id": "vol-0c103471947ff275d",
+    "iops": 100,
+    "multiAttachEnabled": true,
+    "name": "vol-0c103471947ff275d",
+    "size": 5,
+    "snapshotId": "",
+    "state": "available",
+    "tags": [],
+    "volumeId": "vol-0c103471947ff275d",
+    "volumeType": "io1"
+}
+```
+
+> The above command returns a JSON structured like this:
+```json
+{
+    "taskId": "c8f44de4-e36f-456d-9802-3fb59cce3de2",
+    "taskStatus": "PENDING"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/volumes/:id</code>
+
+| Attributes                 | &nbsp;                                          |
+|----------------------------|-------------------------------------------------|
+| `taskId` <br/>*string*     | The task id related to the instance attachment. |
+| `taskStatus` <br/>*string* | The status of the operation.                    |
 
 <!-------------------- DETACH A VOLUME -------------------->
 

--- a/source/includes/aws/_volumes.md
+++ b/source/includes/aws/_volumes.md
@@ -235,6 +235,15 @@ curl -X POST \
     "attachmentDeviceName": "/dev/sda1"
 }
 ```
+| Attributes                 | &nbsp;                                          |
+|----------------------------|-------------------------------------------------|
+| `instanceIdToAttach` <br/>*string*   | Id of the instance the volume will be attached to (must be in the same availability zone). |
+| `attachmentDeviceName` <br/>*string* |  The device name that you assign is used by Amazon EC2. The device names that you're allowed to assign depends on the virtualization type of the selected instance.                  |
+- Linux device names: ***/dev/sdf*** through ***/dev/sdp***
+- Windows device names: ***/dev/xvdf*** through ***/dev/xvdz***
+- Linux root device names: ***/dev/sda1*** or ***/dev/xvda*** (depending on the AMI)
+- Windows root device names: ***/dev/sda1***
+
 
 > The above command returns a JSON structured like this:
 ```json


### PR DESCRIPTION
### Fixes [MC-17108](https://cloud-ops.atlassian.net/browse/MC-17108)

#### Changes made
<!-- Changes should match the template provided below -->
- ...

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->