### PR TITLE
MC-19329: Added information regarding includeNoUsageInvoices query param

### DIFF
--- a/source/includes/administration/_invoices.md
+++ b/source/includes/administration/_invoices.md
@@ -590,6 +590,7 @@ Optional Query Parameters | &nbsp;
 ---------- | -----------
 `includeAllSubOrgs`<br/>*boolean* | Whether or not to include sub-organizations of sub-organizations or just direct sub-organizations of the reseller.
 `billingCycle`<br/>*String* | The cycle which the invoice belongs to. Format is `MM-YYYY`
+`includeNoUsageInvoices`<br/>*boolean* | Whether or not to include invoices which have no usage.
 
 Attributes | &nbsp;
 ---- | -----------


### PR DESCRIPTION
Added new query param "includeNoUsageInvoices" in "GET /invoices/find/:reseller_id/customer_invoices" endpoint to include invoices with no usage.