### PR TITLE
MC-18316: Updated API docs for WAF settings

### DIFF
--- a/source/includes/stackpath/_waf.md
+++ b/source/includes/stackpath/_waf.md
@@ -28,28 +28,36 @@ curl -X GET \
     "owaspThreats": {
       "sqlInjection": false,
       "xssAttack": true,
+      "shellShockAttack": true,
       "remoteFileInclusion": true,
-      "wordpressWafRuleset": true,
       "apacheStrutsExploit": true,
       "localFileInclusion": false,
       "commonWebApplicationVulnerabilities": true,
       "webShellExecutionAttempt": true,
-      "responseHeaderInjection": true,
+      "protocolAttack": true,
+      "csrf": true,
       "openRedirect": false,
-      "shellInjection": false
+      "shellInjection": false,
+      "codeInjection": false,
+      "sensitiveDataExposure": false,
+      "xmlExternalEntity": false,
+      "personalIdentifiableInfo": false,
+      "serverSideTemplateInjection": false
     },
-    "userAgents": {
+    "generalPolicies": {
       "blockInvalidUserAgents": false,
-      "blockUnknownUserAgents": true
+      "blockUnknownUserAgents": true,
+      "httpMethodValidation": true
     },
-    "csrf": true,
     "trafficSources": {
       "viaTorNodes": true,
       "viaProxyNetworks": true,
       "viaHostingServices": true,
       "viaVpn": true,
       "convictedBotTraffic": true,
-      "suspiciousTrafficByLocalIpFormat": true
+      "trafficFromSuspiciousNatRanges": true,
+      "externalReputationBlockList": false,
+      "trafficViaCDN": true
     },
     "antiAutomationBotProtection": {
       "forceBrowserValidationOnTrafficAnomalies": true,
@@ -57,25 +65,26 @@ curl -X GET \
       "challengeHeadlessBrowsers": false,
       "antiScraping": false
     },
-    "spamAndAbuseForm": false,
     "behavioralWaf": {
       "spamProtection": true,
       "blockProbingAndForcedBrowsing": true,
       "obfuscatedAttacksAndZeroDayMitigation": true,
       "repeatedViolations": true,
-      "bruteForceProtection": true
+      "bruteForceProtection": true,
     },
     "cmsProtection": {
+      "wordpressWafRuleset": false,
       "whiteListWordpress": false,
       "whiteListModx": false,
       "whiteListDrupal": false,
       "whiteListJoomla": false,
       "whiteMagento": false,
       "whiteListOriginIp": true,
-      "whiteListUmbraco": false
+      "whiteListUmbraco": false,
+      "whiteListPimcore": true
     },
     "allowKnownBots": {
-      "Internet Archive Bot": true,
+      "Internet Archive Bot": true
     }
   }
 }
@@ -101,32 +110,39 @@ Attributes | &nbsp;
 `owaspThreats.xssAttack`<br/>*boolean* | Block requests suspected of being a Cross-Site-Scripting attack attempt. Cross Site Scripting attacks attempt to exploit vulnerabilities in a Web application and seek to inject a client side script either across an entire site or to a specific user's session. A successful attack would typically allow forbidden access to a user's actions and data.
 `owaspThreats.shellShockAttack`<br/>*boolean* | Block requests suspected of being a Shellshock attack attempt. A Shellshock attack is an attempt to exploit a server's vulnerabilities to gain full access and control over them. A successful attack would typically either abuse a server's resources or hack the website.
 `owaspThreats.remoteFileInclusion`<br/>*boolean* | Block requests suspected of being a Remote File Inclusion attempt. Remote File Inclusion attempts to exploit vulnerabilities in a Web application (typically in PHP) to execute a script from a 3rd party server. RFI attacks provide a backdoor for the hacker to change the behaviour of a server and Web application.
