### PR TITLE
MC-18097: Added api doc for custom ui settings

### DIFF
--- a/source/includes/administration/_billing_settings.md
+++ b/source/includes/administration/_billing_settings.md
@@ -10,7 +10,7 @@ Retrieve the billing settings associated to an organization. If the `organizatio
 
 ```shell
 # Retrieve the billing settings
-curl "https://cloudmc_endpoint/api/rest/reseller/settings/billing/find?organizationId=10572c3d-16e5-450f-8af8-a01e50dc52d4" \
+curl "https://cloudmc_endpoint/api/v2/reseller/settings/billing/find?organizationId=10572c3d-16e5-450f-8af8-a01e50dc52d4" \
    -H "MC-Api-Key: your_api_key"
 ```
 
@@ -60,7 +60,7 @@ Attributes | &nbsp;
 
 ```shell
 # Retrieve billing settings
-curl "https://cloudmc_endpoint/api/rest/reseller/settings/billing/f7ad28a8-1227-44de-9785-6dbd556f3bda" \
+curl "https://cloudmc_endpoint/api/v2/reseller/settings/billing/f7ad28a8-1227-44de-9785-6dbd556f3bda" \
    -H "MC-Api-Key: your_api_key"
 ```
 
@@ -111,7 +111,7 @@ Create new billing settings.
 
 ```shell
 # Creates a new billing settings
-curl -X POST "https://cloudmc_endpoint/api/rest/reseller/settings/billing" \
+curl -X POST "https://cloudmc_endpoint/api/v2/reseller/settings/billing" \
    -H "MC-Api-Key: your_api_key"
 ```
 
@@ -179,7 +179,7 @@ Updates the billing settings of an organization.
 
 ```shell
 # Updates an existing billing settings for an organization
-curl -X PUT "https://cloudmc_endpoint/api/rest/reseller/settings/billing/d785ffcb-9b03-478d-a49b-52a2ccedf1b8 \
+curl -X PUT "https://cloudmc_endpoint/api/v2/reseller/settings/billing/d785ffcb-9b03-478d-a49b-52a2ccedf1b8 \
    -H "MC-Api-Key: your_api_key"
    -H "Content-Type: application/json" \
    -d "request-body"
@@ -251,7 +251,7 @@ Optional | &nbsp;
 Delete an existing billing settings.
 
 ```shell
-curl -X DELETE "https://cloudmc_endpoint/api/rest/reseller/settings/billing/d785ffcb-9b03-478d-a49b-52a2ccedf1b8" \
+curl -X DELETE "https://cloudmc_endpoint/api/v2/reseller/settings/billing/d785ffcb-9b03-478d-a49b-52a2ccedf1b8" \
    -H "MC-Api-Key: your_api_key"
 ```
 

