### PR TITLE
Update nodeCount type to number

### DIFF
--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -186,7 +186,7 @@ Required | &nbsp;
 `shortRegion`<br/>*string* | A short version of the region name.
 `shortZone`<br/>*string* | A short version of the zone name.
 `currentMasterVersion`<br/>*string* | The version of GKE used for this cluster.
-`nodeCount` <br/>*number* | The number of nodes in the primary node pool of this cluster. This must be greater than 0.
+`nodeCount` <br/>*integer* | The number of nodes in the primary node pool of this cluster. This must be greater than 0.
 `nodeType`<br/>*string* | The machine types of the nodes in the default node pool of this cluster.
 `networkName`<br/>*string* | The network that the Kubernetes cluster is in.
 `subnetName`<br/>*string* | Subnetwork to which the cluster will belong. The subnetwork specified must belong the network specified.

--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -69,7 +69,7 @@ curl -X GET \
 Attributes | &nbsp;
 ------- | -----------
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
-`nodeCount`<br/>*number* | Number of nodes in the cluster.
+`nodeCount`<br/>*integer* | Number of nodes in the cluster.
 `endpoint`<br/>*string* | The IP address of the cluster's master node. All interactions with the Kubernetes API are done through the master node.
 `location` <br/> *string* | The zone or region in which the cluster is running. For regional clusters, your cluster nodes may span multiple zones within the region.
 `status` <br/> *string* | The status of the cluster.
@@ -129,7 +129,7 @@ curl -X GET \
 Attributes | &nbsp;
 ------- | -----------
 `creationTimestamp`<br/>*string* | Creation timestamp in RFC3339 text format.
-`nodeCount`<br/>*number* | Number of nodes in the cluster.
+`nodeCount`<br/>*integer* | Number of nodes in the cluster.
 `endpoint`<br/>*string* | The IP address of the cluster's master node. All interactions with the Kubernetes API are done through the master node.
 `location` <br/> *string* | The zone or region in which the cluster is running. For regional clusters, your cluster nodes may span multiple zones within the region.
 `status` <br/> *string* | The status of the cluster.

--- a/source/includes/gcp/_clusters.md
+++ b/source/includes/gcp/_clusters.md
@@ -168,7 +168,7 @@ curl -X POST \
   "shortRegion": "northamerica-northeast1",
   "shortZone": "northamerica-northeast1-a",
   "currentMasterVersion": "1.17.12-gke.1501",
-  "nodeCount":"3",
+  "nodeCount":3,
   "nodeType":"e2-highcpu-16",
   "networkName": "default",
   "subnetName": "default"
@@ -186,7 +186,7 @@ Required | &nbsp;
 `shortRegion`<br/>*string* | A short version of the region name.
 `shortZone`<br/>*string* | A short version of the zone name.
 `currentMasterVersion`<br/>*string* | The version of GKE used for this cluster.
-`nodeCount` <br/>*string* | The number of nodes in the primary node pool of this cluster. This must be greater than 0.
+`nodeCount` <br/>*number* | The number of nodes in the primary node pool of this cluster. This must be greater than 0.
 `nodeType`<br/>*string* | The machine types of the nodes in the default node pool of this cluster.
 `networkName`<br/>*string* | The network that the Kubernetes cluster is in.
 `subnetName`<br/>*string* | Subnetwork to which the cluster will belong. The subnetwork specified must belong the network specified.


### PR DESCRIPTION
### Fixes [MC-19359](https://cloudops.atlassian.net/browse/MC-19359)

#### Changes made
updated the nodeCount type from String to number from the specification as well as example

#### Related PRs
- [[]()](https://github.com/cloudops/cloudmc-gcp-plugin/pull/473)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->