-`owaspThreats.wordpressWafRuleset`<br/>*boolean* | Enable a set of rules designed to block common Wordpress exploits.
 `owaspThreats.apacheStrutsExploit`<br/>*boolean* | Patch known vulnerabilities in the Apache Struts framework by blocking requests suspected of exploiting these vulnerabilities.
 `owaspThreats.localFileInclusion`<br/>*boolean* | Block requests suspected of a Local File Inclusion attempt. Local File Inclusion attempts seek to exploit vulnerabilities in a Web application to execute potentially harmful scripts on your servers.
 `owaspThreats.commonWebApplicationVulnerabilities`<br/>*boolean* | Block attempts to access and potentially harm your servers through common backdoors, such as common control panels, configuration scripts etc. which may be accessible to unwanted users.
 `owaspThreats.webShellExecutionAttempt`<br/>*boolean* | Block requests suspected of Web shell attempts. A Web shell is a script that can be uploaded to a Web server to enable remote administration of the machine. Infected Web servers can either be internet-facing or internal to the network, where the Web shell is used to further pivot to internal hosts.
-`owaspThreats.responseHeaderInjection`<br/>*boolean* | Block requests suspected of Response header injection attempts. Response header injection attempts to inject a header via insufficient user input sanitation.
+`owaspThreats.protocolAttack`<br/>*boolean* | Block requests suspected of Response header injection attempts. Response header injection attempts to inject a header via insufficient user input sanitation.
+`owaspThreats.csrf`<br/>*boolean* | StackPath WAF will generate a CSRF token that is added to forms. Requests without a valid CSRF token will be blocked.
 `owaspThreats.openRedirect`<br/>*boolean* | Block requests suspected of being an Open Redirect attempt. Open Redirect attempts to exploit vulnerabilities in a Web application to redirect a user to a new website without any validation of the target of redirect.
 `owaspThreats.shellInjection`<br/>*boolean* | Block requests suspected of being a shell injection attack attempt. Shell Injection is an attack in which the goal is execution of arbitrary commands on the host operating system via a vulnerable application. Command injection attacks are possible when an application passes unsafe user supplied data (forms, cookies, HTTP headers etc.) to a system shell.
-`userAgents`<br/>*object* | Block requests with missing or invalid user agent string.
-`userAgents.blockInvalidUserAgents`<br/>*boolean* | Block requests in which the HTTP header describing the user-agent (browser and platform) seems invalid and cannot be translated to a known legitimate browser. Automated processes (bots) are most likely to have invalid user agents.
-`userAgents.blockUnknownUserAgents`<br/>*boolean* | Block requests in which the HTTP header describing the user-agent (browser and platform) is missing.
-`csrf`<br/>*boolean* | StackPath WAF will generate a CSRF token that is added to forms. Requests without a valid CSRF token will be blocked.
+`owaspThreats.codeInjection`<br/>*boolean* | Block requests suspected of being a code injection attack attempt. Code injection is the general term for attack types which consist of injecting code that is then interpreted/executed by the application. This type of attack exploits poor handling of untrusted data.
+`owaspThreats.sensitiveDataExposure`<br/>*boolean* | Block requests that do not properly protect sensitive data.
+`owaspThreats.xmlExternalEntity`<br/>*boolean* | Block requests that are potentially an XML external entity injection attack.
+`owaspThreats.personalIdentifiableInfo`<br/>*boolean* | Block requests that do not properly protect personally identifiable information (PII).
+`owaspThreats.serverSideTemplateInjection`<br/>*boolean* | Block requests that are potentially a server-side template injection attack.
+`generalPolicies`<br/>*object* | General policies
+`generalPolicies.blockInvalidUserAgents`<br/>*boolean* | Block requests in which the HTTP header describing the user-agent (browser and platform) seems invalid and cannot be translated to a known legitimate browser. Automated processes (bots) are most likely to have invalid user agents.
+`generalPolicies.blockUnknownUserAgents`<br/>*boolean* | Block requests in which the HTTP header describing the user-agent (browser and platform) is missing.
+`generalPolicies.httpMethodValidation`<br/>*boolean* | Block non-standard and suspicious HTTP methods.
 `trafficSources`<br/>*object* | Real-time threat intelligence for IP addresses, source location, and information on malicious IPs.
 `trafficSources.viaTorNodes`<br/>*boolean* | Challenge traffic from The Onion Ring exit nodes to block bots and known bad devices. While TOR is used sometimes purely for Web anonymity, it is commonly used by hackers, scrapers, and spammers to crawl or hack Web applications.
 `trafficSources.viaProxyNetworks`<br/>*boolean* | Challenge traffic from any known proxy network to block bots and known bad devices. While proxy services are used sometimes purely for Web anonymity, they are also commonly used by hackers, scrapers, and spammers to crawl or hack Web applications.
 `trafficSources.viaHostingServices`<br/>*boolean* | Challenge traffic from IP addresses known to be of hosting service companies. This rule is unlikely to see legitimate human traffic on these IP spaces since they are typically used for server hosting. In most cases, traffic from these IP spaces originate from infected servers that are controlled by hackers.
 `trafficSources.viaVpn`<br/>*boolean* | Challenge traffic from any known VPN to block bots and known bad devices. While VPNs are sometimes used purely for Web anonymity, they are also commonly used by hackers, scrapers, and spammers to crawl or hack Web applications.
 `trafficSources.convictedBotTraffic`<br/>*boolean* | Challenge traffic from IP addresses that have been convicted of automated activities (bots) on this site or on others. These IP addresses are used by malicious automated agents while no legitimate traffic has been observed on them.
