### PR TITLE
MC-17110: Attach volumes on createInstance operation

### DIFF
--- a/source/includes/aws/_instances.md
+++ b/source/includes/aws/_instances.md
@@ -228,8 +228,13 @@ curl -X POST \
     "iops": 3000,
     "throughput": 250
   }],
-  "vpcId" : "vpc-0b23fed563eebe635",
-  "subnetId" : "subnet-0d4d9d813e763d403"
+  "vpcId": "vpc-0b23fed563eebe635",
+  "subnetId": "subnet-0d4d9d813e763d403",
+  "volumesToAttach": [{
+    "volumeId": "vol-1",
+    "device": "/dev/sdg",
+    "availabilityZone": "us-east-1a"
+  }]
 }
 ```
 
@@ -258,7 +263,8 @@ Create a new instance in a given [environment](#administration-environments).
 | `maxCount`<br/>*integer*                | The maximum number of instances to create. Cannot be greater than 20.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `minCount`<br/>*integer*                | The minimum number of instances to create. Should be greater than 1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `sshKey.keyName`<br/>*string*           | The name of the SSH key to be used to connect to this instance via SSH.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `blockDeviceMappings`<br/>*Array*       | Volumes to attached to the instance on launch. To be left empty if the default root volume should be used.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `blockDeviceMappings`<br/>*Array*       | Volumes to attached to the instance on launch. To be left empty if the default root volume should be used.  
+| `volumesToAttach`<br/>*Array*       | Volumes to attached to the instance after it is launched. Only volumes in the same availability zone as the subnet can be attached.      
 
 
 | Optional                                                | &nbsp;                                                                                                                                                             |

--- a/source/includes/aws/_instances.md
+++ b/source/includes/aws/_instances.md
@@ -233,7 +233,6 @@ curl -X POST \
   "volumesToAttach": [{
     "volumeId": "vol-1",
     "device": "/dev/sdg",
-    "availabilityZone": "us-east-1a"
   }]
 }
 ```


### PR DESCRIPTION
### Fixes [MC-17110](https://cloud-ops.atlassian.net/browse/MC-17110)

#### Changes made
<!-- Changes should match the template provided below -->
- ...

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->