### PR TITLE
 MC-18096: add entity to checker, ensures result is set on task

### DIFF
--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -129,6 +129,34 @@ curl -X POST \
 	"sshkey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCguvgDRuUF/wijOJCNmYlQHujCmUHl/i0Ubos4nHy5uCBdn1LGF+PG3TpJqO1LUWqpHaPl4yN7bpsdXyq6a9nxe0C1bQ4FK6P5qm0X320uvqv34jwTPsIbnhw9I317df+xJyXXsL/P5vS4ULPMC5UZjWm4BYe7did4zmXXhA/zmLY6cUg19sZp5r5SUQcf5xHAqO3cQVZwzBhBMwroflZZ59zNpxy+xXPBqC3IdusF2yTDW7bwCQHESUOsd9XhwrzCB+1wETKjLpk0wkWj8G2j1pkKGRpv60QcG85lbZvQAg54v3HYD7fVJCaz9gJJoiyRBnqQ6XVxam5bZgiMKa0J johndoe@machine.local"
 }
 ```
+> The above command(s) return(s) JSON structured like this:
+
+```json
+{
+  "taskId": "ba0d9e44-ce89-4cc0-9c90-da1dcde1a8ac",
+  "taskStatus": "SUCCESS"
+}
+```
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v2/tasks/ba0d9e44-ce89-4cc0-9c90-da1dcde1a8ac"
+```
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+	"data": {
+		"id": "ba0d9e44-ce89-4cc0-9c90-da1dcde1a8ac",
+		"status": "SUCCESS",
+		"created": "2022-06-23T13:11:07.03164-04:00",
+		"result": {
+			"sshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCZcbdHKq1YK4vV5gtemy5SzngDhU3mSGhsxyBe4uKvEwk4shzRBPRc8uvOm0KrzB9KkbuxR3OJ1TbFVijnmvrOGIacN7BsJENBcBsrjjHW3vNPF0ZaJWts+lUPL+6BcuDTNUSyDTpAI1Xs/a3P5E7kOQumiwjlXIwuyJyGIk5Lt2FmZgDSCuZ4fjuUGgQq27RDya7G/eB5eKD9ohmXM567VHWvGQKUV4RdNDM0W4YuQYCAsaLwaKhFMOxr1AK5YOgyJYVVZn280bOx2qDyp6fTN49UTbkOtcQz+S8d2PRLaplY3QVPtelV47s2Gawgl8i3jiXGBbMV6WllLM+ujZy7 ",
+			...
+		}
+	}
+}
+```
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters</code>
 
@@ -149,6 +177,14 @@ Required | &nbsp;
 Optional | &nbsp;
 ------- | -----------
 `rootUsername`<br/>*string* | The user name to create a root user on cluster.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The task's ID.
+`status`<br/>*string* | The task's status.
+`created`<br/>*Date* | The task's creation date.
+`result`<br/>*Object* | The task result, containing details of the newly created cluster.
+`result.sshKey`<br/>*string* | The SSH key for the newly created cluseter.
 
 <!-------------------- DELETE A CLUSTER -------------------->
 

--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -151,6 +151,7 @@ curl -X POST \
 		"status": "SUCCESS",
 		"created": "2022-06-23T13:11:07.03164-04:00",
 		"result": {
+      "rootUsername": "root_nzk",
 			"sshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCZcbdHKq1YK4vV5gtemy5SzngDhU3mSGhsxyBe4uKvEwk4shzRBPRc8uvOm0KrzB9KkbuxR3OJ1TbFVijnmvrOGIacN7BsJENBcBsrjjHW3vNPF0ZaJWts+lUPL+6BcuDTNUSyDTpAI1Xs/a3P5E7kOQumiwjlXIwuyJyGIk5Lt2FmZgDSCuZ4fjuUGgQq27RDya7G/eB5eKD9ohmXM567VHWvGQKUV4RdNDM0W4YuQYCAsaLwaKhFMOxr1AK5YOgyJYVVZn280bOx2qDyp6fTN49UTbkOtcQz+S8d2PRLaplY3QVPtelV47s2Gawgl8i3jiXGBbMV6WllLM+ujZy7 ",
 			...
 		}
@@ -184,7 +185,8 @@ Attributes | &nbsp;
 `status`<br/>*string* | The task's status.
 `created`<br/>*Date* | The task's creation date.
 `result`<br/>*Object* | The task result, containing details of the newly created cluster.
-`result.sshKey`<br/>*string* | The SSH key for the newly created cluseter.
+`result.rootUsername`<br/>*string* | The username for the root user on the newly created cluster.
+`result.sshKey`<br/>*string* | The SSH key for the newly created cluster.
 
 <!-------------------- DELETE A CLUSTER -------------------->
 

--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -210,6 +210,35 @@ curl -X POST \
   "password": "SomePassw0rdVal!d"
 }
 ```
+> The above command(s) return(s) JSON structured like this:
+
+```json
+{
+  "taskId": "00b76dbe-f9de-4f2b-9434-5a7d93fb7112",
+  "taskStatus": "SUCCESS"
+}
+```
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v2/tasks/00b76dbe-f9de-4f2b-9434-5a7d93fb7112"
+```
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+  "data": {
+    "id": "00b76dbe-f9de-4f2b-9434-5a7d93fb7112",
+    "status": "SUCCESS",
+    "created": "2021-04-20T20:58:59.952881-04:00",
+    "result": {
+      "username": "johndoe",
+      "password": "SomePassw0rdVal!d",
+      ...
+    }
+  }
+}
+```
 
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances</code>
 
