### PR TITLE
Added missing kubernetes ingress v1 api

### DIFF
--- a/source/includes/azure/_k8_ingresses.md_v1.erb
+++ b/source/includes/azure/_k8_ingresses.md_v1.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_ingresses_v1.md" %>

--- a/source/includes/gcp/_k8_ingresses_v1.md.erb
+++ b/source/includes/gcp/_k8_ingresses_v1.md.erb
@@ -1,0 +1,1 @@
+<%= partial "includes/kubernetes_extension/_k8_ingresses_v1.md" %>

--- a/source/includes/kubernetes/_k8_ingresses_v1.md
+++ b/source/includes/kubernetes/_k8_ingresses_v1.md
@@ -1,13 +1,13 @@
-### Ingresses V1Beta1
+### Ingresses V1
 
-<!-------------------- LIST INGRESSES V1Beta1 -------------------->
+<!-------------------- LIST INGRESSES V1 -------------------->
 
-#### List ingresses V1Beta1
+#### List ingresses V1
 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1"
 ```
 
 > The above command returns a JSON structured like this:
@@ -73,9 +73,9 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1</code>
 
-Retrieve a list of all ingresses V1Beta1 in a given [environment](#administration-environments).
+Retrieve a list of all ingresses V1 in a given [environment](#administration-environments).
 
 | Attributes                         | &nbsp;                                               |
 | ---------------------------------- | ---------------------------------------------------- |
@@ -93,14 +93,14 @@ Retrieve a list of all ingresses V1Beta1 in a given [environment](#administratio
 
 Note that the list is not complete, since it is referring to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- GET AN INGRESS V1Beta1 -------------------->
+<!-------------------- GET AN INGRESS V1 -------------------->
 
-#### Get an ingress V1Beta1
+#### Get an ingress V1
 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses/cloudmc/cmc-stg"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1/cloudmc/cmc-stg"
 ```
 
 > The above command returns a JSON structured like this:
@@ -134,9 +134,9 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1/:id</code>
 
