### PR TITLE
MC-17223: Add aws s3 delete object docs

### DIFF
--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -9,7 +9,7 @@ View and manage your objects within a bucket.
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/rest/services/aws/test-env/objects/:regionName/:bucketName/:pathToObject/?operation=object_delete"
+   "https://cloudmc_endpoint/rest/services/aws/test-env/objects/:regionName/:bucketName/:pathToObject/"
 ```
 
 > Request body examples:

--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -16,7 +16,6 @@ curl -X DELETE \
 
 ```json
 {
-	"fullPath": "images/",
   "id": "ap-south-1/bucket-root-dwyak/images/",
 }
 ```

--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -1,0 +1,38 @@
+### Objects
+
+View and manage your objects within a bucket.
+
+<!-------------------- DELETE AN OBJECT -------------------->
+
+#### Delete Objects
+
+```shell
+curl -X DELETE \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/rest/services/aws/test-env/objects/:regionName/:bucketName/:pathToObject/?operation=object_delete"
+```
+
+> Request body examples:
+
+```json
+{
+	"fullPath": "images/",
+  "id": "ap-south-1/bucket-root-dwyak/images/",
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "taskId": "30121175-926a-4fd2-991b-ff303ffdf905",
+    "taskStatus": "PENDING"
+}
+```
+
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/objects/:regionName/:bucketName/:fullPath</code>
+| Attributes                 | &nbsp;                                        |
+|----------------------------|-----------------------------------------------|
+| `taskId` <br/>*string*     | The task id related to the bucket deletion. |
+| `taskStatus` <br/>*string* | The status of the operation.                  |
+

--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -33,6 +33,6 @@ curl -X DELETE \
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/objects/:regionName/:bucketName/:fullPath</code>
 | Attributes                 | &nbsp;                                        |
 |----------------------------|-----------------------------------------------|
-| `taskId` <br/>*string*     | The task id related to the bucket deletion. |
+| `taskId` <br/>*string*     | The task id related to the object deletion. |
 | `taskStatus` <br/>*string* | The status of the operation.                  |
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -227,6 +227,7 @@ includes:
   - aws/volumes
   - aws/s3
   - aws/buckets
+  - aws/objects
 
 search: true
 ---


### PR DESCRIPTION
### Fixes [MC-17223](https://cloud-ops.atlassian.net/browse/MC-17223)

#### Changes made
Added a page on s3 bucket object deletions
#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->