--- a/source/includes/administration/_custom_ui_settings.md
+++ b/source/includes/administration/_custom_ui_settings.md
@@ -1,0 +1,256 @@
+### Custom UI Settings
+
+<!-------------------- FIND CUSTOM UI SETTINGS -------------------->
+
+#### Find custom ui settings associated to an organization
+
+`GET /reseller/settings/custom_ui/find?organizationId=:id`
+
+Retrieve the custom ui settings associated to an organization. If the `organizationId` is omitted, the authenticated user's organization will be used.
+
+```shell
+# Retrieve the custom ui settings
+curl "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/find?organizationId=10572c3d-16e5-450f-8af8-a01e50dc52d4" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "organization": {
+      "id": "10572c3d-16e5-450f-8af8-a01e50dc52d4"
+    },
+    "id": "d785ffcb-9b03-478d-a49b-52a2ccedf1b8",
+    "version": 1,
+    "enabled": true,
+    "customUIRootUrl": "https://newui.example.com",
+    "domainToken": "example.com",
+    "gotoParam": "target",
+    "applyTags": [],
+    "denyTags": [],
+    "redirectRoles": []
+  }
+}
+```
+
+Retrieve the custom UI settings associated to an organization.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The configured custom UI settings' id.
+`organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. It cannot be changed.
+`version`<br/>*integer* | The custom UI settings version.
+`enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login.
+`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration.
+`gotoParam`<br/>*string* | Parameter name to get path to redirect the user to.
+`applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match. 
+`denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
+`redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
+
+
+
+<!-------------------- GET CUSTOM UI SETTINGS -------------------->
+#### Retrieve custom UI settings
+
+`GET /reseller/settings/custom_ui/:id`
+
+```shell
+# Retrieve custom UI settings
+curl "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "organization": {
+      "id": "10572c3d-16e5-450f-8af8-a01e50dc52d4"
+    },
+    "id": "d785ffcb-9b03-478d-a49b-52a2ccedf1b8",
+    "version": 1,
+    "enabled": true,
+    "customUIRootUrl": "https://newui.example.com",
+    "domainToken": "example.com",
+    "gotoParam": "target",
+    "applyTags": [],
+    "denyTags": [],
+    "redirectRoles": []
+  }
+}
+```
+
+Retrieve the custom UI settings associated to the custom UI settings id.
+
+Attributes | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The configured custom UI settings' id.
+`organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. It cannot be changed.
+`version`<br/>*integer* | The custom UI settings version.
+`enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login.
+`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration.
+`gotoParam`<br/>*string* | Parameter name to get path to redirect the user to.
+`applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
+`denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
+`redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI.  Possible values are `reseller`,`admin`,`user`,`guest`.
+
+<!-------------------- CREATE CUSTOM UI SETTINGS -------------------->
+#### Create custom UI settings
+
+`POST /reseller/settings/custom_ui`
+
+Create new custom UI settings.
+
+```shell
+# Creates a new custom UI settings
+curl -X POST "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> Request body example:
+
+```json
+{
+  "organization": {
+    "id": "10572c3d-16e5-450f-8af8-a01e50dc52d4"
+  },
+  "enabled": true,
+  "customUIRootUrl": "https://newui.example.com",
+  "domainToken": "example.com",
+  "gotoParam": "target",
+  "applyTags": [],
+  "denyTags": [],
+  "redirectRoles": []
+}
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "organization": {
+      "id": "10572c3d-16e5-450f-8af8-a01e50dc52d4"
+    },
+    "id": "d785ffcb-9b03-478d-a49b-52a2ccedf1b8",
+    "version": 1,
+    "enabled": true,
+    "customUIRootUrl": "https://newui.example.com",
+    "domainToken": "example.com",
+    "gotoParam": "target",
+    "applyTags": [],
+    "denyTags": [],
+    "redirectRoles": []
+  }
+}
+```
+
+Required | &nbsp;
+---------- | -----------
+`enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
+
+Optional | &nbsp;
+---------- | -----------
+`organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. If the `organizationId` is omitted, the authenticated user's organization will be used.
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. Required if the custom ui is enabled.
+`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom ui is enabled.
+`gotoParam`<br/>*string* | Parameter name to get path to redirect the user to.
+`applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
+`denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
+`redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
+
+<!-------------------- UPDATE CUSTOM UI SETTINGS -------------------->
+#### Update custom UI settings
+
+`PUT /reseller/settings/custom_ui/:id`
+
+Updates the custom UI settings of an organization.
+
+```shell
+# Updates an existing custom UI settings for an organization
+curl -X PUT "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8 \
+   -H "MC-Api-Key: your_api_key"
+   -H "Content-Type: application/json" \
+   -d "request-body"
+```
+
+> Request body example:
+
+```json
+{
+  "organization": {
+    "id": "10572c3d-16e5-450f-8af8-a01e50dc52d4"
+  },
+  "id": "d785ffcb-9b03-478d-a49b-52a2ccedf1b8",
+  "version": 1,
+  "enabled": true,
+  "customUIRootUrl": "https://newui.example.com",
+  "domainToken": "example.com",
+  "gotoParam": "target",
+  "applyTags": [],
+  "denyTags": [],
+  "redirectRoles": []
+}
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "organization": {
+      "id": "10572c3d-16e5-450f-8af8-a01e50dc52d4"
+    },
+    "id": "d785ffcb-9b03-478d-a49b-52a2ccedf1b8",
+    "version": 1,
+    "enabled": true,
+    "customUIRootUrl": "https://newui.example.com",
+    "domainToken": "example.com",
+    "gotoParam": "target",
+    "applyTags": [],
+    "denyTags": [],
+    "redirectRoles": []
+  }
+}
+```
+
+Required | &nbsp;
+---------- | -----------
+`id`<br/>*UUID* | The configured custom UI settings' id.
+`organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. It cannot be changed.
+`enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
+
+Optional | &nbsp;
+---------- | -----------
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. . Required if the custom ui is enabled.
+`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. . Required if the custom ui is enabled.
+`gotoParam`<br/>*string* | Parameter name to get path to redirect the user to.
+`applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
+`denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
+`redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI.  Possible values are `reseller`,`admin`,`user`,`guest`.
+
+<!-------------------- DELETE CUSTOM UI SETTINGS -------------------->
+#### Delete custom UI settings
+
+`DELETE /reseller/settings/custom_ui/:id`
+
+Delete an existing custom UI settings.
+
+```shell
+curl -X DELETE "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8" \
+   -H "MC-Api-Key: your_api_key"
+```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+  "taskId": "26022b83-9797-44c0-883c-7e82ecb757e9",
+  "taskStatus": "SUCCESS"
+}
+```