@@ -229,9 +258,20 @@ Required | &nbsp;
 
 Optional | &nbsp;
 ------- | -----------
-`password`<br/>*string* | The password of the administrator account. It must be between between 12 and 72 characters and must be a combination of 3 of the following patterns : Special characters, Uppercase, Lowercase and Numbers. The password is mandatory if the sshkey is not provided.
-`sshkey`<br/>*string* | The ssh key public portion that will be assigned to the user on the machine. This cannot be used for a Windows based OS.
+`password`<br/>*string* | The password of the administrator account. It must be between between 12 and 72 characters and must be a combination of 3 of the following patterns : Special characters, Uppercase, Lowercase and Numbers. The password is mandatory if the SSH key is not provided.
+`sshkey`<br/>*string* | The SSH key public portion that will be assigned to the user on the machine. This cannot be used for a Windows based OS.
 `publicIpAddressId`<br/>*string* | The fully qualified id of the public IP address to associate to the instance.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The task's ID.
+`status`<br/>*string* | The task's status.
+`created`<br/>*Date* | The task's creation date.
+`result`<br/>*Object* | The task result, containing details of the newly created instance.
+`result.securityType`<br/>*string* | The security type used to secure the instance. Either `password` or `sshKey`.
+`result.username`<br/>*string* | The administrator username created on the instance.
+`result.password`<br/>*string* | The password for the newly created instance. Only set if password authentication is configured on the instance.
+`result.sshkey`<br/>*string* | The SSH key for the newly created instance. Only set if SSH key authentication is configured on the instance.
 
 <!-------------------- DELETE AN INSTANCE -------------------->
 
@@ -316,7 +356,36 @@ curl -X POST \
 
 ```json
 {
-  "password": "SomePassw0rdVal!d"
+  "password": "my-new-password"
+}
+```
+> The above command(s) return(s) JSON structured like this:
+
+```json
+{
+  "taskId": "00b76dbe-f9de-4f2b-9434-5a7d93fb7112",
+  "taskStatus": "SUCCESS"
+}
+```
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v2/tasks/00b76dbe-f9de-4f2b-9434-5a7d93fb7112"
+```
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+  "data": {
+    "id": "00b76dbe-f9de-4f2b-9434-5a7d93fb7112",
+    "status": "SUCCESS",
+    "created": "2021-04-20T20:58:59.952881-04:00",
+    "result": {
+      "username": "johndoe",
+      "password": "my-new-password",
+      ...
+    }
+  }
 }
 ```
 
@@ -328,6 +397,15 @@ For Windows instances, reset the administrator account and reset the Remote Desk
 Optional | &nbsp;
 ------ | -----------
 `password`<br/>*string* | The password of the administator account. It must be between between 12 and 72 characters and must be a combination of 3 of the following patterns : Special characters, Uppercase, Lowercase and Numbers. If not provided, a new password is generated.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The task's ID.
+`status`<br/>*string* | The task's status.
+`created`<br/>*Date* | The task's creation date.
+`result`<br/>*Object* | The task result, containing details of the password reset.
+`result.username`<br/>*string* | The administrator username created on the instance.
+`result.password`<br/>*string* | The password for the newly created instance. Only set if password authentication is configured on the instance.
 
 <!-------------------- START AN INSTANCE -------------------->
 

--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -405,7 +405,7 @@ Attributes | &nbsp;
 `created`<br/>*Date* | The task's creation date.
 `result`<br/>*Object* | The task result, containing details of the password reset.
 `result.username`<br/>*string* | The administrator username created on the instance.
-`result.password`<br/>*string* | The password for the newly created instance. Only set if password authentication is configured on the instance.
+`result.password`<br/>*string* | The password for the newly created instance.
 
 <!-------------------- START AN INSTANCE -------------------->
 

--- a/source/includes/stackpath/_instances.md
+++ b/source/includes/stackpath/_instances.md
@@ -176,8 +176,8 @@ Optional | Description | Default
 
 Attributes | &nbsp;
 ------- | -----------
-`id`<br/>*string* | The task ID.
-`status`<br/>*string* | The status.
+`id`<br/>*string* | The task's ID.
+`status`<br/>*string* | The task's status.
 `created`<br/>*Date* | The task's creation date.
 `result`<br/>*Object* | The task result, containing details required to access the instance's console.
 `result.sshCommand`<br/>*String* | The command to execute to access the instance's console.


### PR DESCRIPTION
### Fixes [MC-18096](https://cloud-ops.atlassian.net/browse/MC-18096)

#### Code walkthrough : @evanluc 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
- Several operations like _Reset password_ only return required information via sensitive notifications
- The result is not set on the task, meaning an API user will never know what the new password is for their instance
- (In most cases, sensitive information like passwords and ssh keys is not returned by azure when fetching the entity)

#### Solution
**1. Short term** (for operations returning sensitive credentials)
- Add an `entity` to the `Checker`, which core uses to set the result on a task
- Update exclude annotations, add `scope = Exclude.Scope.AUDIT` to allow the sensitive information to be serialized on task results, see tests for more detail

**2. Long term**
Opened [MC-18704](https://cloudops.atlassian.net/browse/MC-18704). All operations should return a task result. Assume an API user creates a network, they may want to know the resulting network ID.

#### Test cases
- Unit tested
- Manually tested

#### UI changes
No changes

#### Related PRs
- https://github.com/cloudops/cloudmc-azure-plugin/pull/263

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->