### PR TITLE
MC-17689: added api doc for flagging invoices

### DIFF
--- a/source/includes/administration/_invoices.md
+++ b/source/includes/administration/_invoices.md
@@ -2143,9 +2143,9 @@ curl  -X GET 'https://cloudmc_endpoint/rest/invoices/download?invoice_id=3f7b7cc
 `POST /invoices/:invoiceId/flag`
 
 Flag an invoice with a message to prevent the invoice from being automatically issued to the customer. 
-Once an invoice is flagged, pricing configuration changes can be made. 
-If the configuration changes impact the previously flagged invoice, it will be voided and a new invoice will be generated. 
-Note: the flag will be maintained even after a new invoice is generated. In order to clear the flag the invoice must be approved. 
+
+As with other invoices that are not in the hands of the customer, pricing configuration changes can be made to regenerate the invoice.
+If the configuration changes made impact the invoice, it will be voided and a new invoice will be generated. If the invoice was previously flagged, the new invoice will still have the same flag and will need to be manually approved to issue it to the customer.
 
 
 ```shell
@@ -2157,6 +2157,7 @@ curl -X POST "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb
 | Required | &nbsp; |
 | --- | --- |
 | `invoiceId`<br/>*UUID* | The id of the invoice to be flagged |
+| `message`<br/>*String* | A 280 character message about why this invoice needed to be flagged. 
 
 
 > Request body example:

--- a/source/includes/administration/_invoices.md
+++ b/source/includes/administration/_invoices.md
@@ -2136,3 +2136,52 @@ curl  -X GET 'https://cloudmc_endpoint/rest/invoices/download?invoice_id=3f7b7cc
 | Required | &nbsp; |
 | --- | --- |
 | `invoice_id`<br/>*UUID* | The id of the invoice. |
+
+
+<!-------------------- FLAG INVOICE -------------------->
+
+`POST /invoices/:invoiceId/flag`
+
+Flag an invoice with a message to prevent the invoice from being automatically issued to the customer. 
+Once an invoice is flagged, pricing configuration changes can be made. 
+If the configuration changes impact the previously flagged invoice, it will be voided and a new invoice will be generated. 
+Note: the flag will be maintained even after a new invoice is generated. In order to clear the flag the invoice must be approved. 
+
+
+```shell
+# Approve a draft invoice
+curl -X POST "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8416b2cbb/flag" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+| Required | &nbsp; |
+| --- | --- |
+| `invoiceId`<br/>*UUID* | The id of the invoice to be flagged |
+
+
+> Request body example:
+
+```json
+{
+   "message": "The prices charged to this customer are incorrect. We should perform a pricing change and ensure the invoice is regenerated."
+}
+```
+
+> The above command return JSON structured like this:
+```json
+{
+	"data": {
+		"createdAt": "2022-04-08T12:40:33Z",
+		"invoice": {
+			"id": "0bf4b212-816b-4c6d-9466-47abeb0a0826"
+		},
+		"message": "The prices charged to this customer are incorrect. We should perform a pricing change and ensure the invoice is regenerated.",
+		"user": {
+			"firstName": "Jason",
+			"lastName": "Dias",
+			"id": "f117f36e-902e-41fb-b7b2-0a6a73be5396",
+			"email": "jdias@cloudops.com"
+		}
+	}
+}
+```


### PR DESCRIPTION
### Fixes [MC-17689](https://cloud-ops.atlassian.net/browse/MC-17689)

#### Changes made
<!-- Changes should match the template provided below -->
- added doc for flagging an invoice

#### Related PRs
- https://github.com/cloudops/cloudmc-core/pull/1970

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->