### PR TITLE
MC-18179 minor discount startDate doc update for feature

### DIFF
--- a/source/includes/administration/_organization_discounts.md
+++ b/source/includes/administration/_organization_discounts.md
@@ -214,7 +214,7 @@ Required | &nbsp;
 `packageDiscount`<br/>*number* | The discount value that will be applied to all products within the applied pricing.
 `discountedProducts`<br/>*object[string, number]* | A mapping between product IDs and discount values. All pricing products specified will have the discount value applied to them.
 `discountedCategories`<br/>*object[string, number]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them.
-`startDate`<br/>*date* | The start date of the discount. Must be before the earliest ongoing billing cycle startDate
+`startDate`<br/>*date* | The start date of the discount. Must be before the earliest ongoing billing cycle startDate.
 
 Optional | &nbsp;
 ------- | -----------

--- a/source/includes/administration/_organization_discounts.md
+++ b/source/includes/administration/_organization_discounts.md
@@ -214,7 +214,7 @@ Required | &nbsp;
 `packageDiscount`<br/>*number* | The discount value that will be applied to all products within the applied pricing.
 `discountedProducts`<br/>*object[string, number]* | A mapping between product IDs and discount values. All pricing products specified will have the discount value applied to them.
 `discountedCategories`<br/>*object[string, number]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them.
-`startDate`<br/>*date* | The start date of the discount.
+`startDate`<br/>*date* | The start date of the discount. Must be before the earliest ongoing billing cycle startDate
 
 Optional | &nbsp;
 ------- | -----------


### PR DESCRIPTION
### Fixes [MC-18179](https://cloud-ops.atlassian.net/browse/MC-18179)

#### Changes made
<!-- Changes should match the template provided below -->
Under Create Discount Section:
- startDate: "The start date of the discount. Must be before the earliest ongoing billing cycle startDate"

#### Related PRs
- [cloudmc-core pr](https://github.com/cloudops/cloudmc-core/pull/2158)
- [cloudmc-ui pr](https://github.com/cloudops/cloudmc-ui/pull/2469)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->