### PR TITLE
[Cox] MC-19920: Support list of port ranges per network policy rule

### DIFF
--- a/source/includes/edgecompute/_network_policy_rules.md
+++ b/source/includes/edgecompute/_network_policy_rules.md
@@ -24,10 +24,10 @@ curl -X GET \
       "id": "f89e80ed-1208-4607-82b2-df2779d90f21/701825869",
       "description": "Allow ICMP packets",
       "type": "INBOUND",
-      "source": ["0.0.0.0/0"],
+      "sourceIps": ["0.0.0.0/0"],
       "action": "INBOUND",
       "protocol": "ICMP",
-      "portRange": ""
+      "ports": ["80"]
     },
     {
       "stackId": "bcc60174-50e6-44e4-bd45-463845124d87",
@@ -36,10 +36,10 @@ curl -X GET \
       "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/INBOUND/-812331665/0",
       "description": "custom-inbound",
       "type": "INBOUND",
-      "source": ["192.168.0.1/32"],
+      "sourceIps": ["192.168.0.1/32"],
       "action": "ALLOW",
       "protocol": "TCP",
-      "portRange": "80"
+      "ports": ["80"]
     }
   ],
   "metadata": {
@@ -65,10 +65,10 @@ Retrieve a list of all network policy rules in a given [environment](#administra
 | `networkPolicyId`<br/>_UUID_ | The UUID of the network policy to which the network policy rule belongs.                                                                                       |
 | `description`<br/>_string_   | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.                      |
 | `type`<br/>_string_          | The type of network policy rule, either `INBOUND` or `OUTBOUND`.                                                                                               |
-| `source`<br/>_Array[string]_ | The list of subnets that will define all the IPs allowed or denied by this rule.                                                                               |
+| `sourceIps`<br/>_Array[string]_ | The list of subnets that will define all the IPs allowed or denied by this rule.                                                                               |
 | `action`<br/>_string_        | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).                                                                             |
 | `protocol`<br/>_string_      | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP`, `AH`, `ICMP` or `GRE`.                                                                                |
-| `portRange`<br/>_string_     | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.                                |
+| `ports`<br/>*Array[string]* | The list of port ranges on which traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen. Not required for protocol for `ESP` or `AH`.                                |
 
 <!-------------------- GET A NETWORK POLICY RULE -------------------->
 
@@ -91,10 +91,10 @@ curl -X GET \
     "id": "2ac958f2-0976-4de9-95f6-3546fc10f8d0/INBOUND/-812331665/0",
     "description": "custom-inbound",
     "type": "INBOUND",
-    "source": ["192.168.0.1/32"],
+    "sourceIps": ["192.168.0.1/32"],
     "action": "ALLOW",
     "protocol": "TCP",
-    "portRange": "80"
+    "ports": "80"
   }
 }
 ```
@@ -111,10 +111,10 @@ Retrieve a network policy rule in a given [environment](#administration-environm
 | `networkPolicyId`<br/>_UUID_ | The UUID of the network policy to which the network policy rule belongs.                                                                                       |
 | `description`<br/>_string_   | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.                      |
 | `type`<br/>_string_          | The type of network policy rule, either `INBOUND` or `OUTBOUND`.                                                                                               |
-| `source`<br/>_Array[string]_ | The list of subnets that will define all the IPs allowed or denied by this rule.                                                                               |
+| `sourceIps`<br/>_Array[string]_ | The list of subnets that will define all the IPs allowed or denied by this rule.                                                                               |
 | `action`<br/>_string_        | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).                                                                             |
 | `protocol`<br/>_string_      | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP`, `AH`, `ICMP` or `GRE`.                                                                                |
-| `portRange`<br/>_string_     | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.                                |
+| `ports`<br/>*Array[string]* | The list of port ranges on which traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen. Not required for protocol for `ESP` or `AH`.                                |
 
 <!-------------------- CREATE A NETWORK POLICY RULE -------------------->
 
@@ -136,8 +136,8 @@ curl -X POST \
   "protocol": "TCP",
   "type": "INBOUND",
   "action": "ALLOW",
-  "source": ["0.0.0.0/0"],
-  "portRange": "8080"
+  "sourceIps": ["0.0.0.0/0"],
+  "ports": ["8080"]
 }
 ```
 
@@ -152,8 +152,8 @@ Create a new network policy rule.
 | `protocol`<br/>_string_    | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` and `AH`.                                                                         |
 | `type`<br/>_string_        | The type of network policy rule. Supported types are: `INBOUND` (Ingress) and `OUTBOUND` (Egress).                                        |
 | `action`<br/>_string_      | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (block traffic).                                                       |
-| `source`<br/>_Array[string]_ | The list of subnets that will define all the IPs allowed or denied by this rule.                                                                               |
-| `portRange`<br/>_string_   | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen.           |
+| `sourceIps`<br/>_Array[string]_ | The list of subnets that will define all the IPs allowed or denied by this rule.                                                                               |
+| `ports`<br/>*Array[string]* | The list of port ranges on which traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen. Not required for protocol for `ESP` or `AH`.           |
 
 <!-------------------- DELETE A NETWORK POLICY RULE -------------------->
 
@@ -187,10 +187,10 @@ curl -X PUT \
   "description": "npr_cloudmc_isk",
   "workloadId": "6ca53aff-8930-46d6-ba86-afbeb0b46bb7",
   "type": "INBOUND",
-  "source": ["192.168.0.1/32"],
+  "sourceIps": ["192.168.0.1/32"],
   "action": "ALLOW",
   "protocol": "TCP",
-  "portRange": "80"
+  "ports": ["80"]
 }
 ```
 
@@ -203,7 +203,7 @@ Edit a network policy rule.
 | `description`<br/>_string_ | A summary of what this rule does or a name of this rule. It is highly recommended to give a unique description to easily identify a rule.                                    |
 | `workloadId`<br/>_UUID_    | The UUID of the workload to which the network policy rule is applied. Corresponds to the first workload ID in the network policy's list of instance selectors.               |
 | `type`<br/>_string_        | The type of network policy rule. Supported types are: `INBOUND` (Ingress) and `OUTBOUND` (Egress).                                                                           |
-| `source`<br/>_Array[string]_ | The list of subnets that will define all the IPs allowed or denied by this rule.                                                                               |
+| `sourceIps`<br/>_Array[string]_ | The list of subnets that will define all the IPs allowed or denied by this rule.                                                                               |
 | `action`<br/>_string_      | The network policy rule action: `ALLOW` (allow traffic) or `BLOCK` (deny traffic).                                                                                           |
 | `protocol`<br/>_string_    | Supported protocols are: `TCP`, `UDP`, `TCP_UDP`, `ESP` or `AH`.                                                                                                             |
-| `portRange`<br/>_string_   | This specifies on which ports traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen. Not required for protocol for `ESP` or `AH`. |
+| `ports`<br/>*Array[string]* | The list of port ranges on which traffic will be allowed or denied by this rule. It can be a range of ports separated by a hyphen. Not required for protocol for `ESP` or `AH`. |

--- a/source/includes/edgecompute/_network_policy_rules.md
+++ b/source/includes/edgecompute/_network_policy_rules.md
@@ -94,7 +94,7 @@ curl -X GET \
     "sourceIps": ["192.168.0.1/32"],
     "action": "ALLOW",
     "protocol": "TCP",
-    "ports": "80"
+    "ports": ["80"]
   }
 }
 ```


### PR DESCRIPTION
### Fixes [MC-19920](https://cloud-ops.atlassian.net/browse/MC-)

#### Changes made
Network policy rules not support lists or sources and port ranges
- Rename `source` to `sourceIps`
- Rename `portRange` to `ports`

#### Related PRs
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/847
- https://github.com/cloudops/cloudmc-stackpath-plugin/pull/849
- https://github.com/cloudops/cloudmc-api-docs/pull/600

<!-- 
CLOUDMC-API-DOCS TEMPLATE
- all sentences should have periods
- requests and responses should use an example like 'my-env' instead of ':environment'
- use 'js' instead of 'json' when adding comments to json (else they appear in red)

### Upgrade release

```shell
curl -X POST \
   -H "MC-Api-Key: your_api_key" \
   -d "request_body" \
   "https://cloudmc_endpoint/api/v1/services/k8s/my-env/releases/my-release/aerospike?operation=upgrade"
