### PR TITLE
Fix/mc 17224 accept bucektId from getObjects API as opposed to two separate params

### DIFF
--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -9,7 +9,7 @@ View and manage your objects within a bucket.
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/rest/services/aws/test-env/objects?regionName=us-east-1&prefix=photos&bucketName=bucket-root-nvisf'"
+   "https://cloudmc_endpoint/rest/services/aws/test-env/objects?bucketId=us-east-1/bucket-root-brdje"
 ```
 > The above command returns a JSON structured like this:
 
@@ -63,13 +63,13 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/objects/?regionName=us-east-1&bucketName=bucket-root-nvisf</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/objects/?bucketId=:bucketId</code>
 
 Retrieve a list of objects inside a given folder inside a given bucket.
 
 | Attributes                        | &nbsp;                                                                                                                                                                                                                   |
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`<br/>*string*                 | The ID of the object, which is of the form ":regionName/:bucketName/:objectName".                                                                                                                                                |
+| `id`<br/>*string*                 | The ID of the object, which is of the form `:regionName/:bucketName/:objectName`.                                                                                                                                                |
 | `name`<br/>*string*               | The name of the object.                                                                                                                                                     
 | `fullPath`<br/>*string*               | The actual key of the object inside the bucket, which is represented as a full path.                                                                                                                                                    |
 | `size`<br/>*integer*     | The size of the object in bytes.                                                                                                                                                     |
@@ -81,12 +81,11 @@ Retrieve a list of objects inside a given folder inside a given bucket.
 | `isFolder`<br/>*boolean*       | Boolean denoting whether the object acts as a folder. This is always true when the name ends with a '/' character.
 | `bucketName`<br/>*string*       | The name of the bucket the object exists within.
 | `region`<br/>*string*       | The name of the region the object exists within.
-| `isVirtual`<br/>*string*       | Boolean denoting whether the folder is virtual. If true there exists no object named ‘`{folderName}/`‘, and the folder exists only as a part of a complete object path (`{folderName}/{objectName}`). If false, there exists a key in the bucket named ‘{folderName}/’. If the query parameter `nested = true`, the request will not return any virtual folders.
+| `isVirtual`<br/>*string*       | Boolean denoting whether the folder is virtual. If true there exists no object named `:folderName/`, and the folder exists only as a part of a complete object path (`:folderName/:objectName`). If false, there exists a key in the bucket named ‘{folderName}/’. If the query parameter `nested = true`, the request will not return any virtual folders.
 
-| Required Query Paramaters                        | &nbsp;                                                                                                                                                                                                                   |
+| Required Query Parameters                        | &nbsp;                                                                                                                                                                                                                   |
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `bucketName`<br/>*string*       | The name of the bucket to get the objects in.
-| `regionName`<br/>*string*       | The name of the region to get the objects in.
+| `bucketId`<br/>*string*       | The ID of the bucket of the form `:regionName/:bucketName`.
 
 | Optional Query Paramaters                        | &nbsp;                                                                                                                                                                                                                   |
 |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
### Fixes [MC-17224](https://cloud-ops.atlassian.net/browse/MC-)

#### Changes made
<!-- Changes should match the template provided below -->
- ...

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->