### PR TITLE
Added a fix to avoid generating escrows every 4 hours

### DIFF
--- a/.github/escrowBumpVersion.yaml
+++ b/.github/escrowBumpVersion.yaml
@@ -1,0 +1,60 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Bump Escrow Version
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  pull_request:
+    branches:
+      - cmc-dev
+    types:
+      - closed
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # Only run on pr merged on master
+    if: github.event.pull_request.merged == true
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.JENKINS_PAT }}
+
+      - uses: ashley-taylor/read-json-property-action@v1.0
+        with:
+          path: deposit_information.json
+          property: DepositVersion
+        id: getVersion
+
+      - name: Display current version
+        run: echo "Found version ${{steps.getVersion.outputs.value}}"
+      
+      - uses: actions-ecosystem/action-bump-semver@v1
+        id: bumpVersion
+        with:
+          current_version: ${{steps.getVersion.outputs.value}}
+          level: minor
+
+      - name: Display new version
+        run: echo "Bumped version ${{steps.bumpVersion.outputs.new_version}}"
+
+      # Runs a single command using the runners shell
+      - uses: jossef/action-set-json-field@v1
+        with:
+          file: deposit_information.json
+          field: DepositVersion
+          value: ${{ steps.bumpVersion.outputs.new_version }}
+
+      - uses: EndBug/add-and-commit@v8 # You can change this to use a specific version.
+        with:
+          add: 'deposit_information.json'
+          message: 'Bump escrow version to ${{ steps.bumpVersion.outputs.new_version }}'
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,3 @@
-import groovy.json.JsonSlurperClassic
-import groovy.json.JsonOutput
-
 library(identifier: 'utils@v2.4.5', retriever: modernSCM(
   [$class: 'GitSCMSource',
    remote: 'git@github.com:cloudops/cloudmc-jenkins-shared.git',
@@ -36,25 +33,6 @@ pipeline {
                 sh 'git config user.name "$GIT_AUTHOR_NAME"'
                 sh 'git config user.password "$GIT_PASSWORD"'
                 sh 'set -x'
-
-                if (fileExists('deposit_information.json')) {
-                    def json = readFile(file:'deposit_information.json')
-                    def data = new JsonSlurperClassic().parseText(json)
-                    def currentVersion = data.DepositVersion;
-
-                    def versionParts = currentVersion.split('\\.')
-                    assert versionParts.size() == 3: "Helm chart version ${currentVersion} isn't of the form X.X.X!"
-                    versionParts[2] = versionParts[2].toInteger() + 1;
-
-                    def newVersion = versionParts.join('.')
-
-                    echo "updating deposit information file version from ${currentVersion} to ${newVersion}"
-                    def newJson = json.replaceFirst("\"${currentVersion}\"", "\"${newVersion}\"")
-                    writeFile(file:'deposit_information.json', text: newJson)
-                    commit "Bumped escrow version to ${newVersion}"
-                    sh "git push origin cmc-dev"
-                }
-
                 sh "./deploy.sh"
             }
         }
@@ -68,9 +46,3 @@ pipeline {
   }
 }
 
-def commit(message) {
-    def nothingToCommit = sh(script: "git status", returnStdout: true).trim().contains('nothing to commit')
-    if (!nothingToCommit) {
-	    sh "git commit -a -m '$message'"
-    }
-}

--- a/deposit_information.json
+++ b/deposit_information.json
@@ -1,5 +1,5 @@
 {
 	"ContractParty" : "54668-75380",
-	"DepositVersion" : "1.0.889",
+	"DepositVersion" : "1.1.0",
 	"DepositName" : "cloudmc-api-docs Deposit"
 }


### PR DESCRIPTION
### Fixes [MC-](https://cloud-ops.atlassian.net/browse/MC-)

Escrow was generating every 4 hours. This should not happen that much, only on merge to cmc-dev

#### Changes made
<!-- Changes should match the template provided below -->
- Removed the jenkins script update
- Added github action on merge in cmc-dev.

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->