-Retrieve an ingress V1Beta1 and all its info in a given [environment](#administration-environments).
+Retrieve an ingress V1 and all its info in a given [environment](#administration-environments).
 
 | Attributes                         | &nbsp;                                               |
 | ---------------------------------- | ---------------------------------------------------- |
@@ -154,17 +154,17 @@ Retrieve an ingress V1Beta1 and all its info in a given [environment](#administr
 
 Note that the list is not complete, since it is referring to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- CREATE INGRESS V1Beta1 -------------------->
+<!-------------------- CREATE INGRESS V1 -------------------->
 
-#### Create an ingress V1Beta1
+#### Create an ingress V1
 
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1"
   Content-Type: application/json
   {
-  "apiVersion": "networking.k8s.io/v1beta1",
+  "apiVersion": "networking.k8s.io/v1",
   "kind": "Ingress",
   "metadata": {
     "name": "ingress-name",
@@ -183,8 +183,12 @@ curl -X POST \
               "path": "/testpath",
               "pathType": "Prefix",
               "backend": {
-                "serviceName": "test",
-                "servicePort": 80
+                "service": {
+                  "name": "test",
+                  "port": {
+                    "number": 80 
+                  }
+                }
               }
             }
           ]
@@ -195,9 +199,9 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1</code>
 
-Create an ingress V1Beta1 in a given [environment](#administration-environments).
+Create an ingress V1 in a given [environment](#administration-environments).
 
 | Required Attributes           | &nbsp;                                                |
 | ----------------------------- | ----------------------------------------------------- |
@@ -218,14 +222,14 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create ingress task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                     |
 
-<!-------------------- REPLACE AN INGRESS V1Beta1 -------------------->
+<!-------------------- REPLACE AN INGRESS V1 -------------------->
 
-#### Replace an ingress V1Beta1
+#### Replace an ingress V1
 
 ```shell
 curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses/ingress-name/default"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1/ingress-name/default"
 ```
 > Request body example:
 
@@ -236,7 +240,7 @@ curl -X PUT \
     "port": "6556",
     "name": "test"
   },
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "networking.k8s.io/v1",
   "kind": "Ingress",
   "metadata": {
     "creationTimestamp": "2020-08-13T14:13:42.000-04:00",
@@ -254,8 +258,12 @@ curl -X PUT \
           "paths": [
             {
               "backend": {
-                "serviceName": "test",
-                "servicePort": 6556
+                "service": {
+                  "name": "test",
+                  "port": {
+                    "number": 6556
+                  }
+                }
               },
               "path": "/testpath"
             }
@@ -285,9 +293,9 @@ curl -X PUT \
 }
 ```
 
-<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id</code>
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1/:id</code>
 
-Replace an ingress V1Beta1 in a given [environment](#administration-environments).
+Replace an ingress V1 in a given [environment](#administration-environments).
 
 | Required Attributes           | &nbsp;                                                             |
 | ----------------------------- | ------------------------------------------------------------------ |
@@ -303,14 +311,14 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the replace ingress task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                      |
 
-<!-------------------- DELETE AN INGRESS V1Beta1 -------------------->
+<!-------------------- DELETE AN INGRESS V1 -------------------->
 
-#### Delete an ingress V1Beta1
+#### Delete an ingress V1
 
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses/test-ingress/default"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1/test-ingress/default"
 ```
 
 > The above command returns a JSON structured like this:
@@ -322,9 +330,9 @@ curl -X DELETE \
 }
 ```
 
-<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id</code>
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1/:id</code>
 
-Delete an ingress V1Beta1 from a given [environment](#administration-environments).
+Delete an ingress V1 from a given [environment](#administration-environments).
 
 | Attributes                 | &nbsp;                                           |
 | -------------------------- | ------------------------------------------------ |

--- a/source/includes/kubernetes_extension/_k8_ingresses.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses.md
@@ -1,8 +1,8 @@
-#### Ingresses
+#### Ingresses V1Beta1
 
-<!-------------------- LIST INGRESSES -------------------->
+<!-------------------- LIST INGRESSES V1Beta1 -------------------->
 
-##### List ingresses
+##### List ingresses V1Beta1
 
 ```shell
 curl -X GET \
@@ -29,7 +29,6 @@ curl -X GET \
         "name": "cloudmc",
         "namespace": "cmc-stg",
         "resourceVersion": "143213903",
-        "selfLink": "/apis/extensions/v1beta1/namespaces/cmc-stg/ingresses/cloudmc",
         "uid": "376bc4c5-a3e4-11e9-b6bd-02006e76001e"
       },
       "spec": {
@@ -61,7 +60,6 @@ curl -X GET \
         "namespace": "auth",
         "ownerReferences": [],
         "resourceVersion": "143213968",
-        "selfLink": "/apis/extensions/v1beta1/namespaces/auth/ingresses/cm-acme-http-solver-75png",
         "uid": "48720f48-f2bc-45fc-95c5-60cae8ffe11e"
       },
       "spec": {
@@ -77,7 +75,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses?cluster_id=:cluster_id</code>
 
-Retrieve a list of all ingresses in a given [environment](#administration-environments).
+Retrieve a list of all ingresses V1Beta1 in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                             |
 | -------------------------- | -------------------------------------------------- |
@@ -97,11 +95,11 @@ Retrieve a list of all ingresses in a given [environment](#administration-enviro
 | `metadata.uid` <br/>_object_       | The UUID of the ingress                             |
 | `spec`<br/>_object_                | The attributes that a user specifies for an ingress |
 
-Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+Note that the list is not complete, since it is referring to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- GET AN INGRESS -------------------->
+<!-------------------- GET AN INGRESS V1Beta1 -------------------->
 
-##### Get an ingress
+##### Get an ingress V1Beta1
 
 ```shell
 curl -X GET \
@@ -127,7 +125,6 @@ curl -X GET \
       "name": "cloudmc",
       "namespace": "cmc-stg",
       "resourceVersion": "143213903",
-      "selfLink": "/apis/extensions/v1beta1/namespaces/cmc-stg/ingresses/cloudmc",
       "uid": "376bc4c5-a3e4-11e9-b6bd-02006e76001e"
     },
     "spec": {
@@ -143,7 +140,7 @@ curl -X GET \
 
 <code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id?cluster_id=:cluster_id</code>
 
-Retrieve an ingress and all its info in a given [environment](#administration-environments).
+Retrieve an ingress V1Beta1 and all its info in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                             |
 | -------------------------- | -------------------------------------------------- |
@@ -163,11 +160,11 @@ Retrieve an ingress and all its info in a given [environment](#administration-en
 | `metadata.uid` <br/>_object_       | The UUID of the ingress                             |
 | `spec`<br/>_object_                | The attributes that a user specifies for an ingress |
 
-Note that the list is not complete, since it is refering to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
+Note that the list is not complete, since it is referring to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- CREATE AN INGRESS -------------------->
+<!-------------------- CREATE AN INGRESS V1Beta1 -------------------->
 
-##### Create an ingress
+##### Create an ingress V1Beta1
 
 ```shell
 curl -X POST \
@@ -208,7 +205,7 @@ curl -X POST \
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id?cluster_id=:cluster_id</code>
 
-Create an ingress in a given [environment](#administration-environments).
+Create an ingress V1Beta1 in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                             |
 | -------------------------- | -------------------------------------------------- |
@@ -233,9 +230,9 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create ingress task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                     |
 
-<!-------------------- REPLACE AN INGRESS -------------------->
+<!-------------------- REPLACE AN INGRESS V1Beta1 -------------------->
 
-##### Replace an ingress
+##### Replace an ingress V1Beta1
 
 ```shell
 curl -X PUT \
@@ -259,7 +256,6 @@ curl -X PUT \
     "name": "ingress-name",
     "namespace": "default",
     "resourceVersion": "170302224",
-    "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/ingress-name",
     "uid": "c67e6a6a-2b07-4976-8b3d-2ec9fd91ae5d"
   },
   "spec": {
@@ -303,7 +299,7 @@ curl -X PUT \
 
 <code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id?cluster_id=:cluster_id</code>
 
-Replace an ingress in a given [environment](#administration-environments).
+Replace an ingress V1Beta1 in a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                             |
 | -------------------------- | -------------------------------------------------- |
@@ -323,9 +319,9 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the replace ingress task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                      |
 
-<!-------------------- DELETE AN INGRESS -------------------->
+<!-------------------- DELETE AN INGRESS V1Beta1 -------------------->
 
-##### Delete an ingress
+##### Delete an ingress V1Beta1
 
 ```shell
 curl -X DELETE \
@@ -344,7 +340,7 @@ curl -X DELETE \
 
 <code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id?cluster_id=:cluster_id</code>
 
-Delete an ingress from a given [environment](#administration-environments).
+Delete an ingress V1Beta1 from a given [environment](#administration-environments).
 
 | Required                   | &nbsp;                                             |
 | -------------------------- | -------------------------------------------------- |

--- a/source/includes/kubernetes_extension/_k8_ingresses_v1.md
+++ b/source/includes/kubernetes_extension/_k8_ingresses_v1.md
@@ -1,13 +1,13 @@
-### Ingresses V1Beta1
+#### Ingresses V1
 
-<!-------------------- LIST INGRESSES V1Beta1 -------------------->
+<!-------------------- LIST INGRESSES V1 -------------------->
 
-#### List ingresses V1Beta1
+##### List ingresses V1
 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -73,34 +73,38 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1?cluster_id=:cluster_id</code>
 
-Retrieve a list of all ingresses V1Beta1 in a given [environment](#administration-environments).
+Retrieve a list of all ingresses V1 in a given [environment](#administration-environments).
 
-| Attributes                         | &nbsp;                                               |
-| ---------------------------------- | ---------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the ingress.                               |
-| `endpoint` <br/>_string_           | The endpoint of the ingress.                         |
-| `service` <br/>_object_            | The service associated with the ingress.             |
-| `service.port` <br/>_string_       | The port of the service associated with the ingress. |
-| `service.name` <br/>_string_       | The name of the service associated with the ingress. |
-| `metadata` <br/>_object_           | The metadata of the ingress.                         |
-| `metadata.name` <br/>_string_      | The name of the ingress.                             |
-| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created.       |
-| `metadata.labels` <br/>_object_    | The labels associated with the ingress.              |
-| `metadata.uid` <br/>_object_       | The UUID of the ingress.                             |
-| `spec`<br/>_object_                | The attributes that a user specifies for an ingress. |
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
+
+| Attributes                         | &nbsp;                                              |
+| ---------------------------------- | --------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the ingress                               |
+| `endpoint` <br/>_string_           | The endpoint of the ingress                         |
+| `service` <br/>_object_            | The service associated with the ingress             |
+| `service.port` <br/>_string_       | The port of the service associated with the ingress |
+| `service.name` <br/>_string_       | The name of the service associated with the ingress |
+| `metadata` <br/>_object_           | The metadata of the ingress                         |
+| `metadata.name` <br/>_string_      | The name of the ingress                             |
+| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created       |
+| `metadata.labels` <br/>_object_    | The labels associated with the ingress              |
+| `metadata.uid` <br/>_object_       | The UUID of the ingress                             |
+| `spec`<br/>_object_                | The attributes that a user specifies for an ingress |
 
 Note that the list is not complete, since it is referring to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- GET AN INGRESS V1Beta1 -------------------->
+<!-------------------- GET AN INGRESS V1 -------------------->
 
-#### Get an ingress V1Beta1
+##### Get an ingress V1
 
 ```shell
 curl -X GET \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses/cloudmc/cmc-stg"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1/cloudmc/cmc-stg?cluster_id=a_cluster_id"
 ```
 
 > The above command returns a JSON structured like this:
@@ -134,37 +138,41 @@ curl -X GET \
 }
 ```
 
-<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id</code>
+<code>GET /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1/:id?cluster_id=:cluster_id</code>
 
-Retrieve an ingress V1Beta1 and all its info in a given [environment](#administration-environments).
+Retrieve an ingress V1 and all its info in a given [environment](#administration-environments).
 
-| Attributes                         | &nbsp;                                               |
-| ---------------------------------- | ---------------------------------------------------- |
-| `id` <br/>_string_                 | The id of the ingress.                               |
-| `endpoint` <br/>_string_           | The endpoint of the ingress.                         |
-| `service` <br/>_object_            | The service associated with the ingress.             |
-| `service.port` <br/>_string_       | The port of the service associated with the ingress. |
-| `service.name` <br/>_string_       | The name of the service associated with the ingress. |
-| `metadata` <br/>_object_           | The metadata of the ingress.                         |
-| `metadata.name` <br/>_string_      | The name of the ingress.                             |
-| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created.       |
-| `metadata.labels` <br/>_object_    | The labels associated with the ingress.              |
-| `metadata.uid` <br/>_object_       | The UUID of the ingress.                             |
-| `spec`<br/>_object_                | The attributes that a user specifies for an ingress. |
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
+
+| Attributes                         | &nbsp;                                              |
+| ---------------------------------- | --------------------------------------------------- |
+| `id` <br/>_string_                 | The id of the ingress                               |
+| `endpoint` <br/>_string_           | The endpoint of the ingress                         |
+| `service` <br/>_object_            | The service associated with the ingress             |
+| `service.port` <br/>_string_       | The port of the service associated with the ingress |
+| `service.name` <br/>_string_       | The name of the service associated with the ingress |
+| `metadata` <br/>_object_           | The metadata of the ingress                         |
+| `metadata.name` <br/>_string_      | The name of the ingress                             |
+| `metadata.namespace` <br/>_string_ | The namespace in which the ingress is created       |
+| `metadata.labels` <br/>_object_    | The labels associated with the ingress              |
+| `metadata.uid` <br/>_object_       | The UUID of the ingress                             |
+| `spec`<br/>_object_                | The attributes that a user specifies for an ingress |
 
 Note that the list is not complete, since it is referring to the [kubernetes api details](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
 
-<!-------------------- CREATE INGRESS V1Beta1 -------------------->
+<!-------------------- CREATE AN INGRESS V1 -------------------->
 
-#### Create an ingress V1Beta1
+##### Create an ingress V1
 
 ```shell
 curl -X POST \
   -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1"
   Content-Type: application/json
   {
-  "apiVersion": "networking.k8s.io/v1beta1",
+  "apiVersion": "networking.k8s.io/v1",
   "kind": "Ingress",
   "metadata": {
     "name": "ingress-name",
@@ -183,8 +191,12 @@ curl -X POST \
               "path": "/testpath",
               "pathType": "Prefix",
               "backend": {
-                "serviceName": "test",
-                "servicePort": 80
+                "service": {
+                  "name": "test",
+                  "port": {
+                    "number": 80 
+                  }
+                }
               }
             }
           ]
@@ -195,9 +207,13 @@ curl -X POST \
 }
 ```
 
-<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses</code>
+<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1/:id?cluster_id=:cluster_id</code>
 
-Create an ingress V1Beta1 in a given [environment](#administration-environments).
+Create an ingress V1 in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
 
 | Required Attributes           | &nbsp;                                                |
 | ----------------------------- | ----------------------------------------------------- |
@@ -218,14 +234,14 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the create ingress task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                     |
 
-<!-------------------- REPLACE AN INGRESS V1Beta1 -------------------->
+<!-------------------- REPLACE AN INGRESS V1 -------------------->
 
-#### Replace an ingress V1Beta1
+##### Replace an ingress V1
 
 ```shell
 curl -X PUT \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses/ingress-name/default"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1/ingress-name/default?cluster_id=test-cluster"
 ```
 > Request body example:
 
@@ -236,7 +252,7 @@ curl -X PUT \
     "port": "6556",
     "name": "test"
   },
-  "apiVersion": "extensions/v1beta1",
+  "apiVersion": "networking.k8s.io/v1",
   "kind": "Ingress",
   "metadata": {
     "creationTimestamp": "2020-08-13T14:13:42.000-04:00",
@@ -254,8 +270,12 @@ curl -X PUT \
           "paths": [
             {
               "backend": {
-                "serviceName": "test",
-                "servicePort": 6556
+                "service": {
+                  "name": "test",
+                  "port": {
+                    "number": 6556
+                  }
+                }
               },
               "path": "/testpath"
             }
@@ -285,9 +305,13 @@ curl -X PUT \
 }
 ```
 
-<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id</code>
+<code>PUT /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1/:id?cluster_id=:cluster_id</code>
 
-Replace an ingress V1Beta1 in a given [environment](#administration-environments).
+Replace an ingress V1 in a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
 
 | Required Attributes           | &nbsp;                                                             |
 | ----------------------------- | ------------------------------------------------------------------ |
@@ -303,14 +327,14 @@ Return value:
 | `taskId` <br/>_string_     | The id corresponding to the replace ingress task. |
 | `taskStatus` <br/>_string_ | The status of the operation.                      |
 
-<!-------------------- DELETE AN INGRESS V1Beta1 -------------------->
+<!-------------------- DELETE AN INGRESS V1 -------------------->
 
-#### Delete an ingress V1Beta1
+##### Delete an ingress V1
 
 ```shell
 curl -X DELETE \
    -H "MC-Api-Key: your_api_key" \
-   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingresses/test-ingress/default"
+   "https://cloudmc_endpoint/api/v1/services/a_service/an_environment/ingressesv1/test-ingress/default?cluster_id=test-cluster"
 ```
 
 > The above command returns a JSON structured like this:
@@ -322,9 +346,15 @@ curl -X DELETE \
 }
 ```
 
-<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingresses/:id</code>
+<code>DELETE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/ingressesv1/:id?cluster_id=:cluster_id</code>
 
-Delete an ingress V1Beta1 from a given [environment](#administration-environments).
+Delete an ingress V1 from a given [environment](#administration-environments).
+
+| Required                   | &nbsp;                                             |
+| -------------------------- | -------------------------------------------------- |
+| `cluster_id` <br/>_string_ | The id of the cluster in which to get the ingress. |
+
+Return value:
 
 | Attributes                 | &nbsp;                                           |
 | -------------------------- | ------------------------------------------------ |

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -123,6 +123,7 @@ includes:
   - gcp/k8_networking
   - gcp/k8_services
   - gcp/k8_ingresses
+  - gcp/k8_ingresses_v1
   - gcp/k8_configuration
   - gcp/k8_configmaps
   - gcp/k8_secrets
@@ -148,6 +149,7 @@ includes:
   - kubernetes/k8_networking
   - kubernetes/k8_services
   - kubernetes/k8_ingresses
+  - kubernetes/k8_ingresses_v1
   - kubernetes/k8_configuration
   - kubernetes/k8_configmaps
   - kubernetes/k8_secrets
@@ -184,6 +186,7 @@ includes:
   - azure/k8_networking
   - azure/k8_services
   - azure/k8_ingresses
+  - azure/k8_ingresses_v1
   - azure/k8_configuration
   - azure/k8_configmaps
   - azure/k8_secrets


### PR DESCRIPTION
### Fixes [MC-](https://cloud-ops.atlassian.net/browse/MC-)

#### Changes made
<!-- Changes should match the template provided below -->
- Added missing documentation for kubernetes ingress v1

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->