### PR TITLE
MC-18096: add task results for gcp operations returning sensitive creds

### DIFF
--- a/source/includes/azure/_clusters.md
+++ b/source/includes/azure/_clusters.md
@@ -134,7 +134,7 @@ curl -X POST \
 ```json
 {
   "taskId": "ba0d9e44-ce89-4cc0-9c90-da1dcde1a8ac",
-  "taskStatus": "SUCCESS"
+  "taskStatus": "PENDING"
 }
 ```
 ```shell

--- a/source/includes/azure/_instances.md
+++ b/source/includes/azure/_instances.md
@@ -215,7 +215,7 @@ curl -X POST \
 ```json
 {
   "taskId": "00b76dbe-f9de-4f2b-9434-5a7d93fb7112",
-  "taskStatus": "SUCCESS"
+  "taskStatus": "PENDING"
 }
 ```
 ```shell
@@ -364,7 +364,7 @@ curl -X POST \
 ```json
 {
   "taskId": "00b76dbe-f9de-4f2b-9434-5a7d93fb7112",
-  "taskStatus": "SUCCESS"
+  "taskStatus": "PENDING"
 }
 ```
 ```shell

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -510,6 +510,34 @@ curl -X POST \
 }
 ```
 
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
+  "taskStatus": "SUCCESS"
+}
+```
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v2/tasks/c50390c7-9d5b-4af4-a2da-e2a2678a83e8"
+```
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+  "data": {
+    "id": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
+    "status": "SUCCESS",
+    "created": "2021-04-20T20:58:59.952881-04:00",
+    "result": {
+      "command": "ssh my-user@192.0.0.1",
+    }
+  }
+}
+```
+
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=get_ssh</code>
 
 Retrieve a command to allow you to SSH into a give running instance.
@@ -518,6 +546,14 @@ Required | &nbsp;
 ------ | -----------
 `sshKeyId`<br/>*string* | The id of an existing SSH key already save in the environment. Mutually exclusive with `publicKey`.
 `publicKey`<br/>*string* | The SSH key text. Mutually exclusive with `sshKeyId`. A new SSH key will be save in the environment.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The task ID.
+`status`<br/>*string* | The status.
+`created`<br/>*Date* | The task's creation date.
+`result`<br/>*Object* | The task result, containing details required to access the instance's console.
+`result.command`<br/>*String* | The command to execute to access the instance's console.
 
 <!-------------------- SET WINDOWS PASSWORD -------------------->
 
@@ -538,6 +574,36 @@ curl -X POST \
 }
 ```
 
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
+  "taskStatus": "SUCCESS"
+}
+```
+```shell
+curl -X POST \
+   -H "MC-Api-Key: your_api_key" \
+   "https://cloudmc_endpoint/api/v2/tasks/c50390c7-9d5b-4af4-a2da-e2a2678a83e8"
+```
+> The above command(s) return(s) JSON structured like this:
+
+```js
+{
+  "data": {
+    "id": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
+    "status": "SUCCESS",
+    "created": "2021-04-20T20:58:59.952881-04:00",
+    "result": {
+      "externalIpAddress": "192.0.0.1",
+      "username": "my-user",
+      "password": "my-generated-password"
+    }
+  }
+}
+```
+
 <code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/instances/:id?operation=set_windows_password</code>
 
 Set and retrieve a generated password to a given user on a running Windows instance.
@@ -545,6 +611,16 @@ Set and retrieve a generated password to a given user on a running Windows insta
 Required | &nbsp;
 ------ | -----------
 `username`<br/>*string* | The username.
+
+Attributes | &nbsp;
+------- | -----------
+`id`<br/>*string* | The task ID.
+`status`<br/>*string* | The status.
+`created`<br/>*Date* | The task's creation date.
+`result`<br/>*Object* | The task result, containing details required to access the instance's console.
+`result.externalIpAddress`<br/>*String* | The instance's external IP address.
+`result.username`<br/>*String* | The username.
+`result.password`<br/>*String* | The password for the given user.
 
 <!-------------------- MANAGE GROUP MEMBERSHIP -------------------->
 

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -532,7 +532,8 @@ curl -X POST \
     "status": "SUCCESS",
     "created": "2021-04-20T20:58:59.952881-04:00",
     "result": {
-      "command": "ssh my-user@192.0.0.1",
+      "id": "6564997542943928188",
+      "command": "ssh my-user@192.0.0.1"
     }
   }
 }
@@ -553,6 +554,7 @@ Attributes | &nbsp;
 `status`<br/>*string* | The status.
 `created`<br/>*Date* | The task's creation date.
 `result`<br/>*Object* | The task result, containing details required to access the instance's console.
+`result.id`<br/>*String* | The id of the instance being accessed by the SSH command.
 `result.command`<br/>*String* | The command to execute to access the instance's console.
 
 <!-------------------- SET WINDOWS PASSWORD -------------------->

--- a/source/includes/gcp/_instances.md
+++ b/source/includes/gcp/_instances.md
@@ -515,7 +515,7 @@ curl -X POST \
 ```js
 {
   "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
-  "taskStatus": "SUCCESS"
+  "taskStatus": "PENDING"
 }
 ```
 ```shell
@@ -581,7 +581,7 @@ curl -X POST \
 ```js
 {
   "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
-  "taskStatus": "SUCCESS"
+  "taskStatus": "PENDING"
 }
 ```
 ```shell

--- a/source/includes/stackpath/_instances.md
+++ b/source/includes/stackpath/_instances.md
@@ -138,7 +138,7 @@ curl -X POST \
 ```js
 {
   "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
-  "taskStatus": "SUCCESS"
+  "taskStatus": "PENDING"
 }
 ```
 ```shell


### PR DESCRIPTION
### Fixes [MC-18096](https://cloud-ops.atlassian.net/browse/MC-18096)

#### Code walkthrough : @fyrnaga 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
- Some operations like _Get SSH command_ return the command to the user using sensitive notifications via the UI.
- However, API users should also be able to retrieve the command by querying the _task API_ once the task is complete.

#### Solution
- Ensure all operations leveraging notifications set the result on the task, else the operation is useless for API users
- Ensure sensitive fields are not saved in audit events

#### Test cases
- Manually tested
- Added unit tests

#### UI changes
No changes

#### Related PRs
- https://github.com/cloudops/cloudmc-gcp-plugin/pull/428