-`trafficSources.suspiciousTrafficByLocalIpFormat`<br/>*boolean* | Challenge traffic from suspicious NAT ranges.
+`trafficSources.trafficFromSuspiciousNatRanges`<br/>*boolean* | Challenge traffic from high-risk NAT ranges, based on historical web behavior detected by a machine learning classifier.
+`trafficSources.externalReputationBlockList`<br/>*boolean* | Challenge traffic from any known spammer or abuser, based on data from multiple services.
+`trafficSources.trafficViaCDN`<br/>*boolean* | Challenge traffic from IP addresses originating from CDN companies.
 `antiAutomationBotProtection`<br/>*object* | Block automated traffic from scanning and browsing your online application.
 `antiAutomationBotProtection.forceBrowserValidationOnTrafficAnomalies`<br/>*boolean* | Challenge and block requests if the user or device behind them does not keep session cookies and does not execute JavaScripts correctly. Most malicious automated activities (bots) do not meet these conditions and will, therefore, effectively be blocked by the JavaScript challenge triggered in any suspected situation. Clients can also be blocked depending on whether they act in an abnormal to the specific domain—by scraping content in a way that most sessions on this domain don't—or clients that try to, for example, avoid detection by switching IPs.
 `antiAutomationBotProtection.challengeAutomatedClients`<br/>*boolean* | Captcha-challenge and block sessions conducted by standard Web browsers if there is evidence that these sessions are being automated and not driven by a human user. Such automation is used primarily for screen scraping and other very targeted, site-specific malicious automation.
 `antiAutomationBotProtection.challengeHeadlessBrowsers`<br/>*boolean* | Challenge requests if the user or device behind them uses an automation tool that initiates browsers but is actually an automation tool without real display—such as phantomJS, Selenium, or other. While such tools are favored by programmers, they are also extremely popular with scrapers, hackers and even in sophisticated DDoS attacks to circumvent standard anti-bot measures.
 `antiAutomationBotProtection.antiScraping`<br/>*boolean* | A more hardened anti-automation policy that is meant to stop scrapers by using faster and harsher convictions.
-`spamAndAbuseForm`<br/>*boolean* | Challenge and prevent automated tools from making HTTP/S Post requests without validating their session first.
 `cmsProtection`<br/>*object* | Whitelist admin users.
+`cmsProtection.wordpressWafRuleset`<br/>*boolean* | Enable a set of rules designed to block common Wordpress exploits.
 `cmsProtection.whiteListWordpress`<br/>*boolean* | Enable whitelist WordPress admin logged-in users.
 `cmsProtection.whiteListModx`<br/>*boolean* | Enable whitelist MODX admin logged-in users.
 `cmsProtection.whiteListDrupal`<br/>*boolean* | Enable whitelist Drupal admin logged-in users.