--- a/source/includes/administration/_custom_ui_settings.md
+++ b/source/includes/administration/_custom_ui_settings.md
@@ -2,14 +2,14 @@
 
 <!-------------------- FIND CUSTOM UI SETTINGS -------------------->
 
-#### Find custom ui settings associated to an organization
+#### Find custom UI settings associated to an organization
 
 `GET /reseller/settings/custom_ui/find?organizationId=:id`
 
-Retrieve the custom ui settings associated to an organization. If the `organizationId` is omitted, the authenticated user's organization will be used.
+Retrieve the custom UI settings associated to an organization. If the `organizationId` is omitted, the authenticated user's organization will be used.
 
 ```shell
-# Retrieve the custom ui settings
+# Retrieve the custom UI settings
 curl "https://cloudmc_endpoint/api/v2/reseller/settings/custom_ui/find?organizationId=10572c3d-16e5-450f-8af8-a01e50dc52d4" \
    -H "MC-Api-Key: your_api_key"
 ```
@@ -41,11 +41,11 @@ Attributes | &nbsp;
 `id`<br/>*UUID* | The configured custom UI settings' id.
 `organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. It cannot be changed.
 `version`<br/>*integer* | The custom UI settings version.
-`enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
-`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login.
+`enabled`<br/>*boolean* | If the custom UI redirection is enabled or not.
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is logged in.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration.
-`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom ui if they match.
-`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom ui if they match.
+`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom UI if they match.
+`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom UI if they match.
 `redirectRoles`<br/>*Array[string]* | The list of roles that users of the reseller will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
 
 
@@ -88,11 +88,11 @@ Attributes | &nbsp;
 `id`<br/>*UUID* | The configured custom UI settings' id.
 `organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. It cannot be changed.
 `version`<br/>*integer* | The custom UI settings version.
-`enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
-`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login.
+`enabled`<br/>*boolean* | If the custom UI redirection is enabled or not.
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is logged in.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration.
-`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom ui if they match.
-`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom ui if they match.
+`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom UI if they match.
+`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom UI if they match.
 `redirectRoles`<br/>*Array[string]* | The list of roles that users of the reseller will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
 
 <!-------------------- CREATE CUSTOM UI SETTINGS -------------------->
@@ -146,15 +146,15 @@ curl -X POST "https://cloudmc_endpoint/api/v2/reseller/settings/custom_ui" \
 
 Required | &nbsp;
 ---------- | -----------
-`enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
+`enabled`<br/>*boolean* | If the custom UI redirection is enabled or not.
 
 Optional | &nbsp;
 ---------- | -----------
 `organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. If the `organizationId` is omitted, the authenticated user's organization will be used.
-`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. Required if the custom ui is enabled.
-`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom ui is enabled.
-`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom ui if they match.
-`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom ui if they match.
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is logged in. Required if the custom UI is enabled.
+`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom UI is enabled.
+`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom UI if they match.
+`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom UI if they match.
 `redirectRoles`<br/>*Array[string]* | The list of roles that users of the reseller will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
 
 <!-------------------- UPDATE CUSTOM UI SETTINGS -------------------->
@@ -214,14 +214,14 @@ Required | &nbsp;
 ---------- | -----------
 `id`<br/>*UUID* | The configured custom UI settings' id.
 `organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. It cannot be changed.
-`enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
+`enabled`<br/>*boolean* | If the custom UI redirection is enabled or not.
 
 Optional | &nbsp;
 ---------- | -----------
-`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. Required if the custom ui is enabled.
-`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom ui is enabled.
-`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom ui if they match.
-`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom ui if they match.
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is logged in. Required if the custom UI is enabled.
+`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom UI is enabled.
+`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom UI if they match.
+`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom UI if they match.
 `redirectRoles`<br/>*Array[string]* | The list of roles that users of the reseller will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
 
 <!-------------------- DELETE CUSTOM UI SETTINGS -------------------->

