### PR TITLE
update reports documentation

### DIFF
--- a/source/includes/administration/_reports_pricing_v2.md
+++ b/source/includes/administration/_reports_pricing_v2.md
@@ -201,6 +201,7 @@ curl --request GET \
         "name": "JasonOrg",
         "total": "5244.00",
         "currency": "CAD",
+        "orgDeleted": "false",
         "categories": [
           {
             "name": {
@@ -246,6 +247,8 @@ Customer Report Attributes | &nbsp;
 `organizations.appliedPricing.name`<br/>*Object* | A map of short language codes to their translated name for the pricing package.
 `startDate`<br/>*string* | An ISO-8601 instant format string representing the start of the report.
 `endDate`<br/>*string* | An ISO-8601 instant format string representing the end of the report.
+`orgDeleted`<br/>*boolean* | Whether or not the organization is deleted.
+`metadata`<br/>*object* | Additional information about the deletion event of the organization (optional).
 `reportGenerated`<br/>*boolean* | Whether or not a report could be generated for this time period.
 
 <!------------------- GET REVENUE TAXATION REPORT --------------------->

--- a/source/includes/administration/_reports_pricing_v2.md
+++ b/source/includes/administration/_reports_pricing_v2.md
@@ -248,7 +248,7 @@ Customer Report Attributes | &nbsp;
 `startDate`<br/>*string* | An ISO-8601 instant format string representing the start of the report.
 `endDate`<br/>*string* | An ISO-8601 instant format string representing the end of the report.
 `orgDeleted`<br/>*boolean* | Whether or not the organization is deleted.
-`metadata`<br/>*object* | Additional information about the deletion event of the organization (optional).
+`metadata`<br/>*object* | Additional information about the deletion event of the organization.
 `reportGenerated`<br/>*boolean* | Whether or not a report could be generated for this time period.
 
 <!------------------- GET REVENUE TAXATION REPORT --------------------->


### PR DESCRIPTION
### Fixes [MC-17984](https://cloud-ops.atlassian.net/browse/MC-17984)

#### Changes made
<!-- Changes should match the template provided below -->
- update the reports documentation

#### Related PRs
- []()

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->