### PR TITLE
MC-17813: Add gen url docs

### DIFF
--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -413,7 +413,7 @@ curl -X POST \
    "https://cloudmc_endpoint/rest/services/aws/test-env/objects/:regionName/:bucketName/:pathToObject?&operation=generate_url"
 ```
 
-Generates a presigned URL in S3. Must specify a limit in the request which denotes the amount of time (in minutes) until the URL expires. Minimum is 1 minute and maximum is 10008 minutes.
+Generates a presigned URL in S3. Must specify a limit in the request which denotes the amount of time (in minutes) until the URL expires. Minimum is 1 minute and maximum is 10080 minutes.
 
 > Request body examples:
 

--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -403,3 +403,43 @@ Renames a folder in Amazon S3. This operation renames all objects inside the fol
 | `taskId` <br/>*string*     | The task ID related to the folder renaming. |
 | `taskStatus` <br/>*string* | The status of the operation.                  |
 
+<!-------------------- GENERATE URL -------------------->
+
+#### Generate URL
+
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/rest/services/aws/test-env/objects/:regionName/:bucketName/:pathToObject?&operation=generate_url"
+```
+
+Generates a presigned URL in S3. Must specify a limit in the request which denotes the amount of time (in minutes) until the URL expires.
+
+> Request body examples:
+
+```json
+{
+  "limit": "60",
+}
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+    "taskId": "30121175-926a-4fd2-991b-ff303ffdf905",
+    "taskStatus": "SUCCESS"
+}
+```
+
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/objects/:regionName/:bucketName/:objectFullPath?&operation=generate_url</code>
+
+| Required                 | &nbsp;                                        |
+|----------------------------|-----------------------------------------------|
+| `limit` <br/>*integer*     | The length (in minutes) the link will be active for.                         |
+
+| Attributes                 | &nbsp;                                        |
+|----------------------------|-----------------------------------------------|
+| `taskId` <br/>*string*     | The task ID related to the URL generation.    |
+| `taskStatus` <br/>*string* | The status of the operation.                  |
+

--- a/source/includes/aws/_objects.md
+++ b/source/includes/aws/_objects.md
@@ -413,7 +413,7 @@ curl -X POST \
    "https://cloudmc_endpoint/rest/services/aws/test-env/objects/:regionName/:bucketName/:pathToObject?&operation=generate_url"
 ```
 
-Generates a presigned URL in S3. Must specify a limit in the request which denotes the amount of time (in minutes) until the URL expires.
+Generates a presigned URL in S3. Must specify a limit in the request which denotes the amount of time (in minutes) until the URL expires. Minimum is 1 minute and maximum is 10008 minutes.
 
 > Request body examples:
 


### PR DESCRIPTION
Added generate URL docs for s3 

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->