--- a/source/includes/administration/_custom_ui_settings.md
+++ b/source/includes/administration/_custom_ui_settings.md
@@ -10,7 +10,7 @@ Retrieve the custom ui settings associated to an organization. If the `organizat
 
 ```shell
 # Retrieve the custom ui settings
-curl "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/find?organizationId=10572c3d-16e5-450f-8af8-a01e50dc52d4" \
+curl "https://cloudmc_endpoint/api/v2/reseller/settings/custom_ui/find?organizationId=10572c3d-16e5-450f-8af8-a01e50dc52d4" \
    -H "MC-Api-Key: your_api_key"
 ```
 
@@ -44,9 +44,9 @@ Attributes | &nbsp;
 `enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
 `customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration.
-`applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match. 
-`denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
-`redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
+`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom ui if they match.
+`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom ui if they match.
+`redirectRoles`<br/>*Array[string]* | The list of roles that users of the reseller will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
 
 
 
@@ -57,7 +57,7 @@ Attributes | &nbsp;
 
 ```shell
 # Retrieve custom UI settings
-curl "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8" \
+curl "https://cloudmc_endpoint/api/v2/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8" \
    -H "MC-Api-Key: your_api_key"
 ```
 
@@ -91,9 +91,9 @@ Attributes | &nbsp;
 `enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
 `customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration.
-`applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
-`denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
-`redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI.  Possible values are `reseller`,`admin`,`user`,`guest`.
+`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom ui if they match.
+`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom ui if they match.
+`redirectRoles`<br/>*Array[string]* | The list of roles that users of the reseller will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
 
 <!-------------------- CREATE CUSTOM UI SETTINGS -------------------->
 #### Create custom UI settings
@@ -104,7 +104,7 @@ Create new custom UI settings.
 
 ```shell
 # Creates a new custom UI settings
-curl -X POST "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui" \
+curl -X POST "https://cloudmc_endpoint/api/v2/reseller/settings/custom_ui" \
    -H "MC-Api-Key: your_api_key"
 ```
 
@@ -153,9 +153,9 @@ Optional | &nbsp;
 `organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. If the `organizationId` is omitted, the authenticated user's organization will be used.
 `customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. Required if the custom ui is enabled.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom ui is enabled.
-`applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
-`denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
-`redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
+`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom ui if they match.
+`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom ui if they match.
+`redirectRoles`<br/>*Array[string]* | The list of roles that users of the reseller will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
 
 <!-------------------- UPDATE CUSTOM UI SETTINGS -------------------->
 #### Update custom UI settings
@@ -166,7 +166,7 @@ Updates the custom UI settings of an organization.
 
 ```shell
 # Updates an existing custom UI settings for an organization
-curl -X PUT "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8 \
+curl -X PUT "https://cloudmc_endpoint/api/v2/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8 \
    -H "MC-Api-Key: your_api_key"
    -H "Content-Type: application/json" \
    -d "request-body"
@@ -220,9 +220,9 @@ Optional | &nbsp;
 ---------- | -----------
 `customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. Required if the custom ui is enabled.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom ui is enabled.
-`applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
-`denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
-`redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI.  Possible values are `reseller`,`admin`,`user`,`guest`.
+`applyTags`<br/>*Array[string]* | The list of organization tags that will redirect the user of sub-organizations to the custom ui if they match.
+`denyTags`<br/>*Array[string]* | The list of organization tags that will not redirect the user of sub-organizations to the custom ui if they match.
+`redirectRoles`<br/>*Array[string]* | The list of roles that users of the reseller will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
 
 <!-------------------- DELETE CUSTOM UI SETTINGS -------------------->
 #### Delete custom UI settings
@@ -232,7 +232,7 @@ Optional | &nbsp;
 Delete an existing custom UI settings.
 
 ```shell