```
> Request body example(s):

```js
// Format as 'js' instead of 'json' if adding comments (else they appear in red)
// Change to the latest version of a chart
{
  "upgradeChart":  "stable/aerospike",
  "upgradeChart":  1 
}

// Change to a specific version of a chart
{
  "upgradeChart" : "https://kubernetes-charts.storage.googleapis.com/aerospike-0.3.2.tgz"
}
```
> The above command(s) return(s) JSON structured like this:

```js
{
  "taskId": "c50390c7-9d5b-4af4-a2da-e2a2678a83e8",
  "taskStatus": "SUCCESS"
}
```

<code>POST /services/<a href="#administration-service-connections">:service_code</a>/<a href="#administration-environments">:environment_name</a>/releases/:id?operation=upgrade</code>

Upgrade a release in a given [environment](#administration-environments).

Required | &nbsp;
------- | -----------
`upgradeChart` <br/>*string* | The id of the chart to upgrade (repo/name) or the url to the version of the chart to use.  

Optional | &nbsp;
------- | -----------
`values` <br/>*string* | YAML structured text that will overwrite the default values for the upgrade/installation of the chart.

Attributes | &nbsp;
------- | -----------
`taskId` <br/>*string* | The task id related to the pod upgrade.
`taskStatus` <br/>*string* | The status of the operation.
-->