### PR TITLE
Create cluster for the AWS plugin

### DIFF
--- a/source/includes/aws/_clusters.md
+++ b/source/includes/aws/_clusters.md
@@ -158,9 +158,9 @@ curl -X POST \
   "version": "1.22",
   "vpcId": "vpc-1234",
   "subnetIds": ["subnet-1", "subnet-2"],
-  "numberOfNodes": "2",
+  "numberOfNodes": 2,
   "instanceType": "t3.medium",
-  "diskSize": "20"
+  "diskSize": 20
 }
   ```
 
@@ -183,9 +183,9 @@ Required | &nbsp;
 `version`<br/>*string* | The Kubernetes version of the cluster.
 `vpcId`<br/>*string* | The ID of the vpc used for the cluster resources.
 `subnetIds`<br/>*List* | The subnet IDs in your VPC where the control plane may place elastic network interfaces (ENIs) to facilitate communication with your cluster.
-`numberOfNodes` <br/>*string* | Number of nodes in the primary node group for this cluster. You can resize the cluster after creation.
+`numberOfNodes` <br/>*int* | Number of nodes in the primary node group for this cluster. You can resize the cluster after creation.
 `instanceType`<br/>*string* | Machine type of the nodes in the default node group for this cluster.
-`diskSize`<br/>*string* | Size of the attached EBS volume for each node.
+`diskSize`<br/>*int* | Size of the attached EBS volume for each node in GiB.
 
 <!-------------------- DELETE A CLUSTER -------------------->
 

--- a/source/includes/aws/_clusters.md
+++ b/source/includes/aws/_clusters.md
@@ -138,6 +138,55 @@ Attributes | &nbsp;
 `numberOfNodes` <br/> *integer* | The total number of nodes in the cluster.
 `name` <br/> *string* | The name of the cluster.
 `caCert` <br> *string* | The certificate authority data for the cluster.
+<!-------------------- Create A CLUSTER -------------------->
+
+#### Create a cluster
+
+```shell
+curl -X POST \
+   -H "Content-Type: application/json" \
+   -H "MC-Api-Key: your_api_key" \
+   -d "request body" \
+   "https://cloudmc_endpoint/api/v2/services/aws-aaaa/test-env/clusters"
+```
+> Request body examples:
+
+```js
+// Create a cluster
+{
+  "name": "my-cluster",
+  "version": "1.22",
+  "vpcId": "vpc-1234",
+  "subnetIds": ["subnet-1", "subnet-2"],
+  "numberOfNodes": "2",
+  "instanceType": "t3.medium",
+  "diskSize": "20"
+}
+  ```
+
+> The above command returns a JSON structured like this:
+
+```json
+{
+	"taskId": "3f045006-07db-470b-927b-6b2cfe9821af",
+	"taskStatus": "PENDING"
+}
+```
+  
+<code>CREATE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters</code>
+
+Create a new cluster.
+
+Required | &nbsp;
+------- | -----------
+`name`<br/>*string* | The display name of the cluster (unique). It cannot be changed after creation.
+`version`<br/>*string* | The Kubernetes version of the cluster.
+`vpcId`<br/>*string* | The ID of the vpc used for the cluster resources.
+`subnetIds`<br/>*List* | The subnet IDs in your VPC where the control plane may place elastic network interfaces (ENIs) to facilitate communication with your cluster.
+`numberOfNodes` <br/>*string* | Number of nodes in the primary node group for this cluster. You can resize the cluster after creation.
+`instanceType`<br/>*string* | Machine type of the nodes in the default node group for this cluster.
+`diskSize`<br/>*string* | Size of the attached EBS volume for each node.
+
 <!-------------------- DELETE A CLUSTER -------------------->
 
 #### Delete a cluster


### PR DESCRIPTION
### Fixes [MC-18411](https://cloud-ops.atlassian.net/browse/MC-18411)

#### Changes made
<!-- Changes should match the template provided below -->
- Added create cluster section to the AWS plugin

#### Create a cluster

```shell
curl -X POST \
   -H "Content-Type: application/json" \
   -H "MC-Api-Key: your_api_key" \
   -d "request body" \
   "https://cloudmc_endpoint/api/v2/services/aws-aaaa/test-env/clusters"
```
> Request body examples:

```js
// Create a cluster
{
  "name": "my-cluster",
  "version": "1.22",
  "vpcId": "vpc-1234",
  "subnetIds": ["subnet-1", "subnet-2"],
  "numberOfNodes": 2,
  "instanceType": "t3.medium",
  "diskSize": 20
}
  ```

> The above command returns a JSON structured like this:

```json
{
	"taskId": "3f045006-07db-470b-927b-6b2cfe9821af",
	"taskStatus": "PENDING"
}
```
  
<code>CREATE /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/clusters</code>

Create a new cluster.

Required | &nbsp;
------- | -----------
`name`<br/>*string* | The display name of the cluster (unique). It cannot be changed after creation.
`version`<br/>*string* | The Kubernetes version of the cluster.
`vpcId`<br/>*string* | The ID of the vpc used for the cluster resources.
`subnetIds`<br/>*List* | The subnet IDs in your VPC where the control plane may place elastic network interfaces (ENIs) to facilitate communication with your cluster.
`numberOfNodes` <br/>*int* | Number of nodes in the primary node group for this cluster. You can resize the cluster after creation.
`instanceType`<br/>*string* | Machine type of the nodes in the default node group for this cluster.
`diskSize`<br/>*int* | Size of the attached EBS volume for each node in GiB.

### Related PR
- [PR #401](https://github.com/cloudops/cloudmc-aws-plugin/pull/401)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->