-curl -X DELETE "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8" \
+curl -X DELETE "https://cloudmc_endpoint/api/v2/reseller/settings/custom_ui/d785ffcb-9b03-478d-a49b-52a2ccedf1b8" \
    -H "MC-Api-Key: your_api_key"
 ```
 

--- a/source/includes/administration/_custom_ui_settings.md
+++ b/source/includes/administration/_custom_ui_settings.md
@@ -27,7 +27,6 @@ curl "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/find?organiz
     "enabled": true,
     "customUIRootUrl": "https://newui.example.com",
     "domainToken": "example.com",
-    "gotoParam": "target",
     "applyTags": [],
     "denyTags": [],
     "redirectRoles": []
@@ -45,7 +44,6 @@ Attributes | &nbsp;
 `enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
 `customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration.
-`gotoParam`<br/>*string* | Parameter name to get path to redirect the user to.
 `applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match. 
 `denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
 `redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
@@ -76,7 +74,6 @@ curl "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785ffcb-9b0
     "enabled": true,
     "customUIRootUrl": "https://newui.example.com",
     "domainToken": "example.com",
-    "gotoParam": "target",
     "applyTags": [],
     "denyTags": [],
     "redirectRoles": []
@@ -94,7 +91,6 @@ Attributes | &nbsp;
 `enabled`<br/>*boolean* | If the custom ui redirection is enabled or not.
 `customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration.
-`gotoParam`<br/>*string* | Parameter name to get path to redirect the user to.
 `applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
 `denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
 `redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI.  Possible values are `reseller`,`admin`,`user`,`guest`.
@@ -122,7 +118,6 @@ curl -X POST "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui" \
   "enabled": true,
   "customUIRootUrl": "https://newui.example.com",
   "domainToken": "example.com",
-  "gotoParam": "target",
   "applyTags": [],
   "denyTags": [],
   "redirectRoles": []
@@ -142,7 +137,6 @@ curl -X POST "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui" \
     "enabled": true,
     "customUIRootUrl": "https://newui.example.com",
     "domainToken": "example.com",
-    "gotoParam": "target",
     "applyTags": [],
     "denyTags": [],
     "redirectRoles": []
@@ -159,7 +153,6 @@ Optional | &nbsp;
 `organization.id`<br/>*UUID* | The organization id that the custom UI settings are linked to. If the `organizationId` is omitted, the authenticated user's organization will be used.
 `customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. Required if the custom ui is enabled.
 `domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom ui is enabled.
-`gotoParam`<br/>*string* | Parameter name to get path to redirect the user to.
 `applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
 `denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
 `redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI. Possible values are `reseller`,`admin`,`user`,`guest`.
@@ -191,7 +184,6 @@ curl -X PUT "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785f
   "enabled": true,
   "customUIRootUrl": "https://newui.example.com",
   "domainToken": "example.com",
-  "gotoParam": "target",
   "applyTags": [],
   "denyTags": [],
   "redirectRoles": []
@@ -211,7 +203,6 @@ curl -X PUT "https://cloudmc_endpoint/api/rest/reseller/settings/custom_ui/d785f
     "enabled": true,
     "customUIRootUrl": "https://newui.example.com",
     "domainToken": "example.com",
-    "gotoParam": "target",
     "applyTags": [],
     "denyTags": [],
     "redirectRoles": []
@@ -227,9 +218,8 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ---------- | -----------
-`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. . Required if the custom ui is enabled.
-`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. . Required if the custom ui is enabled.
-`gotoParam`<br/>*string* | Parameter name to get path to redirect the user to.
+`customUIRootUrl`<br/>*string* | The base root that the user will be redirected to once the user is login. Required if the custom ui is enabled.
+`domainToken`<br/>*string* | The domain name that will be used in the authentication cookie. The cookie must be acceptable by both the reseller organization custom domain and the url provided in this configuration. Required if the custom ui is enabled.
 `applyTags`<br/>*Array[string]* | The list organization tags that will redirect the user to the custom ui if they match.
 `denyTags`<br/>*Array[string]* | The list organization tags that will not redirect the user to the custom ui if they match.
 `redirectRoles`<br/>*Array[string]* | The list of roles that users will be redirected to the new UI.  Possible values are `reseller`,`admin`,`user`,`guest`.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -48,6 +48,7 @@ includes:
   - administration/custom_navigation
   - administration/metrics
   - administration/caches
+  - administration/custom_ui_settings
   - cloudstack
   - cloudstack/compute # Compute section
   - cloudstack/instances


### PR DESCRIPTION
### Fixes [MC-18097](https://cloud-ops.atlassian.net/browse/MC-18097)

#### Changes made
<!-- Changes should match the template provided below -->
- Added custom ui api docs

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->