### PR TITLE
MC-19131: Document brownfield on service connections

### DIFF
--- a/source/includes/administration/_service_connections.md
+++ b/source/includes/administration/_service_connections.md
@@ -31,6 +31,7 @@ Service connections are the services that you can create resources for (e.g. com
     "supportsUsage": true,
     "supportsInfra": true,
     "lastUsageRecord": "2022-03-28T18:59:59.000Z",
+    "brownfield": false,
     "quotas": [{
       "name": "DefaultQuota",
       "id": "081b1ebb-16c4-49e0-8120-a5b8b356b269"
@@ -55,6 +56,7 @@ Attributes | &nbsp;
 `status`<br/>*Object* | Status of the service connection. Tells you if the service is up.<br/>*includes*: `lastUpdated`, `reachable`.
 `organization`<br/>*Object* | Organization that owns this service connection.<br/>*includes*: `id`, `name`
 `metricsEnabled`<br/>*boolean* | Is metric collection allowed on this service connection.
+`brownfield`<br/>*boolean* | If the connection is brownfield enabled.
 `supportsQuotas`<br/>*boolean* | Are quotas supported on this service connection.
 `supportsPricingV2`<br/>*boolean* | Is the V2 pricing engine supported on this service connection.
 `supportsPolicies`<br/>*boolean* | Are policies supported on this service connection.
@@ -92,6 +94,7 @@ Optional query parameters | &nbsp;
       "id": "5d841eb6-5913-4244-b001-917228e7aa64"
     },
     "metricsEnabled": true,
+    "brownfield": false,
     "supportsQuotas": true,
     "supportsPricingV2": true,
     "supportsPolicies": true,
@@ -123,6 +126,7 @@ Attributes | &nbsp;
 `status`<br/>*Object* | Status of the service connection. Tells you if the service is up.<br/>*includes*: `lastUpdated`, `reachable`.
 `organization`<br/>*Object* | Organization that owns this service connection.<br/>*includes*: `id`, `name`
 `metricsEnabled`<br/>*boolean* | Is metric collection allowed on this service connection.
+`brownfield`<br/>*boolean* | If the connection is brownfield enabled.
 `supportsQuotas`<br/>*boolean* | Are quotas supported on this service connection.
 `supportsPricingV2`<br/>*boolean* | Is the V2 pricing engine supported on this service connection.
 `supportsPolicies`<br/>*boolean* | Are policies supported on this service connection.
@@ -275,6 +279,7 @@ curl -X GET \
         ],
         "infraEntityDescriptors": [],
         "supportsInfra": false,
+        "supportsBrownfield": true,
         "supportedWidgets": [],
         "hasPluginEnvironmentRoles": false,
         "quotaMetricIdentifiers": [
@@ -332,6 +337,7 @@ Attributes                                  | &nbsp;
 `supportsApiCredentials`<br/>*boolean*      | Whether or not this service descriptor supports API credentials.
 `supportsPolicies`<br/>*boolean*            | Whether or not this service descriptor supports policies.
 `supportsUsage`<br/>*boolean*               | Whether or not this service descriptor supports usage.
+`supportsBrownfield`<br/>*boolean*          | Whether or not this service descriptor supports brownfield connections.
 `supportsPricingV2`<br/>*boolean*           | Whether or not this service descriptor supports pricing (V2).
 `supportsCaching`<br/>*boolean*             | Whether or not this service descriptor supports caching.
 
@@ -495,6 +501,7 @@ Optional query parameters | &nbsp;
 `trialEnabled`<br/>*string* | Are trials allowed on this service connection.
 `usageEnabled`<br/>*string* | Is usage collection enabled on this service connection.
 `metricsEnabled`<br/>*string* | Is metric collection enabled on this service connection.
+`brownfield`<br/>*boolean* | True if connecting to an existing service connection from which environments can be linked. Can only be enabled if the service supports brownfield, see [retrieve descriptor](#administration-retrieve-descriptor). If enabled, `trialEnabled` and `usageEnabled` must be false since they are not supported on brownfield connections.
 `commitmentTrackingEnabled`<br/>*string* | Is commitment tracking enabled on this service connection.
 `dependentConnection`<br/>*object* | The dependent connection if there is one.
 `locations`<br/>*Array[object]* | Locations of a service connection region.<br/>*includes*: `name`, `lat` and `lng`


### PR DESCRIPTION
### Fixes [MC-19131](https://cloud-ops.atlassian.net/browse/MC-19131)

#### Changes made
<!-- Changes should match the template provided below -->
- Document creation of brownfield connections via `brownfield` boolean
- Document `supportsBrownfield` property on service descriptor 

#### Related PRs
- https://github.com/cloudops/cloudmc-core/pull/2570

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->