### PR TITLE
Update api documentation for 'apply to new customers' checkbox

### DIFF
--- a/source/includes/administration/_invoices.md
+++ b/source/includes/administration/_invoices.md
@@ -58,7 +58,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices/find/efd32752-c6f2-45cf-b494-cc6b
                             "scope": "ALL_PRODUCTS",
                             "typeString": "PERCENTAGE",
                             "discount": {
-                                "applyToNewCustomersOnly": false,
                                 "discountedProducts": {},
                                 "type": "PERCENTAGE",
                                 "packageDiscount": 22.0,
@@ -94,7 +93,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices/find/efd32752-c6f2-45cf-b494-cc6b
                             "scope": "ALL_PRODUCTS",
                             "typeString": "CREDIT",
                             "discount": {
-                                "applyToNewCustomersOnly": false,
                                 "discountedProducts": {},
                                 "type": "CREDIT",
                                 "packageDiscount": 250000.0,
@@ -234,7 +232,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices/find/efd32752-c6f2-45cf-b494-cc6b
                                     "scope": "CATEGORIES",
                                     "typeString": "PERCENTAGE",
                                     "discount": {
-                                        "applyToNewCustomersOnly": false,
                                         "discountedProducts": {},
                                         "type": "PERCENTAGE",
                                         "referenceId": "6ee154d1-4318-47bb-bb18-2e605c227889",
@@ -285,7 +282,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices/find/efd32752-c6f2-45cf-b494-cc6b
                                     "scope": "ALL_PRODUCTS",
                                     "typeString": "PERCENTAGE",
                                     "discount": {
-                                        "applyToNewCustomersOnly": false,
                                         "discountedProducts": {},
                                         "type": "PERCENTAGE",
                                         "packageDiscount": 22.0,
@@ -511,7 +507,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices/find/efd32752-c6f2-45cf-b494-cc6b
                                             "scope": "PRODUCTS",
                                             "typeString": "PERCENTAGE",
                                             "discount": {
-                                                "applyToNewCustomersOnly": false,
                                                 "discountedProducts": {
                                                     "a36933e3-697a-4093-9057-18aed07479ea": 50
                                                 },
@@ -745,7 +740,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices?organization_id=289ec5fb-0970-44e
                             "scope": "ALL_PRODUCTS",
                             "typeString": "PERCENTAGE",
                             "discount": {
-                                "applyToNewCustomersOnly": false,
                                 "discountedProducts": {},
                                 "type": "PERCENTAGE",
                                 "packageDiscount": 22.0,
@@ -781,7 +775,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices?organization_id=289ec5fb-0970-44e
                             "scope": "ALL_PRODUCTS",
                             "typeString": "CREDIT",
                             "discount": {
-                                "applyToNewCustomersOnly": false,
                                 "discountedProducts": {},
                                 "type": "CREDIT",
                                 "packageDiscount": 250000.0,
@@ -921,7 +914,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices?organization_id=289ec5fb-0970-44e
                                     "scope": "CATEGORIES",
                                     "typeString": "PERCENTAGE",
                                     "discount": {
-                                        "applyToNewCustomersOnly": false,
                                         "discountedProducts": {},
                                         "type": "PERCENTAGE",
                                         "referenceId": "6ee154d1-4318-47bb-bb18-2e605c227889",
@@ -972,7 +964,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices?organization_id=289ec5fb-0970-44e
                                     "scope": "ALL_PRODUCTS",
                                     "typeString": "PERCENTAGE",
                                     "discount": {
-                                        "applyToNewCustomersOnly": false,
                                         "discountedProducts": {},
                                         "type": "PERCENTAGE",
                                         "packageDiscount": 22.0,
@@ -1198,7 +1189,6 @@ curl "https://cloudmc_endpoint/api/v2/invoices?organization_id=289ec5fb-0970-44e
                                             "scope": "PRODUCTS",
                                             "typeString": "PERCENTAGE",
                                             "discount": {
-                                                "applyToNewCustomersOnly": false,
                                                 "discountedProducts": {
                                                     "a36933e3-697a-4093-9057-18aed07479ea": 50
                                                 },
@@ -1476,7 +1466,6 @@ curl -X PUT "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8
                             "scope": "ALL_PRODUCTS",
                             "typeString": "PERCENTAGE",
                             "discount": {
-                                "applyToNewCustomersOnly": false,
                                 "discountedProducts": {},
                                 "type": "PERCENTAGE",
                                 "packageDiscount": 22.0,
@@ -1522,7 +1511,6 @@ curl -X PUT "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8
                             "scope": "ALL_PRODUCTS",
                             "typeString": "CREDIT",
                             "discount": {
-                                "applyToNewCustomersOnly": false,
                                 "discountedProducts": {},
                                 "type": "CREDIT",
                                 "packageDiscount": 250000.0,
@@ -1650,7 +1638,6 @@ curl -X PUT "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8
                                     "scope": "CATEGORIES",
                                     "typeString": "PERCENTAGE",
                                     "discount": {
-                                        "applyToNewCustomersOnly": false,
                                         "discountedProducts": {},
                                         "type": "PERCENTAGE",
                                         "referenceId": "6ee154d1-4318-47bb-bb18-2e605c227889",
@@ -1698,7 +1685,6 @@ curl -X PUT "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8
                                     "scope": "ALL_PRODUCTS",
                                     "typeString": "PERCENTAGE",
                                     "discount": {
-                                        "applyToNewCustomersOnly": false,
                                         "discountedProducts": {},
                                         "type": "PERCENTAGE",
                                         "packageDiscount": 22.0,
@@ -1735,7 +1721,6 @@ curl -X PUT "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8
                                     "scope": "CATEGORIES",
                                     "typeString": "CREDIT",
                                     "discount": {
-                                        "applyToNewCustomersOnly": false,
                                         "discountedProducts": {},
                                         "type": "CREDIT",
                                         "referenceId": "85d5fc06-142a-4e04-9a27-2bf08b3c1be0",
@@ -1950,7 +1935,6 @@ curl -X PUT "https://cloudmc_endpoint/rest/invoices/20e9b8d8-b1cb-4462-b6e8-fbb8
                                             "scope": "PRODUCTS",
                                             "typeString": "PERCENTAGE",
                                             "discount": {
-                                                "applyToNewCustomersOnly": false,
                                                 "discountedProducts": {
                                                     "a36933e3-697a-4093-9057-18aed07479ea": 50
                                                 },

--- a/source/includes/administration/_package_discounts.md
+++ b/source/includes/administration/_package_discounts.md
@@ -21,7 +21,6 @@ curl "https://cloudmc_endpoint/rest/pricing_packages/efd32752-c6f2-45cf-b494-cc6
 {
   "data": [
     {
-      "applyToNewCustomersOnly": true,
       "discountedProducts": {},
       "durationDays": 60,
       "type": "PERCENTAGE",
@@ -61,7 +60,6 @@ Attributes | &nbsp;
 `name`<br/>*Map[String, String]* | The name translations of the discount.
 `pricingPackage`<br/>*Object* | The pricing package being discounted.
 `pricingPackage.id`<br/>*UUID* | The UUID of the pricing package.
-`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `startDate`<br/>*date* | The start date of the discount.
 `cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date.
 `status`<br/>*enum* | The status of the discount. Possible values are: UPCOMING, CURRENT, ENDED.
@@ -85,7 +83,6 @@ curl "https://cloudmc_endpoint/rest/pricing_packages/efd32752-c6f2-45cf-b494-cc6
 {
   "data": [
     {
-      "applyToNewCustomersOnly": true,
       "discountedProducts": {},
       "durationDays": 60,
       "type": "PERCENTAGE",
@@ -121,7 +118,6 @@ Attributes | &nbsp;
 `name`<br/>*Map[String, String]* | The name translations of the discount.
 `pricingPackage`<br/>*Object* | The pricing package being discounted.
 `pricingPackage.id`<br/>*UUID* | The UUID of the pricing package.
-`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `startDate`<br/>*date* | The start date of the discount.
 `cutoffDate`<br/>*date* | The date on which the discount will no longer be offered to customers who have not already received it. If not provided, the discount will always be offered after the start date.
 `status`<br/>*enum* | The status of the discount. Possible values are: UPCOMING, CURRENT, ENDED.
@@ -157,7 +153,6 @@ curl -X POST "https://cloudmc_endpoint/rest/pricing_packages/efd32752-c6f2-45cf-
   },
   "discountScope": "CATEGORIES", 
   "cutoffDate": "2021-07-24T00:00:00.000Z",
-  "applyToNewCustomersOnly": false,
 }
 ```
 
@@ -166,7 +161,6 @@ curl -X POST "https://cloudmc_endpoint/rest/pricing_packages/efd32752-c6f2-45cf-
 ```json
 {
   "data": {
-      "applyToNewCustomersOnly": false,
       "discountedProducts": {},
       "durationDays": 60,
       "type": "PERCENTAGE",
@@ -194,7 +188,6 @@ Required | &nbsp;
 `name`<br/>*Map[String, String]* | The name translations of the discount.
 `type`<br/>*enum* | The type of the discount. It can be either "PERCENTAGE" or "CREDIT".
 `startDate`<br/>*date* | The start date of the discount.
-`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `discountScope`<br/>*enum* | The scope of the discount. It can be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
 `packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the pricing package. Only required if the scope is "ALL_PRODUCTS". The value must be between (0,100] for a percentage discount and greater than 0 for a credit.
 `discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
@@ -234,7 +227,6 @@ curl -X PUT "https://cloudmc_endpoint/api/v2/pricing_packages/efd32752-c6f2-45cf
   },
   "discountScope": "CATEGORIES", 
   "cutoffDate": "2021-08-24T00:00:00.000Z",
-  "applyToNewCustomersOnly": false,
 }
 ```
 
@@ -243,7 +235,6 @@ curl -X PUT "https://cloudmc_endpoint/api/v2/pricing_packages/efd32752-c6f2-45cf
 ```json
 {
   "data": {
-      "applyToNewCustomersOnly": false,
       "discountedProducts": {},
       "durationDays": 60,
       "type": "PERCENTAGE",
@@ -271,7 +262,6 @@ Optional | &nbsp;
 ------- | -----------
 `name`<br/>*Map[String, String]* | The name translations of the discount.
 `startDate`<br/>*date* | The start date of the discount.
-`applyToNewCustomersOnly`<br/>*boolean* | If true, the discount will only be applied to organizations created after the discount start date.
 `discountScope`<br/>*enum* | The scope of the discount. It can be either "ALL_PRODUCTS", "CATEGORIES" or "PRODUCTS".
 `packageDiscount`<br/>*BigDecimal* | The discount value that will be applied to all products within the pricing package. Only required if the scope is "ALL_PRODUCTS". The value must be between (0,100] for a percentage discount and greater than 0 for a credit.
 `discountedCategories`<br/>*Map[UUID, BigDecimal]* | A mapping between category IDs and discount values. All pricing products within a category will have the discount value applied to them. Required to be non-empty if scope is "CATEGORIES". All discount values must be between (0,100] for a percentage discount and greater than 0 for a credit.
@@ -318,7 +308,6 @@ curl -X PUT "https://cloudmc_endpoint/api/v2/pricing_packages/efd32752-c6f2-45cf
 ```json
 {
   "data": {
-      "applyToNewCustomersOnly": false,
       "discountedProducts": {},
       "durationDays": 60,
       "type": "PERCENTAGE",


### PR DESCRIPTION
### Fixes [MC-18976](https://cloudops.atlassian.net/browse/MC-18976)

#### Changes made
Removed the 'applyToNewCustomersOnly' key because it is no longer necessary 

#### Related PRs
- https://github.com/cloudops/cloudmc-core/pull/2460
- https://github.com/cloudops/cloudmc-ui/pull/2770

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->