@@ -134,6 +150,7 @@ Attributes | &nbsp;
 `cmsProtection.whiteMagento`<br/>*boolean* | Enable whitelist Magento admin logged-in users.
 `cmsProtection.whiteListOriginIp`<br/>*boolean* | Enable this policy to whitelist requests coming from the origin for plugin updates and general CMS updates,
 `cmsProtection.whiteListUmbraco`<br/>*boolean* | Enable whitelist Umbraco admin logged-in users.
+`cmsProtection.whiteListPimcore`<br/>*boolean* | Enable whitelist PimCore admin logged-in users.
 `behavioralWaf`<br/>*object* | StackPath's sophisticated user behaviour and reputation analysis rules.
 `behavioralWaf.spamProtection`<br/>*boolean* | Challenge and block user sessions and activities that seem to be aggressively using forms on your website to post spam content, generate new accounts, and more. Also, require a handshake (if not already provided) to clients making POST requests.
 `behavioralWaf.blockProbingAndForcedBrowsing`<br/>*boolean* | Challenge or block sessions and users that seem to make brute-forced requests on random URLs seeking to discover a Web application's structure and hidden directories.
@@ -156,9 +173,9 @@ curl -X PATCH \
 
 ```json
 {
-	"owaspThreats": {
-      "localFileInclusion": false
-	}
+  "owaspThreats": {
+    "localFileInclusion": false
+  }
 }
 ```
 
@@ -188,32 +205,39 @@ Attributes | &nbsp;
 `owaspThreats.xssAttack`<br/>*boolean* | Block requests suspected of being a Cross-Site-Scripting attack attempt. Cross Site Scripting attacks attempt to exploit vulnerabilities in a Web application and seek to inject a client side script either across an entire site or to a specific user's session. A successful attack would typically allow forbidden access to a user's actions and data.
 `owaspThreats.shellShockAttack`<br/>*boolean* | Block requests suspected of being a Shellshock attack attempt. A Shellshock attack is an attempt to exploit a server's vulnerabilities to gain full access and control over them. A successful attack would typically either abuse a server's resources or hack the website.
 `owaspThreats.remoteFileInclusion`<br/>*boolean* | Block requests suspected of being a Remote File Inclusion attempt. Remote File Inclusion attempts to exploit vulnerabilities in a Web application (typically in PHP) to execute a script from a 3rd party server. RFI attacks provide a backdoor for the hacker to change the behaviour of a server and Web application.
-`owaspThreats.wordpressWafRuleset`<br/>*boolean* | Enable a set of rules designed to block common Wordpress exploits.
 `owaspThreats.apacheStrutsExploit`<br/>*boolean* | Patch known vulnerabilities in the Apache Struts framework by blocking requests suspected of exploiting these vulnerabilities.
 `owaspThreats.localFileInclusion`<br/>*boolean* | Block requests suspected of a Local File Inclusion attempt. Local File Inclusion attempts seek to exploit vulnerabilities in a Web application to execute potentially harmful scripts on your servers.
 `owaspThreats.commonWebApplicationVulnerabilities`<br/>*boolean* | Block attempts to access and potentially harm your servers through common backdoors, such as common control panels, configuration scripts etc. which may be accessible to unwanted users.
 `owaspThreats.webShellExecutionAttempt`<br/>*boolean* | Block requests suspected of Web shell attempts. A Web shell is a script that can be uploaded to a Web server to enable remote administration of the machine. Infected Web servers can either be internet-facing or internal to the network, where the Web shell is used to further pivot to internal hosts.
-`owaspThreats.responseHeaderInjection`<br/>*boolean* | Block requests suspected of Response header injection attempts. Response header injection attempts to inject a header via insufficient user input sanitation.
+`owaspThreats.protocolAttack`<br/>*boolean* | Block requests suspected of Response header injection attempts. Response header injection attempts to inject a header via insufficient user input sanitation.
+`owaspThreats.csrf`<br/>*boolean* | StackPath WAF will generate a CSRF token that is added to forms. Requests without a valid CSRF token will be blocked.
 `owaspThreats.openRedirect`<br/>*boolean* | Block requests suspected of being an Open Redirect attempt. Open Redirect attempts to exploit vulnerabilities in a Web application to redirect a user to a new website without any validation of the target of redirect.
 `owaspThreats.shellInjection`<br/>*boolean* | Block requests suspected of being a shell injection attack attempt. Shell Injection is an attack in which the goal is execution of arbitrary commands on the host operating system via a vulnerable application. Command injection attacks are possible when an application passes unsafe user supplied data (forms, cookies, HTTP headers etc.) to a system shell.
