### PR TITLE
MC-19865: Change the source from string to list

### DIFF
--- a/source/includes/stackpath/_network_policy_rules.md
+++ b/source/includes/stackpath/_network_policy_rules.md
@@ -24,7 +24,7 @@ curl -X GET \
       "id": "f89e80ed-1208-4607-82b2-df2779d90f21/701825869",
       "description": "Allow ICMP packets",
       "type": "INBOUND",
-      "source": "0.0.0.0/0",
+      "source": ["0.0.0.0/0"],
       "action": "INBOUND",
       "protocol": "ICMP",
       "portRange": ""
@@ -36,7 +36,7 @@ curl -X GET \
       "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/INBOUND/-812331665/0",
       "description": "custom-inbound",
       "type": "INBOUND",
-      "source": "192.168.0.1/32",
+      "source": ["192.168.0.1/32"],
       "action": "ALLOW",
       "protocol": "TCP",
       "portRange": "80"
@@ -65,7 +65,7 @@ Attributes | &nbsp;
 `networkPolicyId`<br/>*UUID* | The UUID of the network policy to which the network policy rule belongs.
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
 `type`<br/>*string* | The type of network policy rule, either `INBOUND` or `OUTBOUND`.
-`source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
+`source`<br/>*Array[string]* | the list of subnets that will define all the IPs allowed or denied by this rule.
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
 `protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP`, `AH`, `ICMP` or `GRE`.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
@@ -91,7 +91,7 @@ curl -X GET \
     "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/INBOUND/-812331665/0",
     "description": "custom-inbound",
     "type": "INBOUND",
-    "source": "192.168.0.1/32",
+    "source": ["192.168.0.1/32"],
     "action": "ALLOW",
     "protocol": "TCP",
     "portRange": "80"
@@ -111,7 +111,7 @@ Attributes | &nbsp;
 `networkPolicyId`<br/>*UUID* | The UUID of the network policy to which the network policy rule belongs.
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
 `type`<br/>*string* | The type of network policy rule, either `INBOUND` or `OUTBOUND`.
-`source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
+`source`<br/>*Array[string]* | The list of subnets that will define all the IPs allowed or denied by this rule.
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
 `protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP`, `AH`, `ICMP` or `GRE`.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
@@ -135,7 +135,7 @@ curl -X POST \
   "protocol": "TCP",
   "type": "INBOUND",
   "action": "ALLOW",
-  "source": "0.0.0.0/0",
+  "source": ["0.0.0.0/0"],
   "portRange": "8080"
 }
 ```
@@ -151,7 +151,7 @@ Required | &nbsp;
 `protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` and `AH`. 
 `type`<br/>*string* | The type of network policy rule. Supported types are: `INBOUND` (Ingress) and `OUTBOUND` (Egress).
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (block traffic).
-`source`<br/>*string* | A subnet that will define all the IPs allowed or denied by this rule.
+`source`<br/>*Array[string]* | The list of subnets that will define all the IPs allowed or denied by this rule.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.
 
 <!-------------------- DELETE A NETWORK POLICY RULE -------------------->
@@ -185,7 +185,7 @@ curl -X PUT \
   "description": "npr_cloudmc_isk",
   "workloadId": "6ca53aff-8930-46d6-ba86-afbeb0b46bb7",
   "type": "INBOUND",
-  "source": "192.168.0.1/32",
+  "source": ["192.168.0.1/32"],
   "action": "ALLOW",
   "protocol": "TCP",
   "portRange": "80"
@@ -201,7 +201,7 @@ Required | &nbsp;
 `description`<br/>*string* | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.
 `workloadId`<br/>*UUID* | The UUID of the workload to which the network policy rule is applied. Corresponds to the first workload ID in the network policy's list of instance selectors.
 `type`<br/>*string* | The type of network policy rule. Supported types are: `INBOUND` (Ingress) and `OUTBOUND` (Egress).
-`source`<br/>*string* | A CIDR subnet that will define all the IPs allowed or denied by this rule.
+`source`<br/>*Array[string]* | The list of subnets that will define all the IPs allowed or denied by this rule.
 `action`<br/>*string* | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).
 `protocol`<br/>*string* | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` or `AH`.
 `portRange`<br/>*string* | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen. Not required for protocol for `ESP` or `AH`. 


### PR DESCRIPTION
### Fixes [MC-](https://cloud-ops.atlassian.net/browse/MC-)

#### Changes made
<!-- Changes should match the template provided below -->
- Change the source for network policy rules from string to a list of string.

#### Related PRs
- [Stackpath change](https://github.com/cloudops/cloudmc-stackpath-plugin/pull/841)

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->