### PR TITLE
Feature/mc 17232 upload file

### DIFF
--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -2,6 +2,62 @@
 
 View and manage your objects within a bucket.
 
+<!-------------------- UPLOAD AN OBJECT -------------------->
+
+#### Upload Object
+
+```shell
+curl -X POST \
+   -H "X-CSRF-TOKEN: your_token" \
+   -H "Cookie: session_id" \
+   "https://cloudmc_endpoint/rest/services/operation/upload" \
+   --form operation=upload \
+   --form entityType=objects \
+   --form serviceConnectionId=connection_id \
+   --form environmentId=environment_id \
+   --form filename=file_size \
+   --form bucketName=bucket_name \
+   --form regionName=region_name \
+   --form file=path_to_file
+```
+
+> Request body examples as Multipart Form:
+
+```json
+operation: upload
+entityType: objects
+serviceConnectionId: connection_id
+environmentId: environment_id
+filename: file_size
+bucketName: bucket_name
+regionName: region_name
+file: path_to_file
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+	"files": [
+		{
+			"name": "filename.png",
+			"size": 93240,
+			"status": "success"
+		}
+	]
+}
+```
+
+<code>POST /services/operation/upload</code>
+
+Attributes | &nbsp;
+---------- | -----
+`filename: file_size`<br/>*string* | Multipart form part: key-value pair with the name of the file as key and its file size as value.
+`bucketName`<br/>*string* | Multipart form part: key-value pair with "bucketName" as key and the name of the bucket to upload to as value.
+`regionName`<br/>*string* | Multipart form part: key-value pair with "regionName" as key and the name of the region to upload to as value.
+`file`<br/>*file* | Multipart form part: key-value pair with "file" as key and the file to upload as value.
+
+
 <!-------------------- DELETE AN OBJECT -------------------->
 
 #### Delete Objects


### PR DESCRIPTION
### Fixes [MC-17232](https://cloud-ops.atlassian.net/browse/MC-17232)

#### Changes made
![Screen Shot 2022-03-17 at 11 13 47 AM](https://user-images.githubusercontent.com/35710207/158877797-022df5d5-87a9-49b1-8d2f-6f7242626a93.png)


#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->