-`userAgents`<br/>*object* | Block requests with missing or invalid user agent string.
-`userAgents.blockInvalidUserAgents`<br/>*boolean* | Block requests in which the HTTP header describing the user-agent (browser and platform) seems invalid and cannot be translated to a known legitimate browser. Automated processes (bots) are most likely to have invalid user agents.
-`userAgents.blockUnknownUserAgents`<br/>*boolean* | Block requests in which the HTTP header describing the user-agent (browser and platform) is missing.
-`csrf`<br/>*boolean* | StackPath WAF will generate a CSRF token that is added to forms. Requests without a valid CSRF token will be blocked.
+`owaspThreats.codeInjection`<br/>*boolean* | Block requests suspected of being a code injection attack attempt. Code injection is the general term for attack types which consist of injecting code that is then interpreted/executed by the application. This type of attack exploits poor handling of untrusted data.
+`owaspThreats.sensitiveDataExposure`<br/>*boolean* | Block requests that do not properly protect sensitive data.
+`owaspThreats.xmlExternalEntity`<br/>*boolean* | Block requests that are potentially an XML external entity injection attack.
+`owaspThreats.personalIdentifiableInfo`<br/>*boolean* | Block requests that do not properly protect personally identifiable information (PII).
+`owaspThreats.serverSideTemplateInjection`<br/>*boolean* | Block requests that are potentially a server-side template injection attack.
+`generalPolicies`<br/>*object* | General policies
+`generalPolicies.blockInvalidUserAgents`<br/>*boolean* | Block requests in which the HTTP header describing the user-agent (browser and platform) seems invalid and cannot be translated to a known legitimate browser. Automated processes (bots) are most likely to have invalid user agents.
+`generalPolicies.blockUnknownUserAgents`<br/>*boolean* | Block requests in which the HTTP header describing the user-agent (browser and platform) is missing.
+`generalPolicies.httpMethodValidation`<br/>*boolean* | Block non-standard and suspicious HTTP methods.
 `trafficSources`<br/>*object* | Real-time threat intelligence for IP addresses, source location, and information on malicious IPs.
 `trafficSources.viaTorNodes`<br/>*boolean* | Challenge traffic from The Onion Ring exit nodes to block bots and known bad devices. While TOR is used sometimes purely for Web anonymity, it is commonly used by hackers, scrapers, and spammers to crawl or hack Web applications.
 `trafficSources.viaProxyNetworks`<br/>*boolean* | Challenge traffic from any known proxy network to block bots and known bad devices. While proxy services are used sometimes purely for Web anonymity, they are also commonly used by hackers, scrapers, and spammers to crawl or hack Web applications.
 `trafficSources.viaHostingServices`<br/>*boolean* | Challenge traffic from IP addresses known to be of hosting service companies. This rule is unlikely to see legitimate human traffic on these IP spaces since they are typically used for server hosting. In most cases, traffic from these IP spaces originate from infected servers that are controlled by hackers.
 `trafficSources.viaVpn`<br/>*boolean* | Challenge traffic from any known VPN to block bots and known bad devices. While VPNs are sometimes used purely for Web anonymity, they are also commonly used by hackers, scrapers, and spammers to crawl or hack Web applications.
 `trafficSources.convictedBotTraffic`<br/>*boolean* | Challenge traffic from IP addresses that have been convicted of automated activities (bots) on this site or on others. These IP addresses are used by malicious automated agents while no legitimate traffic has been observed on them.
-`trafficSources.suspiciousTrafficByLocalIpFormat`<br/>*boolean* | Challenge traffic from suspicious NAT ranges.
+`trafficSources.trafficFromSuspiciousNatRanges`<br/>*boolean* | Challenge traffic from high-risk NAT ranges, based on historical web behavior detected by a machine learning classifier.
+`trafficSources.externalReputationBlockList`<br/>*boolean* | Challenge traffic from any known spammer or abuser, based on data from multiple services.
+`trafficSources.trafficViaCDN`<br/>*boolean* | Challenge traffic from IP addresses originating from CDN companies.
 `antiAutomationBotProtection`<br/>*object* | Block automated traffic from scanning and browsing your online application.
 `antiAutomationBotProtection.forceBrowserValidationOnTrafficAnomalies`<br/>*boolean* | Challenge and block requests if the user or device behind them does not keep session cookies and does not execute JavaScripts correctly. Most malicious automated activities (bots) do not meet these conditions and will, therefore, effectively be blocked by the JavaScript challenge triggered in any suspected situation. Clients can also be blocked depending on whether they act in an abnormal to the specific domain—by scraping content in a way that most sessions on this domain don't—or clients that try to, for example, avoid detection by switching IPs.
 `antiAutomationBotProtection.challengeAutomatedClients`<br/>*boolean* | Captcha-challenge and block sessions conducted by standard Web browsers if there is evidence that these sessions are being automated and not driven by a human user. Such automation is used primarily for screen scraping and other very targeted, site-specific malicious automation.
 `antiAutomationBotProtection.challengeHeadlessBrowsers`<br/>*boolean* | Challenge requests if the user or device behind them uses an automation tool that initiates browsers but is actually an automation tool without real display—such as phantomJS, Selenium, or other. While such tools are favored by programmers, they are also extremely popular with scrapers, hackers and even in sophisticated DDoS attacks to circumvent standard anti-bot measures.
 `antiAutomationBotProtection.antiScraping`<br/>*boolean* | A more hardened anti-automation policy that is meant to stop scrapers by using faster and harsher convictions.
-`spamAndAbuseForm`<br/>*boolean* | Challenge and prevent automated tools from making HTTP/S Post requests without validating their session first.
 `cmsProtection`<br/>*object* | Whitelist admin users.
+`cmsProtection.wordpressWafRuleset`<br/>*boolean* | Enable a set of rules designed to block common Wordpress exploits.
 `cmsProtection.whiteListWordpress`<br/>*boolean* | Enable whitelist WordPress admin logged-in users.
 `cmsProtection.whiteListModx`<br/>*boolean* | Enable whitelist MODX admin logged-in users.
 `cmsProtection.whiteListDrupal`<br/>*boolean* | Enable whitelist Drupal admin logged-in users.
@@ -221,6 +245,7 @@ Attributes | &nbsp;
 `cmsProtection.whiteMagento`<br/>*boolean* | Enable whitelist Magento admin logged-in users.
 `cmsProtection.whiteListOriginIp`<br/>*boolean* | Enable this policy to whitelist requests coming from the origin for plugin updates and general CMS updates,
 `cmsProtection.whiteListUmbraco`<br/>*boolean* | Enable whitelist Umbraco admin logged-in users.
+`cmsProtection.whiteListPimcore`<br/>*boolean* | Enable whitelist PimCore admin logged-in users.
 `behavioralWaf`<br/>*object* | StackPath's sophisticated user behaviour and reputation analysis rules.
 `behavioralWaf.spamProtection`<br/>*boolean* | Challenge and block user sessions and activities that seem to be aggressively using forms on your website to post spam content, generate new accounts, and more. Also, require a handshake (if not already provided) to clients making POST requests.
 `behavioralWaf.blockProbingAndForcedBrowsing`<br/>*boolean* | Challenge or block sessions and users that seem to make brute-forced requests on random URLs seeking to discover a Web application's structure and hidden directories.

--- a/source/includes/stackpath/_waf.md
+++ b/source/includes/stackpath/_waf.md
@@ -70,7 +70,7 @@ curl -X GET \
       "blockProbingAndForcedBrowsing": true,
       "obfuscatedAttacksAndZeroDayMitigation": true,
       "repeatedViolations": true,
-      "bruteForceProtection": true,
+      "bruteForceProtection": true
     },
     "cmsProtection": {
       "wordpressWafRuleset": false,
@@ -114,7 +114,7 @@ Attributes | &nbsp;
 `owaspThreats.localFileInclusion`<br/>*boolean* | Block requests suspected of a Local File Inclusion attempt. Local File Inclusion attempts seek to exploit vulnerabilities in a Web application to execute potentially harmful scripts on your servers.
 `owaspThreats.commonWebApplicationVulnerabilities`<br/>*boolean* | Block attempts to access and potentially harm your servers through common backdoors, such as common control panels, configuration scripts etc. which may be accessible to unwanted users.
 `owaspThreats.webShellExecutionAttempt`<br/>*boolean* | Block requests suspected of Web shell attempts. A Web shell is a script that can be uploaded to a Web server to enable remote administration of the machine. Infected Web servers can either be internet-facing or internal to the network, where the Web shell is used to further pivot to internal hosts.
-`owaspThreats.protocolAttack`<br/>*boolean* | Block requests suspected of Response header injection attempts. Response header injection attempts to inject a header via insufficient user input sanitation.
+`owaspThreats.protocolAttack`<br/>*boolean* | Block requests suspected of being a protocol attack attempt. Protocol attacks attempt to inject and manipulate headers or query parameters via insufficient user input sanitation.
 `owaspThreats.csrf`<br/>*boolean* | StackPath WAF will generate a CSRF token that is added to forms. Requests without a valid CSRF token will be blocked.
 `owaspThreats.openRedirect`<br/>*boolean* | Block requests suspected of being an Open Redirect attempt. Open Redirect attempts to exploit vulnerabilities in a Web application to redirect a user to a new website without any validation of the target of redirect.
 `owaspThreats.shellInjection`<br/>*boolean* | Block requests suspected of being a shell injection attack attempt. Shell Injection is an attack in which the goal is execution of arbitrary commands on the host operating system via a vulnerable application. Command injection attacks are possible when an application passes unsafe user supplied data (forms, cookies, HTTP headers etc.) to a system shell.
@@ -209,7 +209,7 @@ Attributes | &nbsp;
 `owaspThreats.localFileInclusion`<br/>*boolean* | Block requests suspected of a Local File Inclusion attempt. Local File Inclusion attempts seek to exploit vulnerabilities in a Web application to execute potentially harmful scripts on your servers.
 `owaspThreats.commonWebApplicationVulnerabilities`<br/>*boolean* | Block attempts to access and potentially harm your servers through common backdoors, such as common control panels, configuration scripts etc. which may be accessible to unwanted users.
 `owaspThreats.webShellExecutionAttempt`<br/>*boolean* | Block requests suspected of Web shell attempts. A Web shell is a script that can be uploaded to a Web server to enable remote administration of the machine. Infected Web servers can either be internet-facing or internal to the network, where the Web shell is used to further pivot to internal hosts.
-`owaspThreats.protocolAttack`<br/>*boolean* | Block requests suspected of Response header injection attempts. Response header injection attempts to inject a header via insufficient user input sanitation.
+`owaspThreats.protocolAttack`<br/>*boolean* | Block requests suspected of being a protocol attack attempt. Protocol attacks attempt to inject and manipulate headers or query parameters via insufficient user input sanitation.
 `owaspThreats.csrf`<br/>*boolean* | StackPath WAF will generate a CSRF token that is added to forms. Requests without a valid CSRF token will be blocked.
 `owaspThreats.openRedirect`<br/>*boolean* | Block requests suspected of being an Open Redirect attempt. Open Redirect attempts to exploit vulnerabilities in a Web application to redirect a user to a new website without any validation of the target of redirect.
 `owaspThreats.shellInjection`<br/>*boolean* | Block requests suspected of being a shell injection attack attempt. Shell Injection is an attack in which the goal is execution of arbitrary commands on the host operating system via a vulnerable application. Command injection attacks are possible when an application passes unsafe user supplied data (forms, cookies, HTTP headers etc.) to a system shell.


### PR DESCRIPTION
### Fixes [MC-18316](https://cloud-ops.atlassian.net/browse/MC-18316)

#### Changes made
<!-- Changes should match the template provided below -->
- update model for waf settings after synchronization